### PR TITLE
feat: Effect unification, resilience, CI fixes

### DIFF
--- a/.migration-stashes/stash-0.msg
+++ b/.migration-stashes/stash-0.msg
@@ -1,0 +1,1 @@
+WIP on dev/paper-draft: 966a070 ci: dual-publish to npmjs.com (@tummycrypt) + GitHub Packages (@jesssullivan)

--- a/.migration-stashes/stash-0.patch
+++ b/.migration-stashes/stash-0.patch
@@ -1,0 +1,390 @@
+diff --git a/src/adapters/acuity-scraper.ts b/src/adapters/acuity-scraper.ts
+index cf38224..0ba930e 100644
+--- a/src/adapters/acuity-scraper.ts
++++ b/src/adapters/acuity-scraper.ts
+@@ -1,12 +1,19 @@
+ /**
+  * Acuity Scraper Adapter
+- * Extracts scheduling data from public Acuity pages without API access
+  *
+- * Uses Playwright for reliable browser automation and handles:
+- * - Service (appointment type) extraction
+- * - Availability dates
+- * - Time slots
+- * - Provider information
++ * @deprecated DOM scraping is unreliable — Acuity migrated to a React SPA
++ * (Pylon/Squarespace) where services are loaded via JavaScript, not static HTML.
++ *
++ * Replacement:
++ * - For services: use `extractBusinessFromHtml()` or `fetchBusinessData()` from
++ *   `middleware/steps/extract-business.ts` — extracts the BUSINESS JS object
++ *   embedded in the page HTML without DOM interaction.
++ * - For availability/slots: use `readAvailableDates()` and `readTimeSlots()` from
++ *   `middleware/steps/` — these navigate the React SPA via click-based wizard
++ *   steps, not URL params.
++ *
++ * This file is kept only as a last-resort fallback in the Modal server's
++ * `/services` endpoint fallback chain. All new code should use the replacements.
+  */
+ 
+ import type { Browser, Page } from 'playwright-core';
+@@ -125,7 +132,11 @@ export class AcuityScraper {
+   }
+ 
+   /**
+-   * Extract all services (appointment types) from the scheduling page
++   * Extract all services (appointment types) from the scheduling page.
++   *
++   * @deprecated Always returns `[]` on Acuity's React SPA — the CSS selectors
++   * (`.select-item`, `.category-group`) don't exist in the static HTML.
++   * Use `fetchBusinessData()` from `extract-business.ts` instead.
+    */
+   async scrapeServices(): Promise<E.Either<AcuityError | InfrastructureError, ScrapedService[]>> {
+     let page: Page | null = null;
+@@ -249,7 +260,11 @@ export class AcuityScraper {
+   }
+ 
+   /**
+-   * Extract available dates for a specific service
++   * Extract available dates for a specific service.
++   *
++   * @deprecated Uses URL param navigation (`?appointmentType=`) which requires
++   * Acuity's numeric ID. Use `readAvailableDates()` from `middleware/steps/`
++   * which navigates by clicking the service name in the React SPA.
+    */
+   async scrapeAvailableDates(
+     serviceId: string,
+@@ -319,7 +334,10 @@ export class AcuityScraper {
+   }
+ 
+   /**
+-   * Extract available time slots for a specific date
++   * Extract available time slots for a specific date.
++   *
++   * @deprecated Uses URL param navigation. Use `readTimeSlots()` from
++   * `middleware/steps/` which navigates the React SPA via click interaction.
+    */
+   async scrapeTimeSlots(
+     serviceId: string,
+@@ -410,7 +428,10 @@ export class AcuityScraper {
+ // =============================================================================
+ 
+ /**
+- * Create a scraper instance with TaskEither wrapper
++ * Create a scraper instance with TaskEither wrapper.
++ *
++ * @deprecated Use `fetchBusinessData()` for services and Effect-based wizard
++ * steps (`readAvailableDates`, `readTimeSlots`) for availability/slots.
+  */
+ export const createScraperAdapter = (config: ScraperConfig) => {
+   const scraper = new AcuityScraper(config);
+@@ -507,7 +528,10 @@ export const createScraperAdapter = (config: ScraperConfig) => {
+ // =============================================================================
+ 
+ /**
+- * One-shot scrape of all services (opens and closes browser)
++ * One-shot scrape of all services (opens and closes browser).
++ *
++ * @deprecated Always returns `[]` on Acuity's React SPA.
++ * Use `fetchBusinessData()` from `extract-business.ts` instead.
+  */
+ export const scrapeServicesOnce = async (
+   baseUrl: string
+@@ -524,7 +548,9 @@ export const scrapeServicesOnce = async (
+ };
+ 
+ /**
+- * One-shot scrape of availability (opens and closes browser)
++ * One-shot scrape of availability (opens and closes browser).
++ *
++ * @deprecated Use Effect-based `readTimeSlots()` from `middleware/steps/`.
+  */
+ export const scrapeAvailabilityOnce = async (
+   baseUrl: string,
+diff --git a/src/middleware/acuity-wizard.ts b/src/middleware/acuity-wizard.ts
+index 0e93572..7f36496 100644
+--- a/src/middleware/acuity-wizard.ts
++++ b/src/middleware/acuity-wizard.ts
+@@ -197,6 +197,7 @@ export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdap
+ 		return createRemoteWizardAdapter({
+ 			...config.remote,
+ 			couponCode: config.remote.couponCode ?? config.couponCode,
++			services: config.services,
+ 		});
+ 	}
+ 
+diff --git a/src/middleware/remote-adapter.ts b/src/middleware/remote-adapter.ts
+index b0469a2..688b013 100644
+--- a/src/middleware/remote-adapter.ts
++++ b/src/middleware/remote-adapter.ts
+@@ -49,6 +49,12 @@ export interface RemoteAdapterConfig {
+ 	readonly timeout?: number;
+ 	/** Coupon code for payment bypass */
+ 	readonly couponCode?: string;
++	/**
++	 * Static service catalog. When provided, getServices()/getService() return
++	 * from this list without hitting the remote server. Avoids dependency on
++	 * the middleware's DOM scraper for service listing.
++	 */
++	readonly services?: readonly Service[];
+ }
+ 
+ // =============================================================================
+@@ -157,11 +163,22 @@ export const createRemoteWizardAdapter = (config: RemoteAdapterConfig): Scheduli
+ 	// Read operations - proxied to remote scraper
+ 	// ---------------------------------------------------------------------------
+ 
+-	getServices: () =>
+-		makeRequest<Service[]>(config, '/services', 'GET'),
+-
+-	getService: (serviceId) =>
+-		makeRequest<Service>(config, `/services/${encodeURIComponent(serviceId)}`, 'GET'),
++	getServices: () => {
++		if (config.services) {
++			return TE.right([...config.services]);
++		}
++		return makeRequest<Service[]>(config, '/services', 'GET');
++	},
++
++	getService: (serviceId) => {
++		if (config.services) {
++			const found = config.services.find((s) => s.id === serviceId);
++			return found
++				? TE.right(found)
++				: TE.left(Errors.acuity('NOT_FOUND', `Service ${serviceId} not found`));
++		}
++		return makeRequest<Service>(config, `/services/${encodeURIComponent(serviceId)}`, 'GET');
++	},
+ 
+ 	getProviders: () =>
+ 		TE.right([{
+@@ -190,14 +207,30 @@ export const createRemoteWizardAdapter = (config: RemoteAdapterConfig): Scheduli
+ 			timezone: 'America/New_York',
+ 		}]),
+ 
+-	getAvailableDates: (params) =>
+-		makeRequest<AvailableDate[]>(config, '/availability/dates', 'POST', params),
+-
+-	getAvailableSlots: (params) =>
+-		makeRequest<TimeSlot[]>(config, '/availability/slots', 'POST', params),
+-
+-	checkSlotAvailability: (params) =>
+-		makeRequest<boolean>(config, '/availability/check', 'POST', params),
++	getAvailableDates: (params) => {
++		// Resolve service name for wizard navigation (Acuity navigates by name, not ID)
++		const serviceName = config.services?.find((s) => s.id === params.serviceId)?.name;
++		return makeRequest<AvailableDate[]>(config, '/availability/dates', 'POST', {
++			...params,
++			serviceName: serviceName ?? params.serviceId,
++		});
++	},
++
++	getAvailableSlots: (params) => {
++		const serviceName = config.services?.find((s) => s.id === params.serviceId)?.name;
++		return makeRequest<TimeSlot[]>(config, '/availability/slots', 'POST', {
++			...params,
++			serviceName: serviceName ?? params.serviceId,
++		});
++	},
++
++	checkSlotAvailability: (params) => {
++		const serviceName = config.services?.find((s) => s.id === params.serviceId)?.name;
++		return makeRequest<boolean>(config, '/availability/check', 'POST', {
++			...params,
++			serviceName: serviceName ?? params.serviceId,
++		});
++	},
+ 
+ 	// ---------------------------------------------------------------------------
+ 	// Reservation - not supported (pipeline has graceful fallback)
+diff --git a/src/middleware/server.ts b/src/middleware/server.ts
+index d16a7db..5d8ea44 100644
+--- a/src/middleware/server.ts
++++ b/src/middleware/server.ts
+@@ -43,6 +43,10 @@ import {
+ 	submitBooking,
+ 	extractConfirmation,
+ 	toBooking,
++	readAvailableDates,
++	readTimeSlots,
++	fetchBusinessData,
++	businessToServices,
+ } from './steps/index.js';
+ import type {
+ 	Booking,
+@@ -157,6 +161,23 @@ const getScraper = () => {
+ 
+ let cachedServices: Service[] | null = null;
+ 
++// Static services from SERVICES_JSON env var (avoids scraper dependency)
++const STATIC_SERVICES: Service[] | null = (() => {
++	const raw = process.env.SERVICES_JSON;
++	if (!raw) return null;
++	try {
++		return JSON.parse(raw) as Service[];
++	} catch (e) {
++		console.error('[middleware-server] Failed to parse SERVICES_JSON:', e);
++		return null;
++	}
++})();
++
++if (STATIC_SERVICES) {
++	cachedServices = STATIC_SERVICES;
++	console.log(`[middleware-server] Loaded ${STATIC_SERVICES.length} static services from SERVICES_JSON`);
++}
++
+ // =============================================================================
+ // ROUTE HANDLERS
+ // =============================================================================
+@@ -167,14 +188,43 @@ const handleHealth = (_req: IncomingMessage, res: ServerResponse) => {
+ 		baseUrl: ACUITY_BASE_URL,
+ 		hasCoupon: !!COUPON_CODE,
+ 		headless: browserConfig.headless,
++		staticServices: STATIC_SERVICES ? STATIC_SERVICES.length : 0,
+ 		timestamp: new Date().toISOString(),
+ 	});
+ };
+ 
+ 
+ const handleGetServices = async (_req: IncomingMessage, res: ServerResponse) => {
++	// 1. Prefer static services from env (always reliable, no network needed)
++	if (STATIC_SERVICES) {
++		console.log('[services] source: SERVICES_JSON env');
++		cachedServices = STATIC_SERVICES;
++		return sendSuccess(res, STATIC_SERVICES);
++	}
++
++	// 2. Extract from BUSINESS object (HTTP fetch + regex, no browser)
++	try {
++		const business = await fetchBusinessData(ACUITY_BASE_URL);
++		if (business) {
++			const services = businessToServices(business);
++			if (services.length > 0) {
++				console.log(`[services] source: BUSINESS object (${services.length} services)`);
++				cachedServices = services;
++				return sendSuccess(res, services);
++			}
++			console.warn('[services] BUSINESS object found but 0 active services');
++		}
++	} catch (e) {
++		console.warn('[services] BUSINESS extraction failed:', e instanceof Error ? e.message : e);
++	}
++
++	// 3. Deprecated fallback: DOM scraper (may return [] — Acuity is React SPA)
++	console.warn('[services] falling back to DOM scraper (deprecated)');
+ 	const result = await getScraper().getServices()();
+ 	if (E.isLeft(result)) return sendError(res, 500, result.left);
++	if (result.right.length === 0) {
++		console.error('[services] all sources exhausted — returning empty []');
++	}
+ 	cachedServices = result.right;
+ 	sendSuccess(res, result.right);
+ };
+@@ -196,28 +246,75 @@ const handleGetService = async (serviceId: string, res: ServerResponse) => {
+ };
+ 
+ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse) => {
+-	const body = (await parseBody(req)) as { serviceId: string; startDate?: string };
+-	const result = await getScraper().getAvailableDates(
+-		body.serviceId,
+-		body.startDate?.slice(0, 7),
+-	)();
+-	if (E.isLeft(result)) return sendError(res, 500, result.left);
+-	sendSuccess(res, result.right.map((d) => ({ date: d, slots: 1 })));
++	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; startDate?: string };
++	// Use service name for wizard navigation (click-based, not URL param)
++	const serviceName = body.serviceName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
++	console.log(`[availability/dates] serviceName="${serviceName}" from serviceId="${body.serviceId}"`);
++
++	const result = await runEffect(
++		readAvailableDates({
++			serviceName,
++			targetMonth: body.startDate?.slice(0, 7),
++			monthsToScan: 2,
++		}),
++	);
++
++	if (E.isLeft(result)) {
++		const err = result.left;
++		console.error(`[availability/dates] error:`, err);
++		return sendJson(res, 500, {
++			success: false,
++			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Availability lookup failed' },
++		});
++	}
++	sendSuccess(res, result.right);
+ };
+ 
+ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse) => {
+-	const body = (await parseBody(req)) as { serviceId: string; date: string };
+-	const result = await getScraper().getTimeSlots(body.serviceId, body.date)();
+-	if (E.isLeft(result)) return sendError(res, 500, result.left);
++	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; date: string };
++	const serviceName = body.serviceName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
++	console.log(`[availability/slots] serviceName="${serviceName}" date="${body.date}"`);
++
++	const result = await runEffect(
++		readTimeSlots({
++			serviceName,
++			date: body.date,
++		}),
++	);
++
++	if (E.isLeft(result)) {
++		const err = result.left;
++		console.error(`[availability/slots] error:`, err);
++		return sendJson(res, 500, {
++			success: false,
++			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Slot lookup failed' },
++		});
++	}
+ 	sendSuccess(res, result.right);
+ };
+ 
+ const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse) => {
+-	const body = (await parseBody(req)) as { serviceId: string; datetime: string };
++	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; datetime: string };
+ 	const date = body.datetime.split('T')[0];
+-	const result = await getScraper().getTimeSlots(body.serviceId, date)();
+-	if (E.isLeft(result)) return sendError(res, 500, result.left);
+-	const available = result.right.some((s) => s.datetime === body.datetime && s.available);
++	const serviceName = body.serviceName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
++
++	const result = await runEffect(
++		readTimeSlots({
++			serviceName,
++			date,
++		}),
++	);
++
++	if (E.isLeft(result)) {
++		const err = result.left;
++		return sendJson(res, 500, {
++			success: false,
++			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Slot check failed' },
++		});
++	}
++	const available = result.right.some((s: { datetime: string; available: boolean }) =>
++		s.datetime === body.datetime && s.available
++	);
+ 	sendSuccess(res, available);
+ };
+ 
+diff --git a/src/middleware/steps/index.ts b/src/middleware/steps/index.ts
+index c43032d..b89bee7 100644
+--- a/src/middleware/steps/index.ts
++++ b/src/middleware/steps/index.ts
+@@ -25,3 +25,13 @@ export {
+ 	type ReadSlotsParams,
+ 	type SlotResult,
+ } from './read-slots.js';
++export {
++	extractBusinessFromPage,
++	extractBusinessFromHtml,
++	extractBusinessServices,
++	fetchBusinessData,
++	businessToServices,
++	type AcuityAppointmentType,
++	type AcuityCalendar,
++	type AcuityBusinessData,
++} from './extract-business.js';

--- a/.migration-stashes/stash-0.stat
+++ b/.migration-stashes/stash-0.stat
@@ -1,0 +1,6 @@
+ src/adapters/acuity-scraper.ts   |  50 ++++++++++++----
+ src/middleware/acuity-wizard.ts  |   1 +
+ src/middleware/remote-adapter.ts |  59 ++++++++++++++----
+ src/middleware/server.ts         | 125 ++++++++++++++++++++++++++++++++++-----
+ src/middleware/steps/index.ts    |  10 ++++
+ 5 files changed, 206 insertions(+), 39 deletions(-)

--- a/docs/blog-post.mdx
+++ b/docs/blog-post.mdx
@@ -44,7 +44,7 @@ That advice is bad.
 
 Here is what I actually built:
 
-A 16-method `SchedulingAdapter` interface- services, providers, availability, reservations, bookings, clients- with every method returning `TaskEither<SchedulingError, T>` from fp-ts. Monadic composition all the way down. You cannot accidentally ignore an error because the type system won't let you access the success value without folding over the Either first.
+A 16-method `SchedulingAdapter` interface- services, providers, availability, reservations, bookings, clients- with every method returning `Effect<T, SchedulingError>` from Effect TS. Monadic composition all the way down. You cannot accidentally ignore an error because the type system won't let you access the success value without handling the error channel first.
 
 Then I implemented that interface twice.
 
@@ -65,37 +65,19 @@ That's the strangler fig. Both backends run simultaneously. Alpha gets the homeg
 
 ---
 
-## Effect TS and fp-ts Walk Into a Codebase
+## Effect TS All the Way Down
 
-I am not proud of this part.
+This part used to be embarrassing.
 
-The adapter interface was defined in fp-ts terms before the browser middleware existed. `TaskEither` is the right type for "a lazy async computation that might fail"- it composes beautifully via `pipe`, `chain`, `map`. Consumers of the scheduling adapter get clean monadic composition with explicit error handling. Good.
+The adapter interface was originally defined in fp-ts terms- `TaskEither` for "a lazy async computation that might fail," composing via `pipe`, `chain`, `map`. Then the browser middleware needed resource management (launch browser, create page, guarantee cleanup when step 4 throws), which fp-ts does not do. So the middleware layer used Effect TS, and a bridge function called `runEffect` converted between the two worlds.
 
-Then I needed to manage a Playwright browser lifecycle. Launch browser, create page, run 7 sequential wizard steps, guarantee cleanup even when step 4 throws because Acuity decided to rearrange their radio buttons this week. This is a resource management problem. fp-ts does not do resource management. Effect TS does.
+Two functional effect systems. One bridge function. It was a source of subtle bugs where `Effect.runPromise` would wrap typed errors in `FiberFailure`, destroying the discriminated union structure at the Promise boundary.
 
-So the middleware layer uses Effect. Generator syntax, `Context.Tag` for dependency injection, `Layer.scoped` with `acquireRelease` for the browser process and page instance. Each wizard step is an Effect program that yields the `BrowserService` from context, wraps Playwright calls in `Effect.tryPromise`, and returns typed errors (`WizardStepError`, `SelectorError`, `CouponError`, `BrowserError`).
+So I unified everything on Effect. The adapter interface now returns `Effect<T, SchedulingError>` directly. The browser middleware uses the same library- generator syntax, `Context.Tag` for dependency injection, `Layer.scoped` with `acquireRelease` for the browser process and page instance. Each wizard step is an Effect program that yields the `BrowserService` from context, wraps Playwright calls in `Effect.tryPromise`, and returns typed errors (`WizardStepError`, `SelectorError`, `CouponError`, `BrowserError`).
 
-The bridge between the two worlds is a function called `runEffect`:
+No more bridge. No more converting between two effect systems. The `runEffect` function still exists at the outermost boundary where Effect meets the HTTP handler, but it is a simple `Effect.runPromiseExit` call, not a translation layer between incompatible type systems.
 
-```typescript
-const runEffect = <A>(
-  effect: Effect.Effect<A, MiddlewareError>,
-): SchedulingResult<A> =>
-  () =>
-    Effect.runPromiseExit(effect.pipe(Effect.provide(layer))).then(
-      (exit) => {
-        if (Exit.isSuccess(exit)) return E.right(exit.value);
-        const failure = Cause.failureOption(exit.cause);
-        if (failure._tag === 'Some')
-          return E.left(toSchedulingError(failure.value));
-        return E.left(Errors.infrastructure('UNKNOWN', '...'));
-      },
-    );
-```
-
-That last paragraph is doing a tremendous amount of heavy lifting. We run the Effect to an `Exit` value (not a Promise- an Exit, so we get the typed error channel instead of a FiberFailure wrapper), extract the first failure from the Cause tree, convert it from Effect's tagged error type to fp-ts's discriminated union type via `toSchedulingError`, and wrap the whole thing in a thunk that returns `Promise<Either<SchedulingError, A>>`.
-
-Two functional effect systems. One bridge function. I have made my choices and I will live with them.
+One functional effect system. Zero bridge functions. I have made better choices.
 
 ---
 
@@ -214,7 +196,7 @@ The scheduling adapter interface is the stable contract. The browser middleware 
 
 The adapter interface stays. The availability engine stays. The booking schema, the email templates, the admin calendar, the payment integration- all of that stays. The browser automation was the scaffolding. You don't preserve scaffolding.
 
-Modal and Playwright and the selector registry and the coupon bypass and the `runEffect` bridge and the entire elaborate machinery for puppeteering a React SPA into pretending to be a REST API- all of it was built to be thrown away. That is the design. That is the point.
+Modal and Playwright and the selector registry and the coupon bypass and the entire elaborate machinery for puppeteering a React SPA into pretending to be a REST API- all of it was built to be thrown away. That is the design. That is the point.
 
 Why pay for an API to rebuild a closed-source wizard when you *are* a wizard?
 
@@ -224,7 +206,7 @@ Why pay for an API to rebuild a closed-source wizard when you *are* a wizard?
 
 | Layer | Technology | Purpose |
 |-------|-----------|---------|
-| Adapter interface | fp-ts `TaskEither` | 16-method contract, monadic errors |
+| Adapter interface | Effect TS | 16-method contract, monadic errors |
 | Browser middleware | Effect TS + Playwright | Wizard step programs, resource management |
 | Container runtime | Modal Labs | Serverless Chromium, warm pools |
 | Selector registry | CSS fallback chains | DOM resilience against Emotion hash instability |

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -7,7 +7,7 @@ Tinyland Inc.
 [acuity-middleware-paper.tex](paper/acuity-middleware-paper.tex)
 ## Abstract
 
-Small-business SaaS platforms create vendor lock-in through API paywalls and proprietary data formats. When the vendor restricts programmatic access to premium pricing tiers, businesses face a choice between paying for API access they should already have or accepting that their own data is held hostage. We present a browser automation middleware architecture that implements a standardized 16-method scheduling adapter interface by puppeteering the vendor's public-facing web UI via headless Playwright, deployed as a containerized service on Modal Labs. A feature-flag-driven backend selector enables zero-downtime migration from the legacy vendor to a homegrown PostgreSQL backend, implementing the strangler fig pattern against a third-party SaaS dependency. The system has been deployed in production since March 2026, processing real appointment bookings across both backends simultaneously. We report on the architecture, the dual functional programming approach (Effect TS for browser lifecycle management, fp-ts for adapter composition), the reliability challenges of DOM automation against a React SPA with Emotion CSS, and the lessons learned from automating 604 legacy appointments across 62 weeks of calendar data. The middleware replaces 8 blocked REST API endpoints through DOM interaction alone, demonstrating that browser automation is a viable -- if intentionally temporary -- bridge pattern for escaping SaaS vendor lock-in.
+Small-business SaaS platforms create vendor lock-in through API paywalls and proprietary data formats. When the vendor restricts programmatic access to premium pricing tiers, businesses face a choice between paying for API access they should already have or accepting that their own data is held hostage. We present a browser automation middleware architecture that implements a standardized 16-method scheduling adapter interface by puppeteering the vendor's public-facing web UI via headless Playwright, deployed as a containerized service on Modal Labs. A feature-flag-driven backend selector enables zero-downtime migration from the legacy vendor to a homegrown PostgreSQL backend, implementing the strangler fig pattern against a third-party SaaS dependency. The system has been deployed in production since March 2026, processing real appointment bookings across both backends simultaneously. We report on the architecture, the unified Effect TS functional programming approach (covering browser lifecycle management, adapter composition, error handling, and resource management), the reliability challenges of DOM automation against a React SPA with Emotion CSS, and the lessons learned from automating 604 legacy appointments across 62 weeks of calendar data. The middleware replaces 8 blocked REST API endpoints through DOM interaction alone, demonstrating that browser automation is a viable -- if intentionally temporary -- bridge pattern for escaping SaaS vendor lock-in.
 
 ---
 
@@ -25,7 +25,7 @@ The key insight is that browser automation middleware is not the destination -- 
 
 This paper makes four contributions:
 
-1. A formal 16-method `SchedulingAdapter` interface that abstracts scheduling operations (services, availability, reservations, bookings, clients) across heterogeneous backends, with all methods returning monadic `TaskEither<SchedulingError, T>` for composable error handling.
+1. A formal 16-method `SchedulingAdapter` interface that abstracts scheduling operations (services, availability, reservations, bookings, clients) across heterogeneous backends, with all methods returning monadic `Effect<T, SchedulingError>` for composable error handling.
 
 2. An Effect TS middleware layer that implements this interface via headless browser automation, using typed effect programs for each wizard step, managed browser lifecycle via `acquireRelease`, and a CSS selector registry with fallback chains for resilience against DOM instability.
 
@@ -135,19 +135,15 @@ interface SchedulingAdapter {
 }
 ```
 
-All methods return `SchedulingResult<T>`, defined as `TaskEither<SchedulingError, T>` from fp-ts [18]. The `SchedulingError` type is a discriminated union with seven variants (`AcuityError`, `CalComError`, `PaymentError`, `ValidationError`, `ReservationError`, `IdempotencyError`, `InfrastructureError`), each carrying a `_tag` discriminant, a `code` string, and a human-readable `message`.
+All methods return `SchedulingResult<T>`, defined as `Effect<T, SchedulingError>` from Effect TS [19]. The `SchedulingError` type is a discriminated union with seven variants (`AcuityError`, `CalComError`, `PaymentError`, `ValidationError`, `ReservationError`, `IdempotencyError`, `InfrastructureError`), each carrying a `_tag` discriminant, a `code` string, and a human-readable `message`. (An earlier version used fp-ts [18] `TaskEither` for this type; this was replaced during a full unification migration to Effect.)
 
-This design forces all error handling to be explicit at the type level. Consumers cannot accidentally ignore errors -- they must fold over the `Either` to access the success value. The `TaskEither` wrapper (a thunk returning `Promise<Either<E, A>>`) enables lazy evaluation and composition via `pipe`, `chain`, and `map`.
+This design forces all error handling to be explicit at the type level. Consumers cannot accidentally ignore errors -- they must handle the error channel to access the success value. The `Effect` type enables lazy evaluation and composition via `pipe`, `map`, and `flatMap`.
 
-### C. Dual Functional Programming Architecture
+### C. Unified Effect TS Architecture
 
-The system uses two functional programming libraries simultaneously:
+The system uses Effect TS [19] as its sole functional programming library, providing a unified abstraction across all layers. Effect manages the browser middleware layer -- generator-based programs (`Effect.gen(function* () { ... })`), typed errors via `Data.TaggedError`, dependency injection via `Context.Tag`, and resource lifecycle management via `Layer.scoped` and `Effect.acquireRelease` -- and also provides the adapter interface return type (`Effect<T, SchedulingError>`) and composition operators (`pipe`, `map`, `flatMap`) used by consumers and the booking pipeline.
 
-**Effect TS** [19] manages the browser middleware layer. Effect programs are generator-based (`Effect.gen(function* () { ... })`), with typed errors, dependency injection via `Context.Tag`, and resource lifecycle management via `Layer.scoped` and `Effect.acquireRelease`. The browser and page are acquired resources that are guaranteed to close on scope exit, even if the wizard step programs fail.
-
-**fp-ts** [18] provides the adapter interface type (`TaskEither`) and the composition operators (`pipe`, `chain`, `map`, `tap`) used by consumers and the booking pipeline. The adapter interface is defined in fp-ts terms because it predates the middleware layer and because fp-ts `TaskEither` is simpler to consume than Effect for callers who do not need resource management.
-
-The bridge between the two is the `runEffect` function in the wizard adapter, which converts an Effect program to a `TaskEither` by running the Effect to an `Exit` value and mapping `Success` to `Right` and typed `Failure` to `Left` via the `toSchedulingError` bridge function.
+An earlier version used a dual-library approach: fp-ts [18] for the adapter interface (`TaskEither`) and Effect TS for the browser middleware, with a `runEffect` bridge function converting between the two by running Effect to an `Exit` value and mapping `Success` to `Right` and typed `Failure` to `Left`. This bridge was eliminated during a full unification migration to Effect.
 
 ### D. CSS Selector Registry
 
@@ -311,9 +307,9 @@ Browser automation against a third-party SPA is inherently fragile. Acuity can c
 2. **Disposability by design.** The wizard adapter is a migration bridge. Once the homegrown backend reaches full feature parity, the browser middleware layer is deleted entirely.
 3. **Fallback chains.** The selector registry tries multiple candidates per logical element, absorbing minor DOM restructuring without code changes.
 
-### B. Dual Effect System Complexity
+### B. Effect Unification
 
-Using both Effect TS and fp-ts introduces cognitive overhead. The `runEffect` bridge function is a source of subtle bugs -- incorrectly handling `FiberFailure` wrappers or `Cause` trees can swallow typed errors. In hindsight, a single effect system would be preferable. The dual approach emerged from the adapter interface (defined in fp-ts terms before the middleware layer was built) and the middleware layer (requiring Effect's resource management capabilities). A future version might unify on Effect TS throughout.
+An earlier version of the system used both Effect TS and fp-ts simultaneously, requiring a `runEffect` bridge function that was a source of subtle bugs -- incorrectly handling `FiberFailure` wrappers or `Cause` trees could swallow typed errors. The dual approach emerged from the adapter interface (defined in fp-ts terms before the middleware layer was built) and the middleware layer (requiring Effect's resource management capabilities). The system was subsequently unified on Effect TS throughout, eliminating the bridge function and the fp-ts dependency entirely. This reduced the mental model required of contributors and eliminated an entire class of error-boundary bugs.
 
 ### C. Ethical and Legal Considerations
 

--- a/docs/paper/acuity-middleware-paper.tex
+++ b/docs/paper/acuity-middleware-paper.tex
@@ -33,7 +33,7 @@
 \lstdefinelanguage{TypeScript}{
   keywords={function, return, const, let, if, else, switch, case, class, interface, type, extends, implements, import, export, from, as, new, this, async, await, yield, default, typeof, void, null, undefined, true, false, in, of},
   keywordstyle=\color{tskw}\bfseries,
-  ndkeywords={string, number, boolean, Promise, Effect, Either, TaskEither, SchedulingResult, SchedulingError, SchedulingAdapter, Service, Booking, BookingRequest, Provider, TimeSlot, AvailableDate, SlotReservation, ClientInfo, Layer, Context, Exit, Cause, BrowserService, BrowserError, SelectorError, WizardStepError, CouponError, MiddlewareError, Data, TaggedError, Scope, Page, ResolvedSelector, BrowserConfig, BrowserServiceShape, ConfirmationData, NavigateResult, ServiceResolver, Logger},
+  ndkeywords={string, number, boolean, Promise, Effect, Either, TaskEither, SchedulingResult, SchedulingError, SchedulingAdapter, Service, Booking, BookingRequest, Provider, TimeSlot, AvailableDate, SlotReservation, ClientInfo, Layer, Context, Exit, Cause, BrowserService, BrowserError, SelectorError, WizardStepError, CouponError, MiddlewareError, Data, TaggedError, Scope, Page, ResolvedSelector, BrowserConfig, BrowserServiceShape, ConfirmationData, NavigateResult},
   ndkeywordstyle=\color{tstype},
   sensitive=true,
   comment=[l]{//},
@@ -79,7 +79,7 @@ jess@tinyland.dev}}
 \maketitle
 
 \begin{abstract}
-Small-business SaaS platforms create vendor lock-in through API paywalls and proprietary data formats. When the vendor restricts programmatic access to premium pricing tiers, businesses face a choice between paying for API access they should already have or accepting that their own data is held hostage. We present a browser automation middleware architecture that implements a standardized 17-method scheduling adapter interface by puppeteering the vendor's public-facing web UI via headless Playwright, deployed as a containerized service on Modal Labs. A feature-flag-driven backend selector enables zero-downtime migration from the legacy vendor to a homegrown PostgreSQL backend, implementing the strangler fig pattern against a third-party SaaS dependency. The system has been deployed in production since March 2026, processing real appointment bookings across both backends simultaneously. We report on the architecture, the unified Effect TS functional programming approach for both browser lifecycle management and adapter composition, the reliability challenges of DOM automation against a React SPA with Emotion CSS, and the lessons learned from automating 604 legacy appointments across 62 weeks of calendar data. The middleware replaces 8 blocked REST API endpoints through DOM interaction alone, demonstrating that browser automation is a viable---if intentionally temporary---bridge pattern for escaping SaaS vendor lock-in.
+Small-business SaaS platforms create vendor lock-in through API paywalls and proprietary data formats. When the vendor restricts programmatic access to premium pricing tiers, businesses face a choice between paying for API access they should already have or accepting that their own data is held hostage. We present a browser automation middleware architecture that implements a standardized 17-method scheduling adapter interface by puppeteering the vendor's public-facing web UI via headless Playwright, deployed as a containerized service on Modal Labs. A feature-flag-driven backend selector enables zero-downtime migration from the legacy vendor to a homegrown PostgreSQL backend, implementing the strangler fig pattern against a third-party SaaS dependency. The system has been deployed in production since March 2026, processing real appointment bookings across both backends simultaneously. We report on the architecture, the dual functional programming approach (Effect TS for browser lifecycle management, fp-ts for adapter composition), the reliability challenges of DOM automation against a React SPA with Emotion CSS, and the lessons learned from automating 604 legacy appointments across 62 weeks of calendar data. The middleware replaces 8 blocked REST API endpoints through DOM interaction alone, demonstrating that browser automation is a viable---if intentionally temporary---bridge pattern for escaping SaaS vendor lock-in.
 \end{abstract}
 
 \begin{IEEEkeywords}
@@ -102,7 +102,7 @@ The key insight is that browser automation middleware is not the destination---i
 This paper makes four contributions:
 
 \begin{enumerate}
-\item A formal 17-method \texttt{SchedulingAdapter} interface that abstracts scheduling operations (services, availability, reservations, bookings, clients) across heterogeneous backends, with all methods returning \texttt{Effect.Effect<A, SchedulingError>} for composable error handling.
+\item A formal 17-method \texttt{SchedulingAdapter} interface that abstracts scheduling operations (services, availability, reservations, bookings, clients) across heterogeneous backends, with all methods returning monadic \texttt{TaskEither<SchedulingError, T>} for composable error handling.
 
 \item An Effect TS middleware layer that implements this interface via headless browser automation, using typed effect programs for each wizard step, managed browser lifecycle via \texttt{acquireRelease}, and a CSS selector registry with fallback chains for resilience against DOM instability.
 
@@ -244,41 +244,36 @@ Clients & \texttt{findOrCreateClient}, \texttt{getClientByEmail} & 2 \\
 \end{tabular}
 \end{table}
 
-All methods return \texttt{Effect.Effect<A, SchedulingError>}. The \texttt{SchedulingError} type is a discriminated union with seven variants (\texttt{AcuityError}, \texttt{CalComError}, \texttt{PaymentError}, \texttt{ValidationError}, \texttt{ReservationError}, \texttt{IdempotencyError}, \texttt{InfrastructureError}), each carrying a \texttt{\_tag} discriminant, a \texttt{code} string, and a human-readable \texttt{message}.
+All methods return \texttt{SchedulingResult<T>}, defined as \texttt{TaskEither<SchedulingError, T>} from fp-ts~\cite{fp-ts}. The \texttt{SchedulingError} type is a discriminated union with seven variants (\texttt{AcuityError}, \texttt{CalComError}, \texttt{PaymentError}, \texttt{ValidationError}, \texttt{ReservationError}, \texttt{IdempotencyError}, \texttt{InfrastructureError}), each carrying a \texttt{\_tag} discriminant, a \texttt{code} string, and a human-readable \texttt{message}.
 
-\subsection{Effect TS Architecture}
+\subsection{Dual Functional Programming Architecture}
 
-The system is built entirely on Effect TS~\cite{effect-ts}, using a single functional programming paradigm across all layers. Generator-based programs (\texttt{Effect.gen(function*~\{...\})}) provide sequential composition with typed error propagation, \texttt{Data.TaggedError} classes define exhaustively matchable error variants, and \texttt{Context.Tag} with \texttt{Layer} provides compile-time dependency injection.
+The system uses two functional programming libraries simultaneously, each chosen for the layer where its abstractions are strongest. \textbf{Effect TS}~\cite{effect-ts} manages the browser middleware layer: generator-based programs (\texttt{Effect.gen(function*~\{...\})}), typed errors via \texttt{Data.TaggedError}, dependency injection via \texttt{Context.Tag}, and resource lifecycle via \texttt{Layer.scoped} and \texttt{Effect.acquireRelease}. \textbf{fp-ts}~\cite{fp-ts} provides the adapter interface type (\texttt{TaskEither}) and composition operators (\texttt{pipe}, \texttt{chain}, \texttt{map}).
 
-The \texttt{BrowserService} is defined as a \texttt{Context.Tag} (Listing~\ref{lst:effectarch}), making it a first-class dependency that Effect programs declare in their type signatures. The \texttt{BrowserServiceLive} layer constructs the implementation via nested \texttt{acquireRelease} calls, guaranteeing cleanup on success, failure, or interruption. Consumer programs access the browser through \texttt{yield* BrowserService}, and Effect's type system statically verifies that the required layer is provided before execution.
+The bridge between the two is the \texttt{runEffect} function (Listing~\ref{lst:runeffect}), which converts Effect programs to fp-ts \texttt{TaskEither}. The critical design choice is using \texttt{Effect.runPromiseExit} rather than \texttt{Effect.runPromise}: the latter wraps typed errors in \texttt{FiberFailure}, losing the discriminated union structure at the \texttt{Promise} boundary. The Exit-based approach preserves typed failures by inspecting \texttt{Cause.failureOption} to extract the first \texttt{MiddlewareError}, which \texttt{toSchedulingError} then maps to the adapter-layer \texttt{SchedulingError} union. Unexpected defects (null pointer, timeout) fall through to the infrastructure error path via \texttt{Cause.pretty}.
 
-Adapter methods compose wizard step programs directly via \texttt{Effect.gen}, with error mapping handled by \texttt{Effect.mapError} at the adapter boundary. This eliminates the need for runtime bridges between effect systems---the same \texttt{Effect.Effect} type flows from the innermost browser interaction through to the consumer-facing adapter interface.
-
-\begin{lstlisting}[language=TypeScript,caption={Unified Effect architecture: \texttt{Context.Tag} for dependency injection and \texttt{Effect.gen} for composition},label={lst:effectarch}]
-// Service tag declaration
-class BrowserService extends
-  Context.Tag('BrowserService')<
-    BrowserService,
-    BrowserServiceShape>() {}
-
-// Adapter method: Effect throughout
-const getAvailableDates = (
-  serviceId: string,
-  providerId: string,
-  month: string,
-): Effect.Effect<AvailableDate[],
-                 SchedulingError> =>
-  Effect.gen(function* () {
-    const svc = yield* BrowserService;
-    const page = yield* svc.acquirePage;
-    const dates = yield* readAvailability(
-      page, serviceId, month);
-    return dates;
-  }).pipe(
-    Effect.scoped,
-    Effect.provide(BrowserServiceLive()),
-    Effect.mapError(toSchedulingError),
-  );
+\begin{lstlisting}[language=TypeScript,caption={The \texttt{runEffect} bridge: Effect TS programs to fp-ts TaskEither via Exit inspection},label={lst:runeffect}]
+const runEffect = <A>(
+  effect: Effect.Effect<A, MiddlewareError>,
+): SchedulingResult<A> =>
+  () =>
+    Effect.runPromiseExit(
+      effect.pipe(Effect.provide(layer))
+    ).then((exit) => {
+      if (Exit.isSuccess(exit))
+        return E.right(exit.value);
+      // Extract typed failure from Cause tree
+      const failure =
+        Cause.failureOption(exit.cause);
+      if (failure._tag === 'Some')
+        return E.left(
+          toSchedulingError(failure.value));
+      // Defect: unexpected error
+      return E.left(Errors.infrastructure(
+        'UNKNOWN',
+        `Effect defect: ${
+          Cause.pretty(exit.cause)}`));
+    });
 \end{lstlisting}
 
 \subsection{CSS Selector Registry}
@@ -318,19 +313,6 @@ const resolveSelector = (
 \end{lstlisting}
 
 Two complementary utilities support the registry: \texttt{probeSelector} performs a non-blocking existence check (useful for conditional logic like detecting whether the wizard landed on a payment page), and \texttt{healthCheck} validates a batch of selector keys against the current page, returning passed/failed arrays for diagnostic use.
-
-\subsection{Resilient Service Resolution}
-
-When the practitioner renames a service in Acuity's admin panel (e.g., ``TMD 60 min'' becomes ``TMD/TMJ 60 min (including intraoral)''), the middleware must still map inbound booking requests to the correct Acuity appointment type. The \texttt{ServiceResolver} module implements a 4-strategy cascade via \texttt{Effect.orElse}, where each strategy returns a confidence score and strategy name for observability:
-
-\begin{enumerate}
-\item \textbf{ID match} (confidence 1.0). Direct lookup in Acuity's \texttt{window.BUSINESS.appointmentTypes} array, extracted via page evaluation. This object contains the authoritative service catalog including IDs, names, durations, and prices.
-\item \textbf{Normalized exact match} (confidence 0.95). Case-insensitive comparison after stripping parenthetical qualifiers and normalizing whitespace.
-\item \textbf{Token overlap} (confidence 0.5--0.9). Tokenizes both the query and candidate names, scoring by intersection-over-union of non-stopword tokens.
-\item \textbf{Fuzzy/Levenshtein} (confidence 0.3--0.7). Edit-distance matching as a last resort, with confidence inversely proportional to normalized distance.
-\end{enumerate}
-
-The \texttt{ServiceResolver} follows the same \texttt{Context.Tag}/\texttt{Layer} pattern as \texttt{BrowserService}, allowing it to be injected and tested independently. The BUSINESS object extraction (strategy 1) also serves the health check and reconciliation systems described in Section~\ref{sec:observability}.
 
 \subsection{Error Architecture}
 
@@ -612,17 +594,6 @@ The \texttt{HomegrownAdapter} implements all 17 methods via direct PostgreSQL qu
 
 A pure-function module with zero database dependency generates candidate slots at configurable intervals within business hours, filtering overlaps with occupied blocks. DST safety uses \texttt{Intl.DateTimeFormat} with named timezones. The module has 39 dedicated unit tests.
 
-\subsection{Observability and Self-Healing}
-\label{sec:observability}
-
-The middleware uses NDJSON structured logging via Effect's built-in \texttt{Logger} layer, replacing ad-hoc \texttt{console.log} calls with machine-parseable log lines carrying span context, timestamps, and typed metadata.
-
-\textbf{Tiered selector health checks.} A parameterized \texttt{depth} controls diagnostic granularity: depth=0 performs an HTTP-only BUSINESS object extraction ($\sim$200ms), validating that Acuity's service catalog is reachable without launching a full browser; depth=1 adds service page selector validation ($\sim$3--5s); depth=2 extends to calendar and slot selectors ($\sim$8--15s). Each check returns a structured report with \texttt{passed}, \texttt{failed}, and \texttt{degraded} arrays.
-
-\textbf{Degraded status.} When a primary selector fails but a fallback candidate in the registry chain succeeds, the check returns ``degraded'' rather than ``failed.'' This provides early warning that a DOM change has occurred---the system still functions, but the selector chain has lost a layer of resilience.
-
-\textbf{Service catalog reconciliation.} A daily cron job fetches the \texttt{window.BUSINESS} object from Acuity, compares the returned \texttt{appointmentTypes} against the PostgreSQL service catalog, and alerts on drift---new services added in Acuity but not in the homegrown backend, or price/duration mismatches between the two systems.
-
 %% ============================================================
 \section{Evaluation}
 
@@ -660,11 +631,12 @@ The ``sticky panel'' bug---where the Acuity admin panel's React state management
 \toprule
 \textbf{Component} & \textbf{Tests} \\
 \midrule
-Scheduling-kit (workspace) & 642 \\
-Acuity-middleware & 70 \\
+Scheduling-kit (core) & 555 \\
+Availability engine & 39 \\
+Adapter bridge & 3 \\
 Application (root) & 282 \\
 \midrule
-\textbf{Total} & \textbf{994} \\
+\textbf{Total} & \textbf{879} \\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -718,11 +690,11 @@ Clients (2) & 2/2 & 2/2 \\
 
 Browser automation against a third-party SPA is inherently fragile. Acuity can change their React component structure or Emotion CSS naming at any time. Three mitigations make this acceptable: (a) isolation via adapter interface---only the wizard adapter breaks; (b) disposability by design---the wizard adapter is a migration bridge; (c) fallback chains in the selector registry absorb minor DOM restructuring.
 
-\subsection{Effect Unification}
+\subsection{Dual Effect System Complexity}
 
-The initial architecture used both Effect TS and fp-ts simultaneously, with a \texttt{runEffect} bridge function converting between the two type systems at the adapter boundary. This dual-library approach introduced cognitive overhead and was a source of subtle bugs---particularly around \texttt{FiberFailure} wrapping that destroyed discriminated union structure at the \texttt{Promise} boundary.
+Using both Effect TS and fp-ts introduces cognitive overhead. The \texttt{runEffect} bridge (Listing~\ref{lst:runeffect}) is a source of subtle bugs: the naive approach of using \texttt{Effect.runPromise} wraps typed errors in \texttt{FiberFailure}, which destroys the discriminated union structure and forces \texttt{instanceof} checks rather than \texttt{\_tag}-based pattern matching. The Exit-based approach solves this but requires understanding Effect's \texttt{Cause} algebra---a \texttt{Cause<E>} is a tree that may contain multiple failures, defects (unexpected errors), and interruption signals. Maintaining two parallel discriminated unions (4 middleware variants, 7 adapter variants) with a bridge function between them compounds the mental model required of contributors.
 
-In March 2026, the codebase was unified on Effect TS throughout, eliminating the \texttt{runEffect} bridge entirely. All adapter methods now return \texttt{Effect.Effect<A, SchedulingError>} directly, and the SvelteKit route handlers consume effects via \texttt{Effect.runPromise} at the HTTP boundary. The migration required updating all consumer code from fp-ts \texttt{pipe}/\texttt{chain} composition to Effect's generator syntax, but the result is a single error propagation model from browser interaction through to API response. The two error hierarchies (middleware and adapter) remain separated by design, but error mapping is now a simple \texttt{Effect.mapError} call rather than a cross-library bridge.
+A future version might unify on Effect TS throughout, eliminating the bridge entirely. However, this would require migrating all consumer code from fp-ts \texttt{pipe}/\texttt{chain} composition to Effect's generator syntax---a non-trivial refactor for the SvelteKit application layer.
 
 \subsection{Ethical and Legal Considerations}
 
@@ -735,11 +707,11 @@ The adapter interface + browser middleware + feature-flag routing architecture g
 %% ============================================================
 \section{Conclusion}
 
-We have presented a browser automation middleware architecture for zero-downtime migration away from a SaaS scheduling vendor that restricts API access. The architecture implements the strangler fig pattern with a 17-method adapter interface, a unified Effect TS middleware layer with nested \texttt{acquireRelease} resource management and \texttt{Context.Tag}-based dependency injection, a layered error hierarchy with \texttt{Effect.mapError} bridging, resilient service resolution via a 4-strategy confidence-scored cascade, and feature-flag-driven backend selection. The system has been deployed in production since March 2026, serving real appointment bookings across both backends simultaneously.
+We have presented a browser automation middleware architecture for zero-downtime migration away from a SaaS scheduling vendor that restricts API access. The architecture implements the strangler fig pattern with a 17-method adapter interface, an Effect TS browser middleware layer with nested \texttt{acquireRelease} resource management, a dual error type hierarchy bridging Effect TS and fp-ts, and feature-flag-driven backend selection. The system has been deployed in production since March 2026, serving real appointment bookings across both backends simultaneously.
 
 The browser middleware layer is intentionally temporary---a bridge, not a destination. The strangler fig completes not with a dramatic cutover but with the quiet deletion of the browser automation code that made the migration possible.
 
-Future work includes completing the Acuity sunset, generalizing the middleware framework for other vertical SaaS categories, and investigating AI-assisted selector maintenance for longer-lived browser automation deployments. The unification on Effect TS, completed in March 2026, has reduced cognitive overhead and eliminated a class of bridge-related bugs, validating the investment in a single-effect-system architecture.
+Future work includes completing the Acuity sunset, generalizing the middleware framework for other vertical SaaS categories, and investigating AI-assisted selector maintenance for longer-lived browser automation deployments.
 
 %% ============================================================
 \balance

--- a/docs/paper/acuity-middleware-paper.tex
+++ b/docs/paper/acuity-middleware-paper.tex
@@ -33,7 +33,7 @@
 \lstdefinelanguage{TypeScript}{
   keywords={function, return, const, let, if, else, switch, case, class, interface, type, extends, implements, import, export, from, as, new, this, async, await, yield, default, typeof, void, null, undefined, true, false, in, of},
   keywordstyle=\color{tskw}\bfseries,
-  ndkeywords={string, number, boolean, Promise, Effect, Either, TaskEither, SchedulingResult, SchedulingError, SchedulingAdapter, Service, Booking, BookingRequest, Provider, TimeSlot, AvailableDate, SlotReservation, ClientInfo, Layer, Context, Exit, Cause, BrowserService, BrowserError, SelectorError, WizardStepError, CouponError, MiddlewareError, Data, TaggedError, Scope, Page, ResolvedSelector, BrowserConfig, BrowserServiceShape, ConfirmationData, NavigateResult},
+  ndkeywords={string, number, boolean, Promise, Effect, Exit, SchedulingResult, SchedulingError, SchedulingAdapter, Service, Booking, BookingRequest, Provider, TimeSlot, AvailableDate, SlotReservation, ClientInfo, Layer, Context, Cause, BrowserService, BrowserError, SelectorError, WizardStepError, CouponError, MiddlewareError, Data, TaggedError, Scope, Page, ResolvedSelector, BrowserConfig, BrowserServiceShape, ConfirmationData, NavigateResult},
   ndkeywordstyle=\color{tstype},
   sensitive=true,
   comment=[l]{//},
@@ -79,7 +79,7 @@ jess@tinyland.dev}}
 \maketitle
 
 \begin{abstract}
-Small-business SaaS platforms create vendor lock-in through API paywalls and proprietary data formats. When the vendor restricts programmatic access to premium pricing tiers, businesses face a choice between paying for API access they should already have or accepting that their own data is held hostage. We present a browser automation middleware architecture that implements a standardized 17-method scheduling adapter interface by puppeteering the vendor's public-facing web UI via headless Playwright, deployed as a containerized service on Modal Labs. A feature-flag-driven backend selector enables zero-downtime migration from the legacy vendor to a homegrown PostgreSQL backend, implementing the strangler fig pattern against a third-party SaaS dependency. The system has been deployed in production since March 2026, processing real appointment bookings across both backends simultaneously. We report on the architecture, the dual functional programming approach (Effect TS for browser lifecycle management, fp-ts for adapter composition), the reliability challenges of DOM automation against a React SPA with Emotion CSS, and the lessons learned from automating 604 legacy appointments across 62 weeks of calendar data. The middleware replaces 8 blocked REST API endpoints through DOM interaction alone, demonstrating that browser automation is a viable---if intentionally temporary---bridge pattern for escaping SaaS vendor lock-in.
+Small-business SaaS platforms create vendor lock-in through API paywalls and proprietary data formats. When the vendor restricts programmatic access to premium pricing tiers, businesses face a choice between paying for API access they should already have or accepting that their own data is held hostage. We present a browser automation middleware architecture that implements a standardized 17-method scheduling adapter interface by puppeteering the vendor's public-facing web UI via headless Playwright, deployed as a containerized service on Modal Labs. A feature-flag-driven backend selector enables zero-downtime migration from the legacy vendor to a homegrown PostgreSQL backend, implementing the strangler fig pattern against a third-party SaaS dependency. The system has been deployed in production since March 2026, processing real appointment bookings across both backends simultaneously. We report on the architecture, the unified Effect TS functional programming approach (covering browser lifecycle management, adapter composition, error handling, and resource management), the reliability challenges of DOM automation against a React SPA with Emotion CSS, and the lessons learned from automating 604 legacy appointments across 62 weeks of calendar data. The middleware replaces 8 blocked REST API endpoints through DOM interaction alone, demonstrating that browser automation is a viable---if intentionally temporary---bridge pattern for escaping SaaS vendor lock-in.
 \end{abstract}
 
 \begin{IEEEkeywords}
@@ -102,7 +102,7 @@ The key insight is that browser automation middleware is not the destination---i
 This paper makes four contributions:
 
 \begin{enumerate}
-\item A formal 17-method \texttt{SchedulingAdapter} interface that abstracts scheduling operations (services, availability, reservations, bookings, clients) across heterogeneous backends, with all methods returning monadic \texttt{TaskEither<SchedulingError, T>} for composable error handling.
+\item A formal 17-method \texttt{SchedulingAdapter} interface that abstracts scheduling operations (services, availability, reservations, bookings, clients) across heterogeneous backends, with all methods returning monadic \texttt{Effect<T, SchedulingError>} for composable error handling.
 
 \item An Effect TS middleware layer that implements this interface via headless browser automation, using typed effect programs for each wizard step, managed browser lifecycle via \texttt{acquireRelease}, and a CSS selector registry with fallback chains for resilience against DOM instability.
 
@@ -244,36 +244,34 @@ Clients & \texttt{findOrCreateClient}, \texttt{getClientByEmail} & 2 \\
 \end{tabular}
 \end{table}
 
-All methods return \texttt{SchedulingResult<T>}, defined as \texttt{TaskEither<SchedulingError, T>} from fp-ts~\cite{fp-ts}. The \texttt{SchedulingError} type is a discriminated union with seven variants (\texttt{AcuityError}, \texttt{CalComError}, \texttt{PaymentError}, \texttt{ValidationError}, \texttt{ReservationError}, \texttt{IdempotencyError}, \texttt{InfrastructureError}), each carrying a \texttt{\_tag} discriminant, a \texttt{code} string, and a human-readable \texttt{message}.
+All methods return \texttt{SchedulingResult<T>}, defined as \texttt{Effect<T, SchedulingError>} from Effect TS~\cite{effect-ts}. The \texttt{SchedulingError} type is a discriminated union with seven variants (\texttt{AcuityError}, \texttt{CalComError}, \texttt{PaymentError}, \texttt{ValidationError}, \texttt{ReservationError}, \texttt{IdempotencyError}, \texttt{InfrastructureError}), each carrying a \texttt{\_tag} discriminant, a \texttt{code} string, and a human-readable \texttt{message}. (An earlier version of the system used fp-ts~\cite{fp-ts} \texttt{TaskEither} for the adapter return type; this was replaced by Effect during a full unification migration.)
 
-\subsection{Dual Functional Programming Architecture}
+\subsection{Unified Effect TS Architecture}
 
-The system uses two functional programming libraries simultaneously, each chosen for the layer where its abstractions are strongest. \textbf{Effect TS}~\cite{effect-ts} manages the browser middleware layer: generator-based programs (\texttt{Effect.gen(function*~\{...\})}), typed errors via \texttt{Data.TaggedError}, dependency injection via \texttt{Context.Tag}, and resource lifecycle via \texttt{Layer.scoped} and \texttt{Effect.acquireRelease}. \textbf{fp-ts}~\cite{fp-ts} provides the adapter interface type (\texttt{TaskEither}) and composition operators (\texttt{pipe}, \texttt{chain}, \texttt{map}).
+The system uses Effect TS~\cite{effect-ts} as its sole functional programming library, providing a unified abstraction across all layers. Effect manages the browser middleware layer---generator-based programs (\texttt{Effect.gen(function*~\{...\})}), typed errors via \texttt{Data.TaggedError}, dependency injection via \texttt{Context.Tag}, and resource lifecycle via \texttt{Layer.scoped} and \texttt{Effect.acquireRelease}---and also provides the adapter interface return type (\texttt{Effect<T, SchedulingError>}) and composition operators (\texttt{pipe}, \texttt{map}, \texttt{flatMap}).
 
-The bridge between the two is the \texttt{runEffect} function (Listing~\ref{lst:runeffect}), which converts Effect programs to fp-ts \texttt{TaskEither}. The critical design choice is using \texttt{Effect.runPromiseExit} rather than \texttt{Effect.runPromise}: the latter wraps typed errors in \texttt{FiberFailure}, losing the discriminated union structure at the \texttt{Promise} boundary. The Exit-based approach preserves typed failures by inspecting \texttt{Cause.failureOption} to extract the first \texttt{MiddlewareError}, which \texttt{toSchedulingError} then maps to the adapter-layer \texttt{SchedulingError} union. Unexpected defects (null pointer, timeout) fall through to the infrastructure error path via \texttt{Cause.pretty}.
+An earlier version of the system used a dual-library approach: fp-ts~\cite{fp-ts} for the adapter interface (\texttt{TaskEither}) and Effect TS for the browser middleware. A \texttt{runEffect} bridge function (Listing~\ref{lst:runeffect}) converted between the two. This bridge was a source of subtle bugs---\texttt{Effect.runPromise} wraps typed errors in \texttt{FiberFailure}, destroying the discriminated union structure at the \texttt{Promise} boundary. The unification to Effect throughout eliminated this bridge entirely, using \texttt{Effect.runPromiseExit} only at the outermost execution boundary where the adapter meets the HTTP handler. The Exit-based approach preserves typed failures by inspecting \texttt{Cause.failureOption} to extract the first \texttt{MiddlewareError}, which \texttt{toSchedulingError} then maps to the adapter-layer \texttt{SchedulingError} union. Unexpected defects (null pointer, timeout) fall through to the infrastructure error path via \texttt{Cause.pretty}.
 
-\begin{lstlisting}[language=TypeScript,caption={The \texttt{runEffect} bridge: Effect TS programs to fp-ts TaskEither via Exit inspection},label={lst:runeffect}]
+\begin{lstlisting}[language=TypeScript,caption={The \texttt{runEffect} execution boundary: Effect programs to Promise via Exit inspection (historical bridge to fp-ts \texttt{TaskEither} eliminated during unification)},label={lst:runeffect}]
 const runEffect = <A>(
   effect: Effect.Effect<A, MiddlewareError>,
-): SchedulingResult<A> =>
-  () =>
-    Effect.runPromiseExit(
-      effect.pipe(Effect.provide(layer))
-    ).then((exit) => {
-      if (Exit.isSuccess(exit))
-        return E.right(exit.value);
-      // Extract typed failure from Cause tree
-      const failure =
-        Cause.failureOption(exit.cause);
-      if (failure._tag === 'Some')
-        return E.left(
-          toSchedulingError(failure.value));
-      // Defect: unexpected error
-      return E.left(Errors.infrastructure(
-        'UNKNOWN',
-        `Effect defect: ${
-          Cause.pretty(exit.cause)}`));
-    });
+): Promise<A> =>
+  Effect.runPromiseExit(
+    effect.pipe(Effect.provide(layer))
+  ).then((exit) => {
+    if (Exit.isSuccess(exit))
+      return exit.value;
+    // Extract typed failure from Cause tree
+    const failure =
+      Cause.failureOption(exit.cause);
+    if (failure._tag === 'Some')
+      throw toSchedulingError(failure.value);
+    // Defect: unexpected error
+    throw Errors.infrastructure(
+      'UNKNOWN',
+      `Effect defect: ${
+        Cause.pretty(exit.cause)}`);
+  });
 \end{lstlisting}
 
 \subsection{CSS Selector Registry}
@@ -690,11 +688,11 @@ Clients (2) & 2/2 & 2/2 \\
 
 Browser automation against a third-party SPA is inherently fragile. Acuity can change their React component structure or Emotion CSS naming at any time. Three mitigations make this acceptable: (a) isolation via adapter interface---only the wizard adapter breaks; (b) disposability by design---the wizard adapter is a migration bridge; (c) fallback chains in the selector registry absorb minor DOM restructuring.
 
-\subsection{Dual Effect System Complexity}
+\subsection{Effect Unification}
 
-Using both Effect TS and fp-ts introduces cognitive overhead. The \texttt{runEffect} bridge (Listing~\ref{lst:runeffect}) is a source of subtle bugs: the naive approach of using \texttt{Effect.runPromise} wraps typed errors in \texttt{FiberFailure}, which destroys the discriminated union structure and forces \texttt{instanceof} checks rather than \texttt{\_tag}-based pattern matching. The Exit-based approach solves this but requires understanding Effect's \texttt{Cause} algebra---a \texttt{Cause<E>} is a tree that may contain multiple failures, defects (unexpected errors), and interruption signals. Maintaining two parallel discriminated unions (4 middleware variants, 7 adapter variants) with a bridge function between them compounds the mental model required of contributors.
+An earlier version of the system used both Effect TS and fp-ts simultaneously, requiring a bridge function between the two effect systems. This dual-library approach introduced cognitive overhead: the \texttt{runEffect} bridge was a source of subtle bugs where \texttt{Effect.runPromise} would wrap typed errors in \texttt{FiberFailure}, destroying the discriminated union structure. The Exit-based approach (Listing~\ref{lst:runeffect}) solved the error-handling issue but required understanding Effect's \texttt{Cause} algebra.
 
-A future version might unify on Effect TS throughout, eliminating the bridge entirely. However, this would require migrating all consumer code from fp-ts \texttt{pipe}/\texttt{chain} composition to Effect's generator syntax---a non-trivial refactor for the SvelteKit application layer.
+The system was subsequently unified on Effect TS throughout, eliminating the fp-ts dependency and the bridge function entirely. This migration required converting all consumer code from fp-ts \texttt{pipe}/\texttt{chain} composition to Effect's generator syntax and \texttt{flatMap}/\texttt{map} operators---a non-trivial refactor across the SvelteKit application layer, the scheduling-kit package, and this middleware. The resulting single-library architecture reduced the mental model required of contributors and eliminated an entire class of error-boundary bugs.
 
 \subsection{Ethical and Legal Considerations}
 
@@ -707,7 +705,7 @@ The adapter interface + browser middleware + feature-flag routing architecture g
 %% ============================================================
 \section{Conclusion}
 
-We have presented a browser automation middleware architecture for zero-downtime migration away from a SaaS scheduling vendor that restricts API access. The architecture implements the strangler fig pattern with a 17-method adapter interface, an Effect TS browser middleware layer with nested \texttt{acquireRelease} resource management, a dual error type hierarchy bridging Effect TS and fp-ts, and feature-flag-driven backend selection. The system has been deployed in production since March 2026, serving real appointment bookings across both backends simultaneously.
+We have presented a browser automation middleware architecture for zero-downtime migration away from a SaaS scheduling vendor that restricts API access. The architecture implements the strangler fig pattern with a 17-method adapter interface, a unified Effect TS layer for both browser middleware and adapter composition with nested \texttt{acquireRelease} resource management, a layered error type hierarchy with bridge functions between middleware-specific and adapter-generic error variants, and feature-flag-driven backend selection. The system has been deployed in production since March 2026, serving real appointment bookings across both backends simultaneously.
 
 The browser middleware layer is intentionally temporary---a bridge, not a destination. The strangler fig completes not with a dramatic cutover but with the quiet deletion of the browser automation code that made the migration possible.
 

--- a/docs/paper/acuity-middleware-paper.tex
+++ b/docs/paper/acuity-middleware-paper.tex
@@ -33,7 +33,7 @@
 \lstdefinelanguage{TypeScript}{
   keywords={function, return, const, let, if, else, switch, case, class, interface, type, extends, implements, import, export, from, as, new, this, async, await, yield, default, typeof, void, null, undefined, true, false, in, of},
   keywordstyle=\color{tskw}\bfseries,
-  ndkeywords={string, number, boolean, Promise, Effect, Either, TaskEither, SchedulingResult, SchedulingError, SchedulingAdapter, Service, Booking, BookingRequest, Provider, TimeSlot, AvailableDate, SlotReservation, ClientInfo, Layer, Context, Exit, Cause, BrowserService, BrowserError, SelectorError, WizardStepError, CouponError, MiddlewareError, Data, TaggedError, Scope, Page, ResolvedSelector, BrowserConfig, BrowserServiceShape, ConfirmationData, NavigateResult},
+  ndkeywords={string, number, boolean, Promise, Effect, Either, TaskEither, SchedulingResult, SchedulingError, SchedulingAdapter, Service, Booking, BookingRequest, Provider, TimeSlot, AvailableDate, SlotReservation, ClientInfo, Layer, Context, Exit, Cause, BrowserService, BrowserError, SelectorError, WizardStepError, CouponError, MiddlewareError, Data, TaggedError, Scope, Page, ResolvedSelector, BrowserConfig, BrowserServiceShape, ConfirmationData, NavigateResult, ServiceResolver, Logger},
   ndkeywordstyle=\color{tstype},
   sensitive=true,
   comment=[l]{//},
@@ -79,7 +79,7 @@ jess@tinyland.dev}}
 \maketitle
 
 \begin{abstract}
-Small-business SaaS platforms create vendor lock-in through API paywalls and proprietary data formats. When the vendor restricts programmatic access to premium pricing tiers, businesses face a choice between paying for API access they should already have or accepting that their own data is held hostage. We present a browser automation middleware architecture that implements a standardized 17-method scheduling adapter interface by puppeteering the vendor's public-facing web UI via headless Playwright, deployed as a containerized service on Modal Labs. A feature-flag-driven backend selector enables zero-downtime migration from the legacy vendor to a homegrown PostgreSQL backend, implementing the strangler fig pattern against a third-party SaaS dependency. The system has been deployed in production since March 2026, processing real appointment bookings across both backends simultaneously. We report on the architecture, the dual functional programming approach (Effect TS for browser lifecycle management, fp-ts for adapter composition), the reliability challenges of DOM automation against a React SPA with Emotion CSS, and the lessons learned from automating 604 legacy appointments across 62 weeks of calendar data. The middleware replaces 8 blocked REST API endpoints through DOM interaction alone, demonstrating that browser automation is a viable---if intentionally temporary---bridge pattern for escaping SaaS vendor lock-in.
+Small-business SaaS platforms create vendor lock-in through API paywalls and proprietary data formats. When the vendor restricts programmatic access to premium pricing tiers, businesses face a choice between paying for API access they should already have or accepting that their own data is held hostage. We present a browser automation middleware architecture that implements a standardized 17-method scheduling adapter interface by puppeteering the vendor's public-facing web UI via headless Playwright, deployed as a containerized service on Modal Labs. A feature-flag-driven backend selector enables zero-downtime migration from the legacy vendor to a homegrown PostgreSQL backend, implementing the strangler fig pattern against a third-party SaaS dependency. The system has been deployed in production since March 2026, processing real appointment bookings across both backends simultaneously. We report on the architecture, the unified Effect TS functional programming approach for both browser lifecycle management and adapter composition, the reliability challenges of DOM automation against a React SPA with Emotion CSS, and the lessons learned from automating 604 legacy appointments across 62 weeks of calendar data. The middleware replaces 8 blocked REST API endpoints through DOM interaction alone, demonstrating that browser automation is a viable---if intentionally temporary---bridge pattern for escaping SaaS vendor lock-in.
 \end{abstract}
 
 \begin{IEEEkeywords}
@@ -102,7 +102,7 @@ The key insight is that browser automation middleware is not the destination---i
 This paper makes four contributions:
 
 \begin{enumerate}
-\item A formal 17-method \texttt{SchedulingAdapter} interface that abstracts scheduling operations (services, availability, reservations, bookings, clients) across heterogeneous backends, with all methods returning monadic \texttt{TaskEither<SchedulingError, T>} for composable error handling.
+\item A formal 17-method \texttt{SchedulingAdapter} interface that abstracts scheduling operations (services, availability, reservations, bookings, clients) across heterogeneous backends, with all methods returning \texttt{Effect.Effect<A, SchedulingError>} for composable error handling.
 
 \item An Effect TS middleware layer that implements this interface via headless browser automation, using typed effect programs for each wizard step, managed browser lifecycle via \texttt{acquireRelease}, and a CSS selector registry with fallback chains for resilience against DOM instability.
 
@@ -244,36 +244,41 @@ Clients & \texttt{findOrCreateClient}, \texttt{getClientByEmail} & 2 \\
 \end{tabular}
 \end{table}
 
-All methods return \texttt{SchedulingResult<T>}, defined as \texttt{TaskEither<SchedulingError, T>} from fp-ts~\cite{fp-ts}. The \texttt{SchedulingError} type is a discriminated union with seven variants (\texttt{AcuityError}, \texttt{CalComError}, \texttt{PaymentError}, \texttt{ValidationError}, \texttt{ReservationError}, \texttt{IdempotencyError}, \texttt{InfrastructureError}), each carrying a \texttt{\_tag} discriminant, a \texttt{code} string, and a human-readable \texttt{message}.
+All methods return \texttt{Effect.Effect<A, SchedulingError>}. The \texttt{SchedulingError} type is a discriminated union with seven variants (\texttt{AcuityError}, \texttt{CalComError}, \texttt{PaymentError}, \texttt{ValidationError}, \texttt{ReservationError}, \texttt{IdempotencyError}, \texttt{InfrastructureError}), each carrying a \texttt{\_tag} discriminant, a \texttt{code} string, and a human-readable \texttt{message}.
 
-\subsection{Dual Functional Programming Architecture}
+\subsection{Effect TS Architecture}
 
-The system uses two functional programming libraries simultaneously, each chosen for the layer where its abstractions are strongest. \textbf{Effect TS}~\cite{effect-ts} manages the browser middleware layer: generator-based programs (\texttt{Effect.gen(function*~\{...\})}), typed errors via \texttt{Data.TaggedError}, dependency injection via \texttt{Context.Tag}, and resource lifecycle via \texttt{Layer.scoped} and \texttt{Effect.acquireRelease}. \textbf{fp-ts}~\cite{fp-ts} provides the adapter interface type (\texttt{TaskEither}) and composition operators (\texttt{pipe}, \texttt{chain}, \texttt{map}).
+The system is built entirely on Effect TS~\cite{effect-ts}, using a single functional programming paradigm across all layers. Generator-based programs (\texttt{Effect.gen(function*~\{...\})}) provide sequential composition with typed error propagation, \texttt{Data.TaggedError} classes define exhaustively matchable error variants, and \texttt{Context.Tag} with \texttt{Layer} provides compile-time dependency injection.
 
-The bridge between the two is the \texttt{runEffect} function (Listing~\ref{lst:runeffect}), which converts Effect programs to fp-ts \texttt{TaskEither}. The critical design choice is using \texttt{Effect.runPromiseExit} rather than \texttt{Effect.runPromise}: the latter wraps typed errors in \texttt{FiberFailure}, losing the discriminated union structure at the \texttt{Promise} boundary. The Exit-based approach preserves typed failures by inspecting \texttt{Cause.failureOption} to extract the first \texttt{MiddlewareError}, which \texttt{toSchedulingError} then maps to the adapter-layer \texttt{SchedulingError} union. Unexpected defects (null pointer, timeout) fall through to the infrastructure error path via \texttt{Cause.pretty}.
+The \texttt{BrowserService} is defined as a \texttt{Context.Tag} (Listing~\ref{lst:effectarch}), making it a first-class dependency that Effect programs declare in their type signatures. The \texttt{BrowserServiceLive} layer constructs the implementation via nested \texttt{acquireRelease} calls, guaranteeing cleanup on success, failure, or interruption. Consumer programs access the browser through \texttt{yield* BrowserService}, and Effect's type system statically verifies that the required layer is provided before execution.
 
-\begin{lstlisting}[language=TypeScript,caption={The \texttt{runEffect} bridge: Effect TS programs to fp-ts TaskEither via Exit inspection},label={lst:runeffect}]
-const runEffect = <A>(
-  effect: Effect.Effect<A, MiddlewareError>,
-): SchedulingResult<A> =>
-  () =>
-    Effect.runPromiseExit(
-      effect.pipe(Effect.provide(layer))
-    ).then((exit) => {
-      if (Exit.isSuccess(exit))
-        return E.right(exit.value);
-      // Extract typed failure from Cause tree
-      const failure =
-        Cause.failureOption(exit.cause);
-      if (failure._tag === 'Some')
-        return E.left(
-          toSchedulingError(failure.value));
-      // Defect: unexpected error
-      return E.left(Errors.infrastructure(
-        'UNKNOWN',
-        `Effect defect: ${
-          Cause.pretty(exit.cause)}`));
-    });
+Adapter methods compose wizard step programs directly via \texttt{Effect.gen}, with error mapping handled by \texttt{Effect.mapError} at the adapter boundary. This eliminates the need for runtime bridges between effect systems---the same \texttt{Effect.Effect} type flows from the innermost browser interaction through to the consumer-facing adapter interface.
+
+\begin{lstlisting}[language=TypeScript,caption={Unified Effect architecture: \texttt{Context.Tag} for dependency injection and \texttt{Effect.gen} for composition},label={lst:effectarch}]
+// Service tag declaration
+class BrowserService extends
+  Context.Tag('BrowserService')<
+    BrowserService,
+    BrowserServiceShape>() {}
+
+// Adapter method: Effect throughout
+const getAvailableDates = (
+  serviceId: string,
+  providerId: string,
+  month: string,
+): Effect.Effect<AvailableDate[],
+                 SchedulingError> =>
+  Effect.gen(function* () {
+    const svc = yield* BrowserService;
+    const page = yield* svc.acquirePage;
+    const dates = yield* readAvailability(
+      page, serviceId, month);
+    return dates;
+  }).pipe(
+    Effect.scoped,
+    Effect.provide(BrowserServiceLive()),
+    Effect.mapError(toSchedulingError),
+  );
 \end{lstlisting}
 
 \subsection{CSS Selector Registry}
@@ -313,6 +318,19 @@ const resolveSelector = (
 \end{lstlisting}
 
 Two complementary utilities support the registry: \texttt{probeSelector} performs a non-blocking existence check (useful for conditional logic like detecting whether the wizard landed on a payment page), and \texttt{healthCheck} validates a batch of selector keys against the current page, returning passed/failed arrays for diagnostic use.
+
+\subsection{Resilient Service Resolution}
+
+When the practitioner renames a service in Acuity's admin panel (e.g., ``TMD 60 min'' becomes ``TMD/TMJ 60 min (including intraoral)''), the middleware must still map inbound booking requests to the correct Acuity appointment type. The \texttt{ServiceResolver} module implements a 4-strategy cascade via \texttt{Effect.orElse}, where each strategy returns a confidence score and strategy name for observability:
+
+\begin{enumerate}
+\item \textbf{ID match} (confidence 1.0). Direct lookup in Acuity's \texttt{window.BUSINESS.appointmentTypes} array, extracted via page evaluation. This object contains the authoritative service catalog including IDs, names, durations, and prices.
+\item \textbf{Normalized exact match} (confidence 0.95). Case-insensitive comparison after stripping parenthetical qualifiers and normalizing whitespace.
+\item \textbf{Token overlap} (confidence 0.5--0.9). Tokenizes both the query and candidate names, scoring by intersection-over-union of non-stopword tokens.
+\item \textbf{Fuzzy/Levenshtein} (confidence 0.3--0.7). Edit-distance matching as a last resort, with confidence inversely proportional to normalized distance.
+\end{enumerate}
+
+The \texttt{ServiceResolver} follows the same \texttt{Context.Tag}/\texttt{Layer} pattern as \texttt{BrowserService}, allowing it to be injected and tested independently. The BUSINESS object extraction (strategy 1) also serves the health check and reconciliation systems described in Section~\ref{sec:observability}.
 
 \subsection{Error Architecture}
 
@@ -594,6 +612,17 @@ The \texttt{HomegrownAdapter} implements all 17 methods via direct PostgreSQL qu
 
 A pure-function module with zero database dependency generates candidate slots at configurable intervals within business hours, filtering overlaps with occupied blocks. DST safety uses \texttt{Intl.DateTimeFormat} with named timezones. The module has 39 dedicated unit tests.
 
+\subsection{Observability and Self-Healing}
+\label{sec:observability}
+
+The middleware uses NDJSON structured logging via Effect's built-in \texttt{Logger} layer, replacing ad-hoc \texttt{console.log} calls with machine-parseable log lines carrying span context, timestamps, and typed metadata.
+
+\textbf{Tiered selector health checks.} A parameterized \texttt{depth} controls diagnostic granularity: depth=0 performs an HTTP-only BUSINESS object extraction ($\sim$200ms), validating that Acuity's service catalog is reachable without launching a full browser; depth=1 adds service page selector validation ($\sim$3--5s); depth=2 extends to calendar and slot selectors ($\sim$8--15s). Each check returns a structured report with \texttt{passed}, \texttt{failed}, and \texttt{degraded} arrays.
+
+\textbf{Degraded status.} When a primary selector fails but a fallback candidate in the registry chain succeeds, the check returns ``degraded'' rather than ``failed.'' This provides early warning that a DOM change has occurred---the system still functions, but the selector chain has lost a layer of resilience.
+
+\textbf{Service catalog reconciliation.} A daily cron job fetches the \texttt{window.BUSINESS} object from Acuity, compares the returned \texttt{appointmentTypes} against the PostgreSQL service catalog, and alerts on drift---new services added in Acuity but not in the homegrown backend, or price/duration mismatches between the two systems.
+
 %% ============================================================
 \section{Evaluation}
 
@@ -631,12 +660,11 @@ The ``sticky panel'' bug---where the Acuity admin panel's React state management
 \toprule
 \textbf{Component} & \textbf{Tests} \\
 \midrule
-Scheduling-kit (core) & 555 \\
-Availability engine & 39 \\
-Adapter bridge & 3 \\
+Scheduling-kit (workspace) & 642 \\
+Acuity-middleware & 70 \\
 Application (root) & 282 \\
 \midrule
-\textbf{Total} & \textbf{879} \\
+\textbf{Total} & \textbf{994} \\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -690,11 +718,11 @@ Clients (2) & 2/2 & 2/2 \\
 
 Browser automation against a third-party SPA is inherently fragile. Acuity can change their React component structure or Emotion CSS naming at any time. Three mitigations make this acceptable: (a) isolation via adapter interface---only the wizard adapter breaks; (b) disposability by design---the wizard adapter is a migration bridge; (c) fallback chains in the selector registry absorb minor DOM restructuring.
 
-\subsection{Dual Effect System Complexity}
+\subsection{Effect Unification}
 
-Using both Effect TS and fp-ts introduces cognitive overhead. The \texttt{runEffect} bridge (Listing~\ref{lst:runeffect}) is a source of subtle bugs: the naive approach of using \texttt{Effect.runPromise} wraps typed errors in \texttt{FiberFailure}, which destroys the discriminated union structure and forces \texttt{instanceof} checks rather than \texttt{\_tag}-based pattern matching. The Exit-based approach solves this but requires understanding Effect's \texttt{Cause} algebra---a \texttt{Cause<E>} is a tree that may contain multiple failures, defects (unexpected errors), and interruption signals. Maintaining two parallel discriminated unions (4 middleware variants, 7 adapter variants) with a bridge function between them compounds the mental model required of contributors.
+The initial architecture used both Effect TS and fp-ts simultaneously, with a \texttt{runEffect} bridge function converting between the two type systems at the adapter boundary. This dual-library approach introduced cognitive overhead and was a source of subtle bugs---particularly around \texttt{FiberFailure} wrapping that destroyed discriminated union structure at the \texttt{Promise} boundary.
 
-A future version might unify on Effect TS throughout, eliminating the bridge entirely. However, this would require migrating all consumer code from fp-ts \texttt{pipe}/\texttt{chain} composition to Effect's generator syntax---a non-trivial refactor for the SvelteKit application layer.
+In March 2026, the codebase was unified on Effect TS throughout, eliminating the \texttt{runEffect} bridge entirely. All adapter methods now return \texttt{Effect.Effect<A, SchedulingError>} directly, and the SvelteKit route handlers consume effects via \texttt{Effect.runPromise} at the HTTP boundary. The migration required updating all consumer code from fp-ts \texttt{pipe}/\texttt{chain} composition to Effect's generator syntax, but the result is a single error propagation model from browser interaction through to API response. The two error hierarchies (middleware and adapter) remain separated by design, but error mapping is now a simple \texttt{Effect.mapError} call rather than a cross-library bridge.
 
 \subsection{Ethical and Legal Considerations}
 
@@ -707,11 +735,11 @@ The adapter interface + browser middleware + feature-flag routing architecture g
 %% ============================================================
 \section{Conclusion}
 
-We have presented a browser automation middleware architecture for zero-downtime migration away from a SaaS scheduling vendor that restricts API access. The architecture implements the strangler fig pattern with a 17-method adapter interface, an Effect TS browser middleware layer with nested \texttt{acquireRelease} resource management, a dual error type hierarchy bridging Effect TS and fp-ts, and feature-flag-driven backend selection. The system has been deployed in production since March 2026, serving real appointment bookings across both backends simultaneously.
+We have presented a browser automation middleware architecture for zero-downtime migration away from a SaaS scheduling vendor that restricts API access. The architecture implements the strangler fig pattern with a 17-method adapter interface, a unified Effect TS middleware layer with nested \texttt{acquireRelease} resource management and \texttt{Context.Tag}-based dependency injection, a layered error hierarchy with \texttt{Effect.mapError} bridging, resilient service resolution via a 4-strategy confidence-scored cascade, and feature-flag-driven backend selection. The system has been deployed in production since March 2026, serving real appointment bookings across both backends simultaneously.
 
 The browser middleware layer is intentionally temporary---a bridge, not a destination. The strangler fig completes not with a dramatic cutover but with the quiet deletion of the browser automation code that made the migration possible.
 
-Future work includes completing the Acuity sunset, generalizing the middleware framework for other vertical SaaS categories, and investigating AI-assisted selector maintenance for longer-lived browser automation deployments.
+Future work includes completing the Acuity sunset, generalizing the middleware framework for other vertical SaaS categories, and investigating AI-assisted selector maintenance for longer-lived browser automation deployments. The unification on Effect TS, completed in March 2026, has reduced cognitive overhead and eliminated a class of bridge-related bugs, validating the investment in a single-effect-system architecture.
 
 %% ============================================================
 \balance

--- a/modal-app.py
+++ b/modal-app.py
@@ -50,8 +50,9 @@ image = (
         " --bundle --platform=node --format=esm --outfile=dist/server.mjs"
         " --external:playwright-core --external:playwright"
         " --external:@playwright/test"
-        " --external:@tummycrypt/*"
-        " --external:@neondatabase/*"
+        " --external:@tummycrypt/tinyland-auth-pg"
+        " --external:@tummycrypt/tinyland-auth-pg/*"
+        " --external:@neondatabase/serverless"
         " --external:drizzle-orm --external:drizzle-orm/*"
         " --external:@skeletonlabs/* --external:svelte --external:svelte/*",
         "ls -la /app/dist/server.mjs",

--- a/modal-app.py
+++ b/modal-app.py
@@ -71,7 +71,7 @@ image = (
     timeout=300,
     secrets=[modal.Secret.from_name("scheduling-middleware-secrets")],
 )
-@modal.concurrent(max_inputs=1)
+@modal.concurrent(max_inputs=3)
 @modal.web_server(port=3001, startup_timeout=30)
 def server():
     import subprocess

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/acuity-middleware",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Playwright-based Acuity booking middleware server",
   "type": "module",
   "license": "MIT",
@@ -20,8 +20,13 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "start": "node dist/middleware/server.js",
     "dev": "tsx src/middleware/server.ts",
     "test": "vitest run",
@@ -31,19 +36,23 @@
     "paper:dev": "node docs/paper/watch.mjs"
   },
   "dependencies": {
-    "@tummycrypt/scheduling-kit": "^0.2.0",
-    "effect": "^3.19.14",
-    "playwright-core": "^1.58.1"
+    "@tummycrypt/scheduling-kit": "^0.4.0",
+    "playwright-core": "^1.58.1",
+    "effect": "^3.19.14"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "playwright": "^1.58.2",
-    "tsx": "^4.0.0",
     "typescript": "^5.9.0",
-    "vitest": "^4.0.0"
+    "tsx": "^4.0.0",
+    "vitest": "^4.0.0",
+    "@types/node": "^22.0.0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "pnpm": {
+    "overrides": {
+      "effect": "^3.19.14"
+    }
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@tummycrypt/scheduling-kit": "^0.4.0",
-    "playwright-core": "^1.58.1",
+    "playwright-core": "1.58.1",
     "effect": "^3.19.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/acuity-middleware",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Playwright-based Acuity booking middleware server",
   "type": "module",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.19.14
         version: 3.21.0
       playwright-core:
-        specifier: ^1.58.1
-        version: 1.59.1
+        specifier: 1.58.1
+        version: 1.58.1
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -787,8 +787,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.58.1:
+    resolution: {integrity: sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1604,7 +1604,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.58.1: {}
 
   pngjs@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,11 +19,11 @@ importers:
         version: 3.21.0
       playwright-core:
         specifier: ^1.58.1
-        version: 1.58.2
+        version: 1.59.1
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
-        version: 22.19.15
+        version: 22.19.17
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -32,171 +32,171 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.0
-        version: 4.1.0(@types/node@22.19.15)(vite@8.0.1(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))
+        version: 4.1.2(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.27.4':
-    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.4':
-    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.4':
-    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.4':
-    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.4':
-    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.4':
-    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.4':
-    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.4':
-    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.4':
-    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.4':
-    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.4':
-    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.4':
-    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.4':
-    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.4':
-    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.4':
-    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.4':
-    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.4':
-    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.4':
-    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.4':
-    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.4':
-    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.4':
-    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.4':
-    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.4':
-    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.4':
-    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -217,8 +217,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.2':
+    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@neondatabase/serverless@0.10.4':
     resolution: {integrity: sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==}
@@ -241,100 +244,100 @@ packages:
   '@otplib/preset-v11@12.0.1':
     resolution: {integrity: sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==}
 
-  '@oxc-project/types@0.120.0':
-    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
-    resolution: {integrity: sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
-    resolution: {integrity: sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
-    resolution: {integrity: sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
-    resolution: {integrity: sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.10':
-    resolution: {integrity: sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==}
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -386,8 +389,8 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/node@22.19.15':
-    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/pg@8.11.6':
     resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
@@ -399,34 +402,34 @@ packages:
     resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitest/expect@4.1.0':
-    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
-  '@vitest/mocker@4.1.0':
-    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.0':
-    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
 
-  '@vitest/runner@4.1.0':
-    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
 
-  '@vitest/snapshot@4.1.0':
-    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
 
-  '@vitest/spy@4.1.0':
-    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
 
-  '@vitest/utils@4.1.0':
-    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -590,8 +593,8 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
-  esbuild@0.27.4:
-    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -780,12 +783,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -834,8 +837,8 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  rolldown@1.0.0-rc.10:
-    resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -902,8 +905,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  vite@8.0.1:
-    resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
+  vite@8.0.3:
+    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -945,21 +948,21 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.0:
-    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.0
-      '@vitest/browser-preview': 4.1.0
-      '@vitest/browser-webdriverio': 4.1.0
-      '@vitest/ui': 4.1.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -1011,98 +1014,98 @@ packages:
 
 snapshots:
 
-  '@emnapi/core@1.9.1':
+  '@emnapi/core@1.9.2':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.4':
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-arm64@0.27.4':
+  '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm@0.27.4':
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
-  '@esbuild/android-x64@0.27.4':
+  '@esbuild/android-arm@0.27.7':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.4':
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.4':
+  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.4':
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.4':
+  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.4':
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm@0.27.4':
+  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.4':
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.4':
+  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.4':
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.4':
+  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.4':
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.4':
+  '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
-  '@esbuild/linux-x64@0.27.4':
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.4':
+  '@esbuild/linux-x64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.4':
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.4':
+  '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.4':
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.4':
+  '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.4':
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.4':
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.4':
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
-  '@esbuild/win32-x64@0.27.4':
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1124,10 +1127,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -1158,56 +1161,59 @@ snapshots:
       '@otplib/plugin-crypto': 12.0.1
       '@otplib/plugin-thirty-two': 12.0.1
 
-  '@oxc-project/types@0.120.0': {}
+  '@oxc-project/types@0.122.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.10': {}
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -1308,13 +1314,13 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/node@22.19.15':
+  '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
 
   '@types/pg@8.11.6':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 22.19.17
       pg-protocol: 1.13.0
       pg-types: 4.1.0
 
@@ -1322,44 +1328,44 @@ snapshots:
 
   '@typescript-eslint/types@8.58.0': {}
 
-  '@vitest/expect@4.1.0':
+  '@vitest/expect@4.1.2':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@8.0.1(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.1(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
 
-  '@vitest/pretty-format@4.1.0':
+  '@vitest/pretty-format@4.1.2':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.0':
+  '@vitest/runner@4.1.2':
     dependencies:
-      '@vitest/utils': 4.1.0
+      '@vitest/utils': 4.1.2
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.0':
+  '@vitest/snapshot@4.1.2':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.0': {}
+  '@vitest/spy@4.1.2': {}
 
-  '@vitest/utils@4.1.0':
+  '@vitest/utils@4.1.2':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
+      '@vitest/pretty-format': 4.1.2
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -1421,34 +1427,34 @@ snapshots:
 
   es-module-lexer@2.0.0: {}
 
-  esbuild@0.27.4:
+  esbuild@0.27.7:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.4
-      '@esbuild/android-arm': 0.27.4
-      '@esbuild/android-arm64': 0.27.4
-      '@esbuild/android-x64': 0.27.4
-      '@esbuild/darwin-arm64': 0.27.4
-      '@esbuild/darwin-x64': 0.27.4
-      '@esbuild/freebsd-arm64': 0.27.4
-      '@esbuild/freebsd-x64': 0.27.4
-      '@esbuild/linux-arm': 0.27.4
-      '@esbuild/linux-arm64': 0.27.4
-      '@esbuild/linux-ia32': 0.27.4
-      '@esbuild/linux-loong64': 0.27.4
-      '@esbuild/linux-mips64el': 0.27.4
-      '@esbuild/linux-ppc64': 0.27.4
-      '@esbuild/linux-riscv64': 0.27.4
-      '@esbuild/linux-s390x': 0.27.4
-      '@esbuild/linux-x64': 0.27.4
-      '@esbuild/netbsd-arm64': 0.27.4
-      '@esbuild/netbsd-x64': 0.27.4
-      '@esbuild/openbsd-arm64': 0.27.4
-      '@esbuild/openbsd-x64': 0.27.4
-      '@esbuild/openharmony-arm64': 0.27.4
-      '@esbuild/sunos-x64': 0.27.4
-      '@esbuild/win32-arm64': 0.27.4
-      '@esbuild/win32-ia32': 0.27.4
-      '@esbuild/win32-x64': 0.27.4
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   esm-env@1.2.2: {}
 
@@ -1467,9 +1473,9 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   find-up@4.1.0:
     dependencies:
@@ -1596,9 +1602,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.59.1: {}
 
   pngjs@5.0.0: {}
 
@@ -1634,26 +1640,29 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown@1.0.0-rc.10:
+  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
     dependencies:
-      '@oxc-project/types': 0.120.0
-      '@rolldown/pluginutils': 1.0.0-rc.10
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.10
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.10
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.10
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.10
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.10
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.10
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.10
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   set-blocking@2.0.0: {}
 
@@ -1702,8 +1711,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
 
@@ -1712,7 +1721,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.4
+      esbuild: 0.27.7
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
@@ -1721,43 +1730,46 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  vite@8.0.1(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0):
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       postcss: 8.5.8
-      rolldown: 1.0.0-rc.10
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.15
-      esbuild: 0.27.4
+      '@types/node': 22.19.17
+      esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.21.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
-  vitest@4.1.0(@types/node@22.19.15)(vite@8.0.1(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)):
+  vitest@4.1.2(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.1(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 22.19.17
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,15 +5,15 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@tummycrypt/scheduling-kit': link:../scheduling-kit
+  effect: ^3.19.14
 
 importers:
 
   .:
     dependencies:
       '@tummycrypt/scheduling-kit':
-        specifier: link:../scheduling-kit
-        version: link:../scheduling-kit
+        specifier: ^0.4.0
+        version: 0.4.0(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)
       effect:
         specifier: ^3.19.14
         version: 3.21.0
@@ -24,9 +24,6 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
-      playwright:
-        specifier: ^1.58.2
-        version: 1.58.2
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -204,11 +201,45 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@neondatabase/serverless@0.10.4':
+    resolution: {integrity: sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==}
+
+  '@otplib/core@12.0.1':
+    resolution: {integrity: sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==}
+
+  '@otplib/plugin-crypto@12.0.1':
+    resolution: {integrity: sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==}
+    deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
+
+  '@otplib/plugin-thirty-two@12.0.1':
+    resolution: {integrity: sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==}
+    deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
+
+  '@otplib/preset-default@12.0.1':
+    resolution: {integrity: sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==}
+    deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
+
+  '@otplib/preset-v11@12.0.1':
+    resolution: {integrity: sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==}
 
   '@oxc-project/types@0.120.0':
     resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
@@ -308,6 +339,41 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.9':
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@tummycrypt/scheduling-kit@0.4.0':
+    resolution: {integrity: sha512-VuhIbCx7+DtjajjuDZwK498IiDDQeOp6NZJL1cNN+9UzaexFbbxOEKBLiQm/U5p+QS5DeXU950Og8sM7GDk36Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@skeletonlabs/skeleton': ^4.0.0
+      '@skeletonlabs/skeleton-svelte': ^4.0.0
+      svelte: ^5.0.0
+    peerDependenciesMeta:
+      '@skeletonlabs/skeleton':
+        optional: true
+      '@skeletonlabs/skeleton-svelte':
+        optional: true
+
+  '@tummycrypt/tinyland-auth-pg@0.1.0':
+    resolution: {integrity: sha512-FH+2xb/yXOFXVxGB59xpzkttkuxdAcB9A3PDWoihRaj8s5ljrbwzBH8JO/vK8zBxifFx/z/6yUqp3KsofKJ2Wg==}
+    peerDependencies:
+      '@tummycrypt/tinyland-auth': ^0.2.0
+
+  '@tummycrypt/tinyland-auth@0.2.0':
+    resolution: {integrity: sha512-XL3UfRyBNeuILZw56r5iw+WtUAZ0l7f5zjbDsHGOeR5O0D0rpRZjUMSTqNoHWYjU4NkKl07YKmDphXsTwC6dLA==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+      svelte: ^5.0.0
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      svelte:
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -322,6 +388,16 @@ packages:
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/pg@8.11.6':
+    resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@typescript-eslint/types@8.58.0':
+    resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
@@ -352,23 +428,164 @@ packages:
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devalue@5.6.4:
+    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  drizzle-orm@0.39.3:
+    resolution: {integrity: sha512-EZ8ZpYvDIvKU9C56JYLOmUskazhad+uXZCTCRN4OnRMsL+xAJ05dv1eCpAG5xzhsm1hqiuC5kAZUCS924u2DTw==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   effect@3.21.0:
     resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -377,6 +594,12 @@ packages:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esrap@2.2.4:
+    resolution: {integrity: sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -398,18 +621,28 @@ packages:
       picomatch:
         optional: true
 
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -481,6 +714,13 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -489,11 +729,53 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.7:
+    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  otplib@12.0.1:
+    resolution: {integrity: sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@4.1.0:
+    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
+    engines: {node: '>=10'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -507,17 +789,47 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
-    engines: {node: '>=18'}
-    hasBin: true
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
+
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -526,6 +838,9 @@ packages:
     resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -539,6 +854,22 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  svelte@5.55.1:
+    resolution: {integrity: sha512-QjvU7EFemf6mRzdMGlAFttMWtAAVXrax61SZYHdkD6yoVGQ89VeyKfZD4H1JrV1WLmJBxWhFch9H6ig/87VGjw==}
+    engines: {node: '>=18'}
+
+  thirty-two@1.0.2:
+    resolution: {integrity: sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==}
+    engines: {node: '>=0.2.6'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -649,10 +980,34 @@ packages:
       jsdom:
         optional: true
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -750,7 +1105,24 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -758,6 +1130,33 @@ snapshots:
       '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@neondatabase/serverless@0.10.4':
+    dependencies:
+      '@types/pg': 8.11.6
+
+  '@otplib/core@12.0.1': {}
+
+  '@otplib/plugin-crypto@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+
+  '@otplib/plugin-thirty-two@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+      thirty-two: 1.0.2
+
+  '@otplib/preset-default@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+      '@otplib/plugin-crypto': 12.0.1
+      '@otplib/plugin-thirty-two': 12.0.1
+
+  '@otplib/preset-v11@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+      '@otplib/plugin-crypto': 12.0.1
+      '@otplib/plugin-thirty-two': 12.0.1
 
   '@oxc-project/types@0.120.0': {}
 
@@ -812,6 +1211,89 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
+  '@tummycrypt/scheduling-kit@0.4.0(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)':
+    dependencies:
+      '@tummycrypt/tinyland-auth-pg': 0.1.0(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)
+      effect: 3.21.0
+      svelte: 5.55.1
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@tummycrypt/tinyland-auth'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+
+  '@tummycrypt/tinyland-auth-pg@0.1.0(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)':
+    dependencies:
+      '@neondatabase/serverless': 0.10.4
+      '@tummycrypt/tinyland-auth': 0.2.0(svelte@5.55.1)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+
+  '@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1)':
+    dependencies:
+      bcryptjs: 2.4.3
+      nanoid: 5.1.7
+      otplib: 12.0.1
+      qrcode: 1.5.4
+    optionalDependencies:
+      svelte: 5.55.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -829,6 +1311,16 @@ snapshots:
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.11.6':
+    dependencies:
+      '@types/node': 22.19.15
+      pg-protocol: 1.13.0
+      pg-types: 4.1.0
+
+  '@types/trusted-types@2.0.7': {}
+
+  '@typescript-eslint/types@8.58.0': {}
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -871,18 +1363,61 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  acorn@8.16.0: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  aria-query@5.3.1: {}
+
   assertion-error@2.0.1: {}
+
+  axobject-query@4.1.0: {}
+
+  bcryptjs@2.4.3: {}
+
+  camelcase@5.3.1: {}
 
   chai@6.2.2: {}
 
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
+  clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   convert-source-map@2.0.0: {}
 
+  decamelize@1.2.0: {}
+
   detect-libc@2.1.2: {}
+
+  devalue@5.6.4: {}
+
+  dijkstrajs@1.0.3: {}
+
+  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6):
+    optionalDependencies:
+      '@neondatabase/serverless': 0.10.4
+      '@types/pg': 8.11.6
 
   effect@3.21.0:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
+
+  emoji-regex@8.0.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -915,6 +1450,13 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
+  esm-env@1.2.2: {}
+
+  esrap@2.2.4:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@typescript-eslint/types': 8.58.0
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -929,15 +1471,25 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  fsevents@2.3.2:
-    optional: true
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   fsevents@2.3.3:
     optional: true
 
+  get-caller-file@2.0.5: {}
+
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -988,15 +1540,59 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  locate-character@3.0.0: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.7: {}
+
+  obuf@1.1.2: {}
+
   obug@2.1.1: {}
 
+  otplib@12.0.1:
+    dependencies:
+      '@otplib/core': 12.0.1
+      '@otplib/preset-default': 12.0.1
+      '@otplib/preset-v11': 12.0.1
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
+  path-exists@4.0.0: {}
+
   pathe@2.0.3: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-numeric@1.0.2: {}
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@4.1.0:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
 
   picocolors@1.1.1: {}
 
@@ -1004,11 +1600,7 @@ snapshots:
 
   playwright-core@1.58.2: {}
 
-  playwright@1.58.2:
-    dependencies:
-      playwright-core: 1.58.2
-    optionalDependencies:
-      fsevents: 2.3.2
+  pngjs@5.0.0: {}
 
   postcss@8.5.8:
     dependencies:
@@ -1016,7 +1608,29 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@3.0.4: {}
+
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
+  postgres-date@2.1.0: {}
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
+
   pure-rand@6.1.0: {}
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
+  require-directory@2.1.1: {}
+
+  require-main-filename@2.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -1041,6 +1655,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
 
+  set-blocking@2.0.0: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -1048,6 +1664,37 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  svelte@5.55.1:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.6.4
+      esm-env: 1.2.2
+      esrap: 2.2.4
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+
+  thirty-two@1.0.2: {}
 
   tinybench@2.9.0: {}
 
@@ -1114,7 +1761,40 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  which-module@2.0.1: {}
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@4.0.3: {}
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
+
+  zimmerframe@1.1.4: {}
+
+  zod@4.3.6: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-overrides:
-  '@tummycrypt/scheduling-kit': link:../scheduling-kit

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,10 +1,9 @@
 /**
  * Re-export core types from @tummycrypt/scheduling-kit.
  *
- * Type-only imports — no runtime code pulled in from scheduling-kit.
- * The Errors factory is inlined to avoid dragging in the full
- * scheduling-kit module tree (Svelte components, drizzle, etc.)
- * which breaks esbuild bundling for the Modal container.
+ * We selectively re-export only the types module (not utils/pipelines)
+ * to avoid pulling in fp-ts runtime code that has ESM import issues
+ * in the published package.
  */
 export type {
   AcuityError,
@@ -33,38 +32,4 @@ export type {
   SchedulingConfig,
 } from '@tummycrypt/scheduling-kit/core';
 
-// Inlined from scheduling-kit/core/types.ts to avoid runtime import
-// that would pull in the full module tree via esbuild.
-import type {
-  AcuityError,
-  CalComError,
-  PaymentError,
-  ValidationError,
-  ReservationError,
-  IdempotencyError,
-  InfrastructureError,
-} from '@tummycrypt/scheduling-kit/core';
-
-export const Errors = {
-  acuity: (code: string, message: string, statusCode?: number, endpoint?: string): AcuityError => ({
-    _tag: 'AcuityError', code, message, statusCode, endpoint,
-  }),
-  calcom: (code: string, message: string, statusCode?: number): CalComError => ({
-    _tag: 'CalComError', code, message, statusCode,
-  }),
-  payment: (code: string, message: string, processor: string, recoverable = false, transactionId?: string): PaymentError => ({
-    _tag: 'PaymentError', code, message, processor, recoverable, transactionId,
-  }),
-  validation: (field: string, message: string, value?: unknown): ValidationError => ({
-    _tag: 'ValidationError', field, message, value,
-  }),
-  reservation: (code: 'SLOT_TAKEN' | 'BLOCK_FAILED' | 'TIMEOUT', message: string, datetime?: string): ReservationError => ({
-    _tag: 'ReservationError', code, message, datetime,
-  }),
-  idempotency: (key: string, existingResult?: unknown): IdempotencyError => ({
-    _tag: 'IdempotencyError', key, existingResult,
-  }),
-  infrastructure: (code: 'NETWORK' | 'TIMEOUT' | 'REDIS' | 'UNKNOWN', message: string, cause?: Error): InfrastructureError => ({
-    _tag: 'InfrastructureError', code, message, cause,
-  }),
-} as const;
+export { Errors } from '@tummycrypt/scheduling-kit/core';

--- a/src/middleware/acuity-wizard.ts
+++ b/src/middleware/acuity-wizard.ts
@@ -16,7 +16,7 @@
  * fp-ts (pipeline/adapter layer).
  */
 
-import { Effect, Layer, pipe } from 'effect';
+import { Effect, pipe } from 'effect';
 
 import type { SchedulingAdapter } from '../adapters/types.js';
 import { createScraperAdapter, type ScraperConfig } from '../adapters/acuity-scraper.js';
@@ -29,7 +29,6 @@ import type {
 import { Errors } from '../core/types.js';
 import { BrowserServiceLive, type BrowserConfig, defaultBrowserConfig } from './browser-service.js';
 import { toSchedulingError, type MiddlewareError } from './errors.js';
-import { ServiceResolverLive } from './service-resolver.js';
 import { createRemoteWizardAdapter, type RemoteAdapterConfig } from './remote-adapter.js';
 import {
 	navigateToBooking,
@@ -205,7 +204,7 @@ export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdap
 		...config,
 	};
 
-	const layer = Layer.merge(BrowserServiceLive(browserConfig), ServiceResolverLive);
+	const layer = BrowserServiceLive(browserConfig);
 
 	// Provide browser layer and map MiddlewareError → SchedulingError
 	const runWizard = <A>(

--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -73,6 +73,6 @@ export const toSchedulingError = (error: MiddlewareError): SchedulingError => {
 		case 'CouponError':
 			return Errors.acuity('BOOKING_FAILED', `Coupon error: ${error.message}`);
 		case 'ServiceResolverError':
-			return Errors.acuity('NOT_FOUND', `Service not found: ${error.message}`);
+			return Errors.acuity('SCRAPE_FAILED', `Service resolution failed: ${error.message}`);
 	}
 };

--- a/src/middleware/server.ts
+++ b/src/middleware/server.ts
@@ -30,14 +30,10 @@
  */
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { Effect, Exit, Cause, Layer, Scope } from 'effect';
-// Scraper removed — deprecated and caused esbuild bundling issues.
-// Services are served from SERVICES_JSON env or BUSINESS object extraction.
+import { Effect, Exit, Cause, Scope } from 'effect';
+import { createScraperAdapter, type ScraperConfig } from '../adapters/acuity-scraper.js';
 import { BrowserService, BrowserServiceLive, type BrowserConfig, defaultBrowserConfig } from './browser-service.js';
 import { toSchedulingError, type MiddlewareError } from './errors.js';
-import { ServiceResolver, ServiceResolverLive } from './service-resolver.js';
-import { LoggerLive, ndjsonLog } from './logger.js';
-import { selectorHealthCheck } from './selector-health.js';
 import {
 	navigateToBooking,
 	fillFormFields,
@@ -46,10 +42,10 @@ import {
 	submitBooking,
 	extractConfirmation,
 	toBooking,
+	readAvailableDates,
+	readTimeSlots,
 	fetchBusinessData,
 	businessToServices,
-	readDatesViaUrl,
-	readSlotsViaUrl,
 } from './steps/index.js';
 import type {
 	Booking,
@@ -76,7 +72,14 @@ const browserConfig: BrowserConfig = {
 	launchArgs: process.env.CHROMIUM_LAUNCH_ARGS?.split(','),
 };
 
-// scraperConfig removed — scraper deprecated, BUSINESS extraction replaces it
+const scraperConfig: ScraperConfig = {
+	baseUrl: ACUITY_BASE_URL,
+	headless: browserConfig.headless,
+	timeout: browserConfig.timeout,
+	userAgent: browserConfig.userAgent,
+	executablePath: browserConfig.executablePath,
+	launchArgs: browserConfig.launchArgs ? [...browserConfig.launchArgs] : undefined,
+};
 
 // =============================================================================
 // RESPONSE HELPERS
@@ -127,14 +130,12 @@ const parseBody = async (req: IncomingMessage): Promise<unknown> => {
 // EFFECT RUNNER
 // =============================================================================
 
-const layer = Layer.merge(BrowserServiceLive(browserConfig), ServiceResolverLive).pipe(
-	Layer.provide(LoggerLive),
-);
+const layer = BrowserServiceLive(browserConfig);
 
 type Result<A> = { ok: true; value: A } | { ok: false; error: SchedulingError };
 
 const runEffect = async <A>(
-	effect: Effect.Effect<A, MiddlewareError, BrowserService | ServiceResolver | Scope.Scope>,
+	effect: Effect.Effect<A, MiddlewareError, BrowserService | Scope.Scope>,
 ): Promise<Result<A>> => {
 	const exit = await Effect.runPromiseExit(
 		Effect.scoped(effect.pipe(Effect.provide(layer))),
@@ -168,6 +169,15 @@ const runSchedulingEffect = async <A>(
 // SCRAPER (cached)
 // =============================================================================
 
+let scraper: ReturnType<typeof createScraperAdapter> | null = null;
+
+const getScraper = () => {
+	if (!scraper) {
+		scraper = createScraperAdapter(scraperConfig);
+	}
+	return scraper;
+};
+
 let cachedServices: Service[] | null = null;
 
 // Static services from SERVICES_JSON env var (avoids scraper dependency)
@@ -177,53 +187,28 @@ const STATIC_SERVICES: Service[] | null = (() => {
 	try {
 		return JSON.parse(raw) as Service[];
 	} catch (e) {
-		ndjsonLog('ERROR', 'Failed to parse SERVICES_JSON', { error: String(e) });
+		console.error('[middleware-server] Failed to parse SERVICES_JSON:', e);
 		return null;
 	}
 })();
 
 if (STATIC_SERVICES) {
 	cachedServices = STATIC_SERVICES;
-	ndjsonLog('INFO', 'Loaded static services from SERVICES_JSON', { count: STATIC_SERVICES.length });
+	console.log(`[middleware-server] Loaded ${STATIC_SERVICES.length} static services from SERVICES_JSON`);
 }
 
 // =============================================================================
 // ROUTE HANDLERS
 // =============================================================================
 
-let requestCount = 0;
-const startedAt = new Date().toISOString();
-
-const handleHealth = async (req: IncomingMessage, res: ServerResponse) => {
-	const url = new URL(req.url ?? '/', `http://localhost:${PORT}`);
-	const depth = Number(url.searchParams.get('depth') ?? 0) as 0 | 1 | 2;
-
-	const baseHealth = {
+const handleHealth = (_req: IncomingMessage, res: ServerResponse) => {
+	sendSuccess(res, {
 		status: 'ok',
 		baseUrl: ACUITY_BASE_URL,
 		hasCoupon: !!COUPON_CODE,
 		headless: browserConfig.headless,
 		staticServices: STATIC_SERVICES ? STATIC_SERVICES.length : 0,
-		uptime: process.uptime(),
-		startedAt,
-		requestCount,
 		timestamp: new Date().toISOString(),
-	};
-
-	if (depth === 0) {
-		return sendSuccess(res, baseHealth);
-	}
-
-	// Tiered selector health check (requires browser)
-	const result = await runEffect(selectorHealthCheck(ACUITY_BASE_URL, depth));
-	if (!result.ok) {
-		return sendSuccess(res, { ...baseHealth, selectorCheck: null, selectorError: 'probe failed' });
-	}
-
-	return sendSuccess(res, {
-		...baseHealth,
-		status: result.value.status,
-		selectorCheck: result.value,
 	});
 };
 
@@ -231,7 +216,7 @@ const handleHealth = async (req: IncomingMessage, res: ServerResponse) => {
 const handleGetServices = async (_req: IncomingMessage, res: ServerResponse) => {
 	// 1. Prefer static services from env (always reliable, no network needed)
 	if (STATIC_SERVICES) {
-		ndjsonLog('INFO', 'Services source: SERVICES_JSON env');
+		console.log('[services] source: SERVICES_JSON env');
 		cachedServices = STATIC_SERVICES;
 		return sendSuccess(res, STATIC_SERVICES);
 	}
@@ -242,31 +227,34 @@ const handleGetServices = async (_req: IncomingMessage, res: ServerResponse) => 
 		if (business) {
 			const services = businessToServices(business);
 			if (services.length > 0) {
-				ndjsonLog('INFO', 'Services source: BUSINESS object', { count: services.length });
+				console.log(`[services] source: BUSINESS object (${services.length} services)`);
 				cachedServices = services;
 				return sendSuccess(res, services);
 			}
-			ndjsonLog('WARN', 'BUSINESS object found but 0 active services');
+			console.warn('[services] BUSINESS object found but 0 active services');
 		}
 	} catch (e) {
-		ndjsonLog('WARN', 'BUSINESS extraction failed', { error: e instanceof Error ? e.message : String(e) });
+		console.warn('[services] BUSINESS extraction failed:', e instanceof Error ? e.message : e);
 	}
 
-	// No more fallbacks — return empty with warning
-	ndjsonLog('ERROR', 'All service sources exhausted (SERVICES_JSON not set, BUSINESS extraction failed)');
-	sendSuccess(res, []);
+	// 3. Deprecated fallback: DOM scraper (may return [] — Acuity is React SPA)
+	console.warn('[services] falling back to DOM scraper (deprecated)');
+	const result = await runSchedulingEffect(getScraper().getServices());
+	if (!result.ok) return sendError(res, 500, result.error);
+	if (result.value.length === 0) {
+		console.error('[services] all sources exhausted — returning empty []');
+	}
+	cachedServices = result.value;
+	sendSuccess(res, result.value);
 };
 
 const handleGetService = async (serviceId: string, res: ServerResponse) => {
 	if (!cachedServices) {
-		// Try BUSINESS extraction to populate cache
-		try {
-			const business = await fetchBusinessData(ACUITY_BASE_URL);
-			if (business) cachedServices = businessToServices(business);
-		} catch { /* ignore */ }
+		const result = await runSchedulingEffect(getScraper().getServices());
+		if (!result.ok) return sendError(res, 500, result.error);
+		cachedServices = result.value;
 	}
-	if (!cachedServices) cachedServices = [];
-	const found = cachedServices.find((s) => s.id === serviceId);
+	const found = cachedServices!.find((s) => s.id === serviceId);
 	if (!found) {
 		return sendJson(res, 404, {
 			success: false,
@@ -278,19 +266,24 @@ const handleGetService = async (serviceId: string, res: ServerResponse) => {
 
 const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; startDate?: string };
-	// Use Acuity numeric ID for direct URL navigation (bypasses collapsed categories)
-	const serviceId = body.serviceId;
-	ndjsonLog('INFO', 'availability/dates', { serviceId, startDate: body.startDate });
+	// Use service name for wizard navigation (click-based, not URL param)
+	const serviceName = body.serviceName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
+	console.log(`[availability/dates] serviceName="${serviceName}" from serviceId="${body.serviceId}"`);
 
 	const result = await runEffect(
-		readDatesViaUrl(serviceId, body.startDate?.slice(0, 7)),
+		readAvailableDates({
+			serviceName,
+			targetMonth: body.startDate?.slice(0, 7),
+			monthsToScan: 2,
+		}),
 	);
 
 	if (!result.ok) {
-		ndjsonLog('ERROR', 'availability/dates failed', { error: result.error });
+		const err = result.error;
+		console.error(`[availability/dates] error:`, err);
 		return sendJson(res, 500, {
 			success: false,
-			error: { tag: 'InfrastructureError', code: 'AVAILABILITY_FAILED', message: 'message' in result.error ? result.error.message : 'Availability lookup failed' },
+			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Availability lookup failed' },
 		});
 	}
 	sendSuccess(res, result.value);
@@ -298,17 +291,22 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse) =
 
 const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; date: string };
-	ndjsonLog('INFO', 'availability/slots', { serviceId: body.serviceId, date: body.date });
+	const serviceName = body.serviceName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
+	console.log(`[availability/slots] serviceName="${serviceName}" date="${body.date}"`);
 
 	const result = await runEffect(
-		readSlotsViaUrl(body.serviceId, body.date),
+		readTimeSlots({
+			serviceName,
+			date: body.date,
+		}),
 	);
 
 	if (!result.ok) {
-		ndjsonLog('ERROR', 'availability/slots failed', { error: result.error });
+		const err = result.error;
+		console.error(`[availability/slots] error:`, err);
 		return sendJson(res, 500, {
 			success: false,
-			error: { tag: 'InfrastructureError', code: 'SLOTS_FAILED', message: 'message' in result.error ? result.error.message : 'Slot lookup failed' },
+			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Slot lookup failed' },
 		});
 	}
 	sendSuccess(res, result.value);
@@ -317,15 +315,20 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse) =
 const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; datetime: string };
 	const date = body.datetime.split('T')[0];
+	const serviceName = body.serviceName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
 
 	const result = await runEffect(
-		readSlotsViaUrl(body.serviceId, date),
+		readTimeSlots({
+			serviceName,
+			date,
+		}),
 	);
 
 	if (!result.ok) {
+		const err = result.error;
 		return sendJson(res, 500, {
 			success: false,
-			error: { tag: 'InfrastructureError', code: 'CHECK_FAILED', message: 'message' in result.error ? result.error.message : 'Slot check failed' },
+			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Slot check failed' },
 		});
 	}
 	const available = result.value.some((s: { datetime: string; available: boolean }) =>
@@ -414,7 +417,6 @@ const server = createServer(async (req, res) => {
 	const url = new URL(req.url ?? '/', `http://localhost:${PORT}`);
 	const path = url.pathname;
 	const method = req.method?.toUpperCase() ?? 'GET';
-	requestCount++;
 
 	// Auth check (skip health endpoint)
 	if (AUTH_TOKEN && path !== '/health') {
@@ -460,7 +462,7 @@ const server = createServer(async (req, res) => {
 			error: { tag: 'InfrastructureError', code: 'NOT_FOUND', message: `Unknown route: ${method} ${path}` },
 		});
 	} catch (e) {
-		ndjsonLog('ERROR', 'Unhandled error', { method, path, error: e instanceof Error ? e.message : String(e) });
+		console.error(`[middleware-server] Unhandled error on ${method} ${path}:`, e);
 		sendJson(res, 500, {
 			success: false,
 			error: {
@@ -475,13 +477,11 @@ const server = createServer(async (req, res) => {
 // Only start listening when this file is executed directly (not imported)
 if (process.argv[1]?.match(/server\.(ts|js|mjs)$/)) {
 	server.listen(PORT, '0.0.0.0', () => {
-		ndjsonLog('INFO', 'Middleware server started', {
-			port: PORT,
-			baseUrl: ACUITY_BASE_URL,
-			coupon: COUPON_CODE ? 'configured' : 'NOT SET',
-			auth: AUTH_TOKEN ? 'enabled' : 'disabled',
-			headless: browserConfig.headless,
-		});
+		console.log(`[middleware-server] Listening on port ${PORT}`);
+		console.log(`[middleware-server] Acuity URL: ${ACUITY_BASE_URL}`);
+		console.log(`[middleware-server] Coupon: ${COUPON_CODE ? 'configured' : 'NOT SET'}`);
+		console.log(`[middleware-server] Auth: ${AUTH_TOKEN ? 'enabled' : 'disabled'}`);
+		console.log(`[middleware-server] Headless: ${browserConfig.headless}`);
 	});
 }
 

--- a/src/middleware/server.ts
+++ b/src/middleware/server.ts
@@ -34,7 +34,7 @@ import { Effect, Exit, Cause, Layer, Scope } from 'effect';
 // Scraper removed — deprecated and caused esbuild bundling issues.
 // Services are served from SERVICES_JSON env or BUSINESS object extraction.
 import { BrowserService, BrowserServiceLive, type BrowserConfig, defaultBrowserConfig } from './browser-service.js';
-import { WizardStepError, toSchedulingError, type MiddlewareError } from './errors.js';
+import { toSchedulingError, type MiddlewareError } from './errors.js';
 import { ServiceResolver, ServiceResolverLive } from './service-resolver.js';
 import { LoggerLive, ndjsonLog } from './logger.js';
 import { selectorHealthCheck } from './selector-health.js';

--- a/src/middleware/server.ts
+++ b/src/middleware/server.ts
@@ -341,6 +341,19 @@ const handleCreateBooking = async (req: IncomingMessage, res: ServerResponse) =>
 	const body = (await parseBody(req)) as { request: BookingRequest; couponCode?: string };
 	const { request } = body;
 
+	// Ensure services are cached before resolving name
+	if (!cachedServices) {
+		try {
+			const business = await fetchBusinessData(ACUITY_BASE_URL);
+			if (business) {
+				cachedServices = businessToServices(business);
+				console.log(`[booking] Warmed service cache: ${cachedServices.length} services`);
+			}
+		} catch (e) {
+			console.warn('[booking] Service cache warm failed:', e instanceof Error ? e.message : e);
+		}
+	}
+
 	const serviceName = cachedServices?.find((s) => s.id === request.serviceId)?.name;
 
 	const result = await runEffect(
@@ -379,7 +392,19 @@ const handleCreateBookingWithPayment = async (req: IncomingMessage, res: ServerR
 		});
 	}
 
-	// Try to get service details for richer booking data
+	// Ensure services are cached before resolving name
+	if (!cachedServices) {
+		try {
+			const business = await fetchBusinessData(ACUITY_BASE_URL);
+			if (business) {
+				cachedServices = businessToServices(business);
+				console.log(`[booking] Warmed service cache: ${cachedServices.length} services`);
+			}
+		} catch (e) {
+			console.warn('[booking] Service cache warm failed:', e instanceof Error ? e.message : e);
+		}
+	}
+
 	const service = cachedServices?.find((s) => s.id === request.serviceId);
 	const serviceName = service?.name ?? request.serviceId;
 

--- a/src/middleware/server.ts
+++ b/src/middleware/server.ts
@@ -198,6 +198,35 @@ if (STATIC_SERVICES) {
 }
 
 // =============================================================================
+// SERVICE NAME RESOLUTION
+// =============================================================================
+
+/**
+ * Resolve a service ID to its display name for wizard navigation.
+ * Ensures cachedServices is populated (via BUSINESS extraction) before lookup.
+ * Rejects numeric-only serviceName (remote adapter fallback) and resolves from cache.
+ */
+const resolveServiceName = async (serviceId: string, serviceName?: string): Promise<string> => {
+	// If caller provided a real (non-numeric) name, use it
+	if (serviceName && !/^\d+$/.test(serviceName)) return serviceName;
+
+	// Ensure services are cached
+	if (!cachedServices) {
+		try {
+			const business = await fetchBusinessData(ACUITY_BASE_URL);
+			if (business) {
+				cachedServices = businessToServices(business);
+				console.log(`[resolve] Warmed service cache: ${cachedServices.length} services`);
+			}
+		} catch (e) {
+			console.warn('[resolve] Service cache warm failed:', e instanceof Error ? e.message : e);
+		}
+	}
+
+	return cachedServices?.find((s) => s.id === serviceId)?.name ?? serviceId;
+};
+
+// =============================================================================
 // ROUTE HANDLERS
 // =============================================================================
 
@@ -266,10 +295,7 @@ const handleGetService = async (serviceId: string, res: ServerResponse) => {
 
 const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; startDate?: string };
-	// Use service name for wizard navigation (click-based, not URL param)
-	// Treat numeric-only serviceName as unresolved (remote adapter sends serviceId as fallback)
-	const resolvedName = body.serviceName && !/^\d+$/.test(body.serviceName) ? body.serviceName : undefined;
-	const serviceName = resolvedName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
+	const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
 	console.log(`[availability/dates] serviceName="${serviceName}" from serviceId="${body.serviceId}"`);
 
 	const result = await runEffect(
@@ -293,8 +319,7 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse) =
 
 const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; date: string };
-	const resolvedName = body.serviceName && !/^\d+$/.test(body.serviceName) ? body.serviceName : undefined;
-	const serviceName = resolvedName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
+	const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
 	console.log(`[availability/slots] serviceName="${serviceName}" date="${body.date}"`);
 
 	const result = await runEffect(
@@ -318,8 +343,7 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse) =
 const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; datetime: string };
 	const date = body.datetime.split('T')[0];
-	const resolvedName = body.serviceName && !/^\d+$/.test(body.serviceName) ? body.serviceName : undefined;
-	const serviceName = resolvedName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
+	const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
 
 	const result = await runEffect(
 		readTimeSlots({
@@ -345,20 +369,7 @@ const handleCreateBooking = async (req: IncomingMessage, res: ServerResponse) =>
 	const body = (await parseBody(req)) as { request: BookingRequest; couponCode?: string };
 	const { request } = body;
 
-	// Ensure services are cached before resolving name
-	if (!cachedServices) {
-		try {
-			const business = await fetchBusinessData(ACUITY_BASE_URL);
-			if (business) {
-				cachedServices = businessToServices(business);
-				console.log(`[booking] Warmed service cache: ${cachedServices.length} services`);
-			}
-		} catch (e) {
-			console.warn('[booking] Service cache warm failed:', e instanceof Error ? e.message : e);
-		}
-	}
-
-	const serviceName = cachedServices?.find((s) => s.id === request.serviceId)?.name;
+	const serviceName = await resolveServiceName(request.serviceId);
 
 	const result = await runEffect(
 		Effect.gen(function* () {
@@ -396,21 +407,8 @@ const handleCreateBookingWithPayment = async (req: IncomingMessage, res: ServerR
 		});
 	}
 
-	// Ensure services are cached before resolving name
-	if (!cachedServices) {
-		try {
-			const business = await fetchBusinessData(ACUITY_BASE_URL);
-			if (business) {
-				cachedServices = businessToServices(business);
-				console.log(`[booking] Warmed service cache: ${cachedServices.length} services`);
-			}
-		} catch (e) {
-			console.warn('[booking] Service cache warm failed:', e instanceof Error ? e.message : e);
-		}
-	}
-
+	const serviceName = await resolveServiceName(request.serviceId);
 	const service = cachedServices?.find((s) => s.id === request.serviceId);
-	const serviceName = service?.name ?? request.serviceId;
 
 	const result = await runEffect(
 		Effect.gen(function* () {

--- a/src/middleware/server.ts
+++ b/src/middleware/server.ts
@@ -279,9 +279,22 @@ const handleGetServices = async (_req: IncomingMessage, res: ServerResponse) => 
 
 const handleGetService = async (serviceId: string, res: ServerResponse) => {
 	if (!cachedServices) {
-		const result = await runSchedulingEffect(getScraper().getServices());
-		if (!result.ok) return sendError(res, 500, result.error);
-		cachedServices = result.value;
+		// Prefer BUSINESS extraction (HTTP, no browser) over DOM scraper
+		try {
+			const business = await fetchBusinessData(ACUITY_BASE_URL);
+			if (business) {
+				cachedServices = businessToServices(business);
+				console.log(`[service] Warmed cache via BUSINESS: ${cachedServices.length} services`);
+			}
+		} catch (e) {
+			console.warn('[service] BUSINESS extraction failed:', e instanceof Error ? e.message : e);
+		}
+		// Fallback to scraper if BUSINESS failed
+		if (!cachedServices) {
+			const result = await runSchedulingEffect(getScraper().getServices());
+			if (!result.ok) return sendError(res, 500, result.error);
+			cachedServices = result.value;
+		}
 	}
 	const found = cachedServices!.find((s) => s.id === serviceId);
 	if (!found) {

--- a/src/middleware/server.ts
+++ b/src/middleware/server.ts
@@ -135,7 +135,7 @@ const layer = BrowserServiceLive(browserConfig);
 type Result<A> = { ok: true; value: A } | { ok: false; error: SchedulingError };
 
 const runEffect = async <A>(
-	effect: Effect.Effect<A, MiddlewareError, BrowserService | Scope.Scope>,
+	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
 ): Promise<Result<A>> => {
 	const exit = await Effect.runPromiseExit(
 		Effect.scoped(effect.pipe(Effect.provide(layer))),
@@ -144,7 +144,7 @@ const runEffect = async <A>(
 		return { ok: true, value: exit.value };
 	}
 	const failure = Cause.failureOption(exit.cause);
-	if (failure._tag === 'Some') {
+	if (failure._tag === 'Some' && failure.value !== undefined) {
 		return { ok: false, error: toSchedulingError(failure.value) };
 	}
 	return { ok: false, error: { _tag: 'InfrastructureError', code: 'UNKNOWN', message: Cause.pretty(exit.cause) } };

--- a/src/middleware/server.ts
+++ b/src/middleware/server.ts
@@ -267,7 +267,9 @@ const handleGetService = async (serviceId: string, res: ServerResponse) => {
 const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; startDate?: string };
 	// Use service name for wizard navigation (click-based, not URL param)
-	const serviceName = body.serviceName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
+	// Treat numeric-only serviceName as unresolved (remote adapter sends serviceId as fallback)
+	const resolvedName = body.serviceName && !/^\d+$/.test(body.serviceName) ? body.serviceName : undefined;
+	const serviceName = resolvedName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
 	console.log(`[availability/dates] serviceName="${serviceName}" from serviceId="${body.serviceId}"`);
 
 	const result = await runEffect(
@@ -291,7 +293,8 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse) =
 
 const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; date: string };
-	const serviceName = body.serviceName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
+	const resolvedName = body.serviceName && !/^\d+$/.test(body.serviceName) ? body.serviceName : undefined;
+	const serviceName = resolvedName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
 	console.log(`[availability/slots] serviceName="${serviceName}" date="${body.date}"`);
 
 	const result = await runEffect(
@@ -315,7 +318,8 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse) =
 const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; datetime: string };
 	const date = body.datetime.split('T')[0];
-	const serviceName = body.serviceName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
+	const resolvedName = body.serviceName && !/^\d+$/.test(body.serviceName) ? body.serviceName : undefined;
+	const serviceName = resolvedName ?? cachedServices?.find((s) => s.id === body.serviceId)?.name ?? body.serviceId;
 
 	const result = await runEffect(
 		readTimeSlots({

--- a/src/middleware/server.ts
+++ b/src/middleware/server.ts
@@ -34,7 +34,7 @@ import { Effect, Exit, Cause, Layer, Scope } from 'effect';
 // Scraper removed — deprecated and caused esbuild bundling issues.
 // Services are served from SERVICES_JSON env or BUSINESS object extraction.
 import { BrowserService, BrowserServiceLive, type BrowserConfig, defaultBrowserConfig } from './browser-service.js';
-import { toSchedulingError, type MiddlewareError } from './errors.js';
+import { WizardStepError, toSchedulingError, type MiddlewareError } from './errors.js';
 import { ServiceResolver, ServiceResolverLive } from './service-resolver.js';
 import { LoggerLive, ndjsonLog } from './logger.js';
 import { selectorHealthCheck } from './selector-health.js';

--- a/src/middleware/steps/extract-business.ts
+++ b/src/middleware/steps/extract-business.ts
@@ -227,13 +227,9 @@ export const extractBusinessServices = Effect.gen(function* () {
 	const services = businessToServices(business);
 
 	if (services.length === 0) {
-		yield* Effect.logWarning('BUSINESS object found but contained 0 active services').pipe(
-			Effect.annotateLogs({ step: 'extract-business' }),
-		);
+		console.warn('[extract-business] BUSINESS object found but contained 0 active services');
 	} else {
-		yield* Effect.logInfo('Extracted services from BUSINESS object').pipe(
-			Effect.annotateLogs({ step: 'extract-business', count: services.length }),
-		);
+		console.log(`[extract-business] Extracted ${services.length} services from BUSINESS object`);
 	}
 
 	return services;

--- a/src/middleware/steps/fill-form.ts
+++ b/src/middleware/steps/fill-form.ts
@@ -345,7 +345,8 @@ const advancePastForm = (page: Page): Effect.Effect<boolean, WizardStepError> =>
 			try: async () => {
 				await continueBtn.element.click();
 				// Wait for navigation to payment page (URL ends in /payment)
-				await page.waitForURL((url) => url.href.includes('/payment'), { timeout: 15000 });
+				// Increased timeout: Acuity's server-side validation can take 10-20s
+				await page.waitForURL((url) => url.href.includes('/payment'), { timeout: 30000 });
 			},
 			catch: (e) =>
 				new WizardStepError({

--- a/src/middleware/steps/fill-form.ts
+++ b/src/middleware/steps/fill-form.ts
@@ -82,22 +82,29 @@ export const fillFormFields = (params: FillFormParams) =>
 			}
 		}
 
+		// Fill any remaining required textareas that are still empty.
+		// This catches mandatory intake questions (e.g., "What would you like
+		// to work on?", "How many hours of restful sleep?") regardless of their
+		// field IDs, which change when Jen edits the Acuity intake form.
+		yield* fillRequiredTextareas(page, params.client.notes);
+		intakeFieldsCompleted.push('requiredTextareas');
+
 		// Fill intake radio buttons (yes/no questions)
 		const radioAnswer = params.intakeRadioAnswer ?? 'no';
 		yield* fillIntakeRadios(page, radioAnswer);
 		intakeFieldsCompleted.push('radioButtons');
 
-		// Fill "How did you hear" checkbox
+		// Fill "How did you hear" checkbox (may not exist on current form)
 		const hearOption = params.howDidYouHear ?? 'Internet search';
 		yield* fillHowDidYouHear(page, hearOption);
 		intakeFieldsCompleted.push('howDidYouHear');
 
-		// Fill medication textarea
+		// Fill medication textarea (may not exist on current form)
 		const medication = params.medication ?? 'None';
 		yield* fillMedication(page, medication);
 		intakeFieldsCompleted.push('medication');
 
-		// Fill terms checkbox
+		// Fill terms checkbox (may not exist on current form)
 		yield* fillTermsCheckbox(page);
 		intakeFieldsCompleted.push('termsCheckbox');
 
@@ -215,6 +222,48 @@ const fillCustomField = (
 
 		return true;
 	});
+
+/**
+ * Fill any required textareas that are still empty.
+ *
+ * Acuity intake forms have mandatory custom fields (aria-required="true")
+ * whose field IDs change when the practitioner edits the form. Instead of
+ * hardcoding IDs, we scan the page for any required textarea that hasn't
+ * been filled yet and provide a sensible default.
+ */
+const fillRequiredTextareas = (
+	page: Page,
+	clientNotes?: string,
+): Effect.Effect<void, never> =>
+	Effect.tryPromise({
+		try: async () => {
+			const textareas = await page.$$('textarea[aria-required="true"]');
+			for (const textarea of textareas) {
+				const currentValue = await textarea.evaluate(
+					(el) => (el as HTMLTextAreaElement).value,
+				);
+				if (currentValue.trim()) continue; // Already filled
+
+				// Use client notes for the first empty textarea, "N/A" for the rest
+				const label = await textarea.evaluate((el) => {
+					const container = el.closest('[class*="field"]') ?? el.parentElement;
+					const labelEl = container?.querySelector('label');
+					return labelEl?.textContent?.trim() ?? '';
+				});
+
+				let defaultValue = 'N/A';
+				if (label.toLowerCase().includes('work on') || label.toLowerCase().includes('session')) {
+					defaultValue = clientNotes?.trim() || 'General wellness';
+				} else if (label.toLowerCase().includes('sleep')) {
+					defaultValue = '7-8 hours';
+				}
+
+				await textarea.scrollIntoViewIfNeeded();
+				await textarea.fill(defaultValue);
+			}
+		},
+		catch: () => undefined,
+	}).pipe(Effect.orElseSucceed(() => undefined));
 
 /**
  * Fill intake radio buttons.

--- a/src/middleware/steps/index.ts
+++ b/src/middleware/steps/index.ts
@@ -35,9 +35,3 @@ export {
 	type AcuityCalendar,
 	type AcuityBusinessData,
 } from './extract-business.js';
-export {
-	readDatesViaUrl,
-	readSlotsViaUrl,
-	type UrlDateResult,
-	type UrlSlotResult,
-} from './read-via-url.js';

--- a/src/middleware/steps/navigate.ts
+++ b/src/middleware/steps/navigate.ts
@@ -12,20 +12,13 @@
  *   /schedule/<hash>
  *   /schedule/<hash>/appointment/<aptId>/calendar/<calId>
  *   /schedule/<hash>/appointment/<aptId>/calendar/<calId>/datetime/<ISO>
- *
- * NOTE: Service selection, calendar navigation, and day selection
- * use shared modules (wizard-service.ts, wizard-calendar.ts) to
- * avoid code duplication with read-availability.ts and read-slots.ts.
  */
 
 import { Effect } from 'effect';
-import type { Page } from 'playwright-core';
+import type { Page, ElementHandle } from 'playwright-core';
 import { BrowserService } from '../browser-service.js';
 import { WizardStepError } from '../errors.js';
 import { resolveSelector, probe, Selectors } from '../selectors.js';
-import { navigateToMonth, selectDay } from '../wizard-calendar.js';
-import { clickServiceBook } from '../wizard-service.js';
-import { parseSlotText } from '../slot-parser.js';
 import type { ClientInfo } from '../../core/types.js';
 
 // =============================================================================
@@ -77,17 +70,17 @@ export const navigateToBooking = (params: NavigateParams) =>
 				}),
 		});
 
-		// Step 2: Find and click target service's "Book" button (shared)
-		const { appointmentTypeId, calendarId } = yield* clickServiceBook(
+		// Step 2: Find and click target service's "Book" button
+		const { appointmentTypeId, calendarId } = yield* selectService(
+			page,
 			params.serviceName,
 			params.appointmentTypeId,
-			'navigate',
 		);
 
-		// Step 3: Navigate calendar to target date and click (shared)
+		// Step 3: Navigate calendar to target date and click
 		const targetDate = parseDate(params.datetime);
-		yield* navigateToMonth(page, targetDate.getMonth(), targetDate.getFullYear(), 'navigate');
-		yield* selectDay(page, targetDate.getDate(), 'navigate');
+		yield* navigateCalendar(page, targetDate);
+		yield* selectDay(page, targetDate);
 
 		// Step 4: Select matching time slot
 		const targetTime = parseTime(params.datetime);
@@ -110,12 +103,316 @@ export const navigateToBooking = (params: NavigateParams) =>
 	});
 
 // =============================================================================
+// STEP 2: SERVICE SELECTION
+// =============================================================================
+
+/**
+ * Find the service by name and click its "Book" button.
+ * After clicking, waits for URL to include /appointment/<id>/calendar/<id>.
+ */
+const selectService = (
+	page: Page,
+	serviceName: string,
+	expectedAppointmentTypeId?: string,
+) =>
+	Effect.gen(function* () {
+		// Wait for service list to load
+		yield* resolveSelector(page, Selectors.serviceList, 10000).pipe(
+			Effect.catchTag('SelectorError', () =>
+				Effect.fail(
+					new WizardStepError({
+						step: 'navigate',
+						message: 'Service list did not load within timeout',
+					}),
+				),
+			),
+		);
+
+		// Find the service item matching our target name
+		const serviceItem: ElementHandle | null = yield* Effect.tryPromise({
+			try: async () => {
+				const items = await page.$$(Selectors.serviceList[0]);
+				for (const item of items) {
+					const nameEl = await item.$(Selectors.serviceName[0]);
+					const name = await nameEl?.textContent();
+					if (name && name.trim().toLowerCase().includes(serviceName.toLowerCase())) {
+						return item;
+					}
+				}
+				return null;
+			},
+			catch: (e) =>
+				new WizardStepError({
+					step: 'navigate',
+					message: `Error searching services: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		if (!serviceItem) {
+			return yield* Effect.fail(
+				new WizardStepError({
+					step: 'navigate',
+					message: `Service "${serviceName}" not found on the page`,
+				}),
+			);
+		}
+
+		// Click the "Book" button within this service item
+		const bookBtn = yield* Effect.tryPromise({
+			try: () => serviceItem.$(Selectors.serviceBookButton[0]),
+			catch: (e) =>
+				new WizardStepError({
+					step: 'navigate',
+					message: `Error finding Book button: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		if (!bookBtn) {
+			return yield* Effect.fail(
+				new WizardStepError({
+					step: 'navigate',
+					message: `"Book" button not found for service "${serviceName}"`,
+				}),
+			);
+		}
+
+		yield* Effect.tryPromise({
+			try: async () => {
+				await bookBtn.click();
+				await page.waitForURL(/\/appointment\/\d+\/calendar\/\d+/, { timeout: 10000 });
+			},
+			catch: (e) =>
+				new WizardStepError({
+					step: 'navigate',
+					message: `Failed to navigate after clicking Book: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		// Extract IDs from URL: /appointment/<aptId>/calendar/<calId>
+		const url = page.url();
+		const appointmentMatch = url.match(/\/appointment\/(\d+)/);
+		const calendarMatch = url.match(/\/calendar\/(\d+)/);
+		const appointmentTypeId = appointmentMatch?.[1] ?? null;
+		const calendarId = calendarMatch?.[1] ?? null;
+
+		// Verify appointment type ID if caller provided an expected value
+		if (expectedAppointmentTypeId && appointmentTypeId !== expectedAppointmentTypeId) {
+			return yield* Effect.fail(
+				new WizardStepError({
+					step: 'navigate',
+					message: `Expected appointment type ${expectedAppointmentTypeId} but got ${appointmentTypeId}`,
+				}),
+			);
+		}
+
+		return { appointmentTypeId, calendarId };
+	});
+
+// =============================================================================
+// STEP 3: CALENDAR NAVIGATION
+// =============================================================================
+
+/**
+ * Navigate the react-calendar to the target month using prev/next buttons.
+ * Stops after 12 iterations to prevent infinite loops.
+ */
+const navigateCalendar = (page: Page, targetDate: Date) =>
+	Effect.gen(function* () {
+		// Wait for calendar to load
+		yield* resolveSelector(page, Selectors.calendar, 10000).pipe(
+			Effect.catchTag('SelectorError', () =>
+				Effect.fail(
+					new WizardStepError({
+						step: 'navigate',
+						message: 'Calendar did not load within timeout',
+					}),
+				),
+			),
+		);
+
+		// Wait for the month label to render (may lag behind calendar container)
+		yield* Effect.tryPromise({
+			try: () => page.waitForSelector(Selectors.calendarMonth[0], { timeout: 5000 }),
+			catch: () => null,
+		}).pipe(Effect.orElseSucceed(() => null));
+
+		const targetMonth = targetDate.getMonth();
+		const targetYear = targetDate.getFullYear();
+
+		for (let i = 0; i < 12; i++) {
+			// Retry month detection up to 3 times with brief waits
+			let current: { month: number; year: number } | null = null;
+			for (let retry = 0; retry < 3; retry++) {
+				current = yield* getCurrentCalendarMonth(page);
+				if (current) break;
+				yield* Effect.tryPromise({
+					try: () => page.waitForTimeout(500),
+					catch: () => null,
+				}).pipe(Effect.orElseSucceed(() => null));
+			}
+
+			if (!current) {
+				return yield* Effect.fail(
+					new WizardStepError({
+						step: 'navigate',
+						message: 'Could not determine current calendar month after retries',
+					}),
+				);
+			}
+
+			if (current.month === targetMonth && current.year === targetYear) {
+				return; // Already on the correct month
+			}
+
+			// Determine navigation direction
+			const currentFirst = new Date(current.year, current.month, 1);
+			const targetFirst = new Date(targetYear, targetMonth, 1);
+
+			if (targetFirst > currentFirst) {
+				yield* clickCalendarNav(page, 'next');
+			} else {
+				yield* clickCalendarNav(page, 'prev');
+			}
+
+			// Wait for calendar to re-render
+			yield* Effect.tryPromise({
+				try: () => page.waitForTimeout(500),
+				catch: () =>
+					new WizardStepError({ step: 'navigate', message: 'Calendar nav wait interrupted' }),
+			});
+		}
+	});
+
+const MONTH_NAMES = [
+	'january', 'february', 'march', 'april', 'may', 'june',
+	'july', 'august', 'september', 'october', 'november', 'december',
+];
+
+const getCurrentCalendarMonth = (
+	page: Page,
+): Effect.Effect<{ month: number; year: number } | null, never> =>
+	Effect.tryPromise({
+		try: async () => {
+			for (const selector of Selectors.calendarMonth) {
+				const text = await page
+					.$eval(selector, (el) => el.textContent?.trim() ?? null)
+					.catch(() => null);
+				if (text) {
+					// react-calendar label may contain nested spans — extract visible text
+					// Patterns: "March 2026", "March\n2026", "March 2026 "
+					const match = text.match(/([A-Za-z]+)\s+(\d{4})/);
+					if (match) {
+						const monthIndex = MONTH_NAMES.indexOf(match[1].toLowerCase());
+						if (monthIndex >= 0) {
+							return { month: monthIndex, year: parseInt(match[2], 10) };
+						}
+					}
+				}
+			}
+			return null;
+		},
+		catch: () => null,
+	}).pipe(Effect.orElseSucceed(() => null));
+
+const clickCalendarNav = (
+	page: Page,
+	direction: 'prev' | 'next',
+): Effect.Effect<void, WizardStepError> =>
+	Effect.gen(function* () {
+		const selectors = direction === 'prev' ? Selectors.calendarPrev : Selectors.calendarNext;
+		const btn = yield* resolveSelector(page, selectors, 3000).pipe(
+			Effect.catchTag('SelectorError', () =>
+				Effect.fail(
+					new WizardStepError({
+						step: 'navigate',
+						message: `Calendar ${direction} button not found`,
+					}),
+				),
+			),
+		);
+		yield* Effect.tryPromise({
+			try: () => btn.element.click(),
+			catch: (e) =>
+				new WizardStepError({
+					step: 'navigate',
+					message: `Failed to click calendar ${direction}: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+	});
+
+// =============================================================================
+// STEP 3B: DAY SELECTION
+// =============================================================================
+
+/**
+ * Click the calendar tile matching our target day number.
+ * Skips disabled tiles and neighboring-month tiles.
+ */
+const selectDay = (page: Page, targetDate: Date) =>
+	Effect.gen(function* () {
+		const dayOfMonth = targetDate.getDate();
+
+		const clicked = yield* Effect.tryPromise({
+			try: async () => {
+				const tiles = await page.$$(Selectors.calendarDay[0]);
+				for (const tile of tiles) {
+					const isDisabled = await tile.evaluate((el) => (el as HTMLButtonElement).disabled);
+					if (isDisabled) continue;
+
+					// Skip neighboring-month tiles (e.g. Feb 28 showing in March view)
+					const classes = await tile.getAttribute('class') ?? '';
+					if (classes.includes('neighboringMonth')) continue;
+
+					const text = await tile.textContent();
+					const dayNum = parseInt(text?.trim() ?? '', 10);
+					if (dayNum === dayOfMonth) {
+						await tile.click();
+						return true;
+					}
+				}
+				return false;
+			},
+			catch: (e) =>
+				new WizardStepError({
+					step: 'navigate',
+					message: `Error selecting day ${dayOfMonth}: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		if (!clicked) {
+			return yield* Effect.fail(
+				new WizardStepError({
+					step: 'navigate',
+					message: `Day ${dayOfMonth} not available on calendar`,
+				}),
+			);
+		}
+
+		// Wait for time slots to appear
+		yield* resolveSelector(page, Selectors.timeSlotContainer, 10000).pipe(
+			Effect.catchTag('SelectorError', () =>
+				Effect.fail(
+					new WizardStepError({
+						step: 'navigate',
+						message: 'Time slots did not appear after selecting day',
+					}),
+				),
+			),
+		);
+	});
+
+// =============================================================================
 // STEP 4: TIME SLOT SELECTION
 // =============================================================================
 
 /**
  * Click the time slot matching our target time.
- * Uses parseSlotText to extract clean time from "10:00 AM1 spot left".
+ * Slot text contains time + availability info: "10:00 AM1 spot left"
  */
 const selectTimeSlot = (page: Page, targetTime: string) =>
 	Effect.gen(function* () {
@@ -124,16 +421,7 @@ const selectTimeSlot = (page: Page, targetTime: string) =>
 				const slots = await page.$$(Selectors.timeSlot[0]);
 				for (const slot of slots) {
 					const text = await slot.textContent();
-					if (!text) continue;
-
-					const parsed = parseSlotText(text);
-					if (parsed && parsed.time.includes(targetTime)) {
-						await slot.click();
-						return true;
-					}
-
-					// Fallback: raw text includes check
-					if (text.includes(targetTime)) {
+					if (text && text.includes(targetTime)) {
 						await slot.click();
 						return true;
 					}

--- a/src/middleware/steps/navigate.ts
+++ b/src/middleware/steps/navigate.ts
@@ -70,6 +70,20 @@ export const navigateToBooking = (params: NavigateParams) =>
 				}),
 		});
 
+		// Step 1b: Bypass category view if present
+		// Acuity may show "Select Appointment Category" first. Click "SHOW ALL APPOINTMENTS"
+		// to expand all services, then proceed with normal service selection.
+		yield* Effect.tryPromise({
+			try: async () => {
+				const showAllBtn = await page.$('button:has-text("SHOW ALL APPOINTMENTS")');
+				if (showAllBtn) {
+					await showAllBtn.click();
+					await page.waitForTimeout(1000);
+				}
+			},
+			catch: () => undefined, // Ignore — page may not have categories
+		});
+
 		// Step 2: Find and click target service's "Book" button
 		const { appointmentTypeId, calendarId } = yield* selectService(
 			page,

--- a/src/middleware/steps/read-availability.ts
+++ b/src/middleware/steps/read-availability.ts
@@ -6,19 +6,13 @@
  *
  * Returns available dates for the currently visible month.
  * Callers should advance months if needed.
- *
- * NOTE: Service selection and calendar navigation use shared modules
- * (wizard-service.ts, wizard-calendar.ts) to avoid code duplication
- * with navigate.ts and read-slots.ts.
  */
 
 import { Effect } from 'effect';
-import type { Page } from 'playwright-core';
+import type { Page, ElementHandle } from 'playwright-core';
 import { BrowserService } from '../browser-service.js';
 import { WizardStepError } from '../errors.js';
 import { resolveSelector, Selectors } from '../selectors.js';
-import { getCurrentCalendarMonth, navigateToMonth } from '../wizard-calendar.js';
-import { clickServiceBook } from '../wizard-service.js';
 
 // =============================================================================
 // TYPES
@@ -69,19 +63,16 @@ export const readAvailableDates = (params: ReadAvailabilityParams) =>
 				}),
 		});
 
-		// Step 2: Click the target service's "Book" button (shared)
-		yield* clickServiceBook(params.serviceName, params.appointmentTypeId, 'read-availability');
+		// Step 2: Click the target service's "Book" button
+		yield* clickServiceBook(page, params.serviceName, params.appointmentTypeId);
 
 		// Step 3: Read available dates from calendar
 		const monthsToScan = params.monthsToScan ?? 2;
 		const allDates: AvailableDateResult[] = [];
 
-		// If a specific target month is requested, navigate to it first (shared)
+		// If a specific target month is requested, navigate to it first
 		if (params.targetMonth) {
-			const [yearStr, monthStr] = params.targetMonth.split('-');
-			const targetYear = parseInt(yearStr, 10);
-			const targetMonthIdx = parseInt(monthStr, 10) - 1;
-			yield* navigateToMonth(page, targetMonthIdx, targetYear, 'read-availability');
+			yield* navigateToMonth(page, params.targetMonth);
 		}
 
 		for (let i = 0; i < monthsToScan; i++) {
@@ -103,6 +94,106 @@ export const readAvailableDates = (params: ReadAvailabilityParams) =>
 // =============================================================================
 
 /**
+ * Find a service by name and click its "Book" button.
+ * Waits for calendar URL pattern after clicking.
+ */
+const clickServiceBook = (
+	page: Page,
+	serviceName: string,
+	expectedId?: string,
+) =>
+	Effect.gen(function* () {
+		// Wait for service list
+		yield* resolveSelector(page, Selectors.serviceList, 10000).pipe(
+			Effect.catchTag('SelectorError', () =>
+				Effect.fail(
+					new WizardStepError({
+						step: 'read-availability',
+						message: 'Service list did not load',
+					}),
+				),
+			),
+		);
+
+		// Find matching service
+		const serviceItem: ElementHandle | null = yield* Effect.tryPromise({
+			try: async () => {
+				const items = await page.$$(Selectors.serviceList[0]);
+				for (const item of items) {
+					const nameEl = await item.$(Selectors.serviceName[0]);
+					const name = await nameEl?.textContent();
+					if (name && name.trim().toLowerCase().includes(serviceName.toLowerCase())) {
+						return item;
+					}
+				}
+				return null;
+			},
+			catch: (e) =>
+				new WizardStepError({
+					step: 'read-availability',
+					message: `Error searching services: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		if (!serviceItem) {
+			return yield* Effect.fail(
+				new WizardStepError({
+					step: 'read-availability',
+					message: `Service "${serviceName}" not found`,
+				}),
+			);
+		}
+
+		// Click "Book" button
+		const bookBtn = yield* Effect.tryPromise({
+			try: () => serviceItem.$(Selectors.serviceBookButton[0]),
+			catch: (e) =>
+				new WizardStepError({
+					step: 'read-availability',
+					message: `Book button error: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		if (!bookBtn) {
+			return yield* Effect.fail(
+				new WizardStepError({
+					step: 'read-availability',
+					message: `"Book" button not found for "${serviceName}"`,
+				}),
+			);
+		}
+
+		yield* Effect.tryPromise({
+			try: async () => {
+				await bookBtn.click();
+				await page.waitForURL(/\/appointment\/\d+\/calendar\/\d+/, { timeout: 10000 });
+			},
+			catch: (e) =>
+				new WizardStepError({
+					step: 'read-availability',
+					message: `Failed to navigate to calendar: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		// Verify appointment type ID if provided
+		if (expectedId) {
+			const url = page.url();
+			const match = url.match(/\/appointment\/(\d+)/);
+			if (match && match[1] !== expectedId) {
+				return yield* Effect.fail(
+					new WizardStepError({
+						step: 'read-availability',
+						message: `Expected appointment type ${expectedId} but got ${match[1]}`,
+					}),
+				);
+			}
+		}
+	});
+
+/**
  * Read all available (non-disabled) dates from the currently visible calendar month.
  */
 const readCalendarDates = (page: Page): Effect.Effect<AvailableDateResult[], WizardStepError> =>
@@ -119,17 +210,8 @@ const readCalendarDates = (page: Page): Effect.Effect<AvailableDateResult[], Wiz
 			),
 		);
 
-		// Get current month/year from calendar label (shared)
-		const monthInfo = yield* getCurrentCalendarMonth(page).pipe(
-			Effect.flatMap((info) =>
-				info
-					? Effect.succeed(info)
-					: Effect.fail(new WizardStepError({
-						step: 'read-availability',
-						message: 'Could not determine calendar month after retries',
-					})),
-			),
-		);
+		// Get current month/year from calendar label
+		const monthInfo = yield* getCalendarMonthInfo(page);
 
 		// Read all non-disabled, non-neighboring-month tiles
 		const dates = yield* Effect.tryPromise({
@@ -164,6 +246,121 @@ const readCalendarDates = (page: Page): Effect.Effect<AvailableDateResult[], Wiz
 		});
 
 		return dates;
+	});
+
+const MONTH_NAMES = [
+	'january', 'february', 'march', 'april', 'may', 'june',
+	'july', 'august', 'september', 'october', 'november', 'december',
+];
+
+/**
+ * Get the currently displayed month and year from the calendar label.
+ * Retries up to 3 times with brief waits for React rendering.
+ */
+const getCalendarMonthInfo = (
+	page: Page,
+): Effect.Effect<{ month: number; year: number }, WizardStepError> =>
+	Effect.gen(function* () {
+		// Wait for calendar month label to appear
+		yield* Effect.tryPromise({
+			try: () => page.waitForSelector(Selectors.calendarMonth[0], { timeout: 5000 }),
+			catch: () => null,
+		}).pipe(Effect.orElseSucceed(() => null));
+
+		// Retry up to 3 times — React may still be rendering
+		for (let retry = 0; retry < 3; retry++) {
+			const info = yield* Effect.tryPromise({
+				try: async () => {
+					for (const selector of Selectors.calendarMonth) {
+						const text = await page.$eval(selector, (el) => el.textContent?.trim() ?? null).catch(() => null);
+						if (text) {
+							// Try "March 2026" or "March\n2026" or "March2026" (nested spans)
+							const match = text.match(/([A-Za-z]+)\s*(\d{4})/);
+							if (match) {
+								const monthIndex = MONTH_NAMES.indexOf(match[1].toLowerCase());
+								if (monthIndex >= 0) {
+									return { month: monthIndex, year: parseInt(match[2], 10) };
+								}
+							}
+						}
+					}
+					// Also try innerText which resolves visibility better than textContent
+					for (const selector of Selectors.calendarMonth) {
+						const text = await page.$eval(selector, (el) => (el as HTMLElement).innerText?.trim() ?? null).catch(() => null);
+						if (text) {
+							const match = text.match(/([A-Za-z]+)\s*(\d{4})/);
+							if (match) {
+								const monthIndex = MONTH_NAMES.indexOf(match[1].toLowerCase());
+								if (monthIndex >= 0) {
+									return { month: monthIndex, year: parseInt(match[2], 10) };
+								}
+							}
+						}
+					}
+					return null;
+				},
+				catch: () => null,
+			}).pipe(Effect.orElseSucceed(() => null));
+
+			if (info) return info;
+
+			// Wait before retrying
+			yield* Effect.tryPromise({
+				try: () => page.waitForTimeout(1000),
+				catch: () => null,
+			}).pipe(Effect.orElseSucceed(() => null));
+		}
+
+		return yield* Effect.fail(
+			new WizardStepError({
+				step: 'read-availability',
+				message: 'Could not determine calendar month after 3 retries',
+			}),
+		);
+	});
+
+/**
+ * Navigate the calendar to a specific target month (YYYY-MM format).
+ */
+const navigateToMonth = (page: Page, targetMonth: string): Effect.Effect<void, WizardStepError> =>
+	Effect.gen(function* () {
+		const [yearStr, monthStr] = targetMonth.split('-');
+		const targetYear = parseInt(yearStr, 10);
+		const targetMonthIdx = parseInt(monthStr, 10) - 1;
+
+		for (let i = 0; i < 12; i++) {
+			const current = yield* getCalendarMonthInfo(page);
+			if (current.month === targetMonthIdx && current.year === targetYear) return;
+
+			const currentFirst = new Date(current.year, current.month, 1);
+			const targetFirst = new Date(targetYear, targetMonthIdx, 1);
+			const direction = targetFirst > currentFirst ? 'next' : 'prev';
+			const selectors = direction === 'prev' ? Selectors.calendarPrev : Selectors.calendarNext;
+
+			const btn = yield* resolveSelector(page, selectors, 3000).pipe(
+				Effect.catchTag('SelectorError', () =>
+					Effect.fail(
+						new WizardStepError({
+							step: 'read-availability',
+							message: `Calendar ${direction} button not found`,
+						}),
+					),
+				),
+			);
+
+			yield* Effect.tryPromise({
+				try: async () => {
+					await btn.element.click();
+					await page.waitForTimeout(500);
+				},
+				catch: (e) =>
+					new WizardStepError({
+						step: 'read-availability',
+						message: `Calendar nav failed: ${e instanceof Error ? e.message : String(e)}`,
+						cause: e,
+					}),
+			});
+		}
 	});
 
 /**

--- a/src/middleware/steps/read-availability.ts
+++ b/src/middleware/steps/read-availability.ts
@@ -63,6 +63,18 @@ export const readAvailableDates = (params: ReadAvailabilityParams) =>
 				}),
 		});
 
+		// Step 1b: Bypass category view if present
+		yield* Effect.tryPromise({
+			try: async () => {
+				const showAllBtn = await page.$('button:has-text("SHOW ALL APPOINTMENTS")');
+				if (showAllBtn) {
+					await showAllBtn.click();
+					await page.waitForTimeout(1000);
+				}
+			},
+			catch: () => undefined,
+		});
+
 		// Step 2: Click the target service's "Book" button
 		yield* clickServiceBook(page, params.serviceName, params.appointmentTypeId);
 

--- a/src/middleware/steps/read-slots.ts
+++ b/src/middleware/steps/read-slots.ts
@@ -59,6 +59,18 @@ export const readTimeSlots = (params: ReadSlotsParams) =>
 				}),
 		});
 
+		// Step 1b: Bypass category view if present
+		yield* Effect.tryPromise({
+			try: async () => {
+				const showAllBtn = await page.$('button:has-text("SHOW ALL APPOINTMENTS")');
+				if (showAllBtn) {
+					await showAllBtn.click();
+					await page.waitForTimeout(1000);
+				}
+			},
+			catch: () => undefined,
+		});
+
 		// Step 2: Click the target service's "Book" button
 		yield* clickServiceBook(page, params.serviceName, params.appointmentTypeId);
 

--- a/src/middleware/steps/read-slots.ts
+++ b/src/middleware/steps/read-slots.ts
@@ -4,20 +4,13 @@
  * Navigates to the service calendar via click-through,
  * advances to the target date, clicks the day tile,
  * and reads all available time slot buttons.
- *
- * NOTE: Service selection, calendar navigation, and day selection
- * use shared modules (wizard-service.ts, wizard-calendar.ts) to
- * avoid code duplication with navigate.ts and read-availability.ts.
  */
 
 import { Effect } from 'effect';
-import type { Page } from 'playwright-core';
+import type { Page, ElementHandle } from 'playwright-core';
 import { BrowserService } from '../browser-service.js';
 import { WizardStepError } from '../errors.js';
-import { Selectors } from '../selectors.js';
-import { navigateToMonth, selectDay } from '../wizard-calendar.js';
-import { clickServiceBook } from '../wizard-service.js';
-import { parseSlotText, buildIsoDatetime } from '../slot-parser.js';
+import { resolveSelector, Selectors } from '../selectors.js';
 
 // =============================================================================
 // TYPES
@@ -66,20 +59,16 @@ export const readTimeSlots = (params: ReadSlotsParams) =>
 				}),
 		});
 
-		// Step 2: Click the target service's "Book" button (shared)
-		yield* clickServiceBook(params.serviceName, params.appointmentTypeId, 'read-slots');
+		// Step 2: Click the target service's "Book" button
+		yield* clickServiceBook(page, params.serviceName, params.appointmentTypeId);
 
-		// Step 3: Navigate to the target month (shared)
+		// Step 3: Navigate to the target month
 		const targetDate = new Date(params.date + 'T12:00:00');
-		yield* navigateToMonth(
-			page,
-			targetDate.getMonth(),
-			targetDate.getFullYear(),
-			'read-slots',
-		);
+		const targetMonth = `${targetDate.getFullYear()}-${String(targetDate.getMonth() + 1).padStart(2, '0')}`;
+		yield* navigateToTargetMonth(page, targetMonth);
 
-		// Step 4: Click the target day (shared)
-		yield* selectDay(page, targetDate.getDate(), 'read-slots');
+		// Step 4: Click the target day
+		yield* clickDay(page, targetDate.getDate());
 
 		// Step 5: Read time slots
 		const slots = yield* readSlotButtons(page, params.date);
@@ -91,9 +80,277 @@ export const readTimeSlots = (params: ReadSlotsParams) =>
 // HELPERS
 // =============================================================================
 
+const clickServiceBook = (
+	page: Page,
+	serviceName: string,
+	expectedId?: string,
+) =>
+	Effect.gen(function* () {
+		yield* resolveSelector(page, Selectors.serviceList, 10000).pipe(
+			Effect.catchTag('SelectorError', () =>
+				Effect.fail(
+					new WizardStepError({
+						step: 'read-slots',
+						message: 'Service list did not load',
+					}),
+				),
+			),
+		);
+
+		const serviceItem: ElementHandle | null = yield* Effect.tryPromise({
+			try: async () => {
+				const items = await page.$$(Selectors.serviceList[0]);
+				for (const item of items) {
+					const nameEl = await item.$(Selectors.serviceName[0]);
+					const name = await nameEl?.textContent();
+					if (name && name.trim().toLowerCase().includes(serviceName.toLowerCase())) {
+						return item;
+					}
+				}
+				return null;
+			},
+			catch: (e) =>
+				new WizardStepError({
+					step: 'read-slots',
+					message: `Error searching services: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		if (!serviceItem) {
+			return yield* Effect.fail(
+				new WizardStepError({
+					step: 'read-slots',
+					message: `Service "${serviceName}" not found`,
+				}),
+			);
+		}
+
+		const bookBtn = yield* Effect.tryPromise({
+			try: () => serviceItem.$(Selectors.serviceBookButton[0]),
+			catch: (e) =>
+				new WizardStepError({
+					step: 'read-slots',
+					message: `Book button error: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		if (!bookBtn) {
+			return yield* Effect.fail(
+				new WizardStepError({
+					step: 'read-slots',
+					message: `"Book" button not found for "${serviceName}"`,
+				}),
+			);
+		}
+
+		yield* Effect.tryPromise({
+			try: async () => {
+				await bookBtn.click();
+				await page.waitForURL(/\/appointment\/\d+\/calendar\/\d+/, { timeout: 10000 });
+			},
+			catch: (e) =>
+				new WizardStepError({
+					step: 'read-slots',
+					message: `Failed to navigate to calendar: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		if (expectedId) {
+			const url = page.url();
+			const match = url.match(/\/appointment\/(\d+)/);
+			if (match && match[1] !== expectedId) {
+				return yield* Effect.fail(
+					new WizardStepError({
+						step: 'read-slots',
+						message: `Expected appointment type ${expectedId} but got ${match[1]}`,
+					}),
+				);
+			}
+		}
+	});
+
+const MONTH_NAMES = [
+	'january', 'february', 'march', 'april', 'may', 'june',
+	'july', 'august', 'september', 'october', 'november', 'december',
+];
+
+const navigateToTargetMonth = (page: Page, targetMonth: string): Effect.Effect<void, WizardStepError> =>
+	Effect.gen(function* () {
+		yield* resolveSelector(page, Selectors.calendar, 10000).pipe(
+			Effect.catchTag('SelectorError', () =>
+				Effect.fail(
+					new WizardStepError({
+						step: 'read-slots',
+						message: 'Calendar did not load',
+					}),
+				),
+			),
+		);
+
+		const [yearStr, monthStr] = targetMonth.split('-');
+		const targetYear = parseInt(yearStr, 10);
+		const targetMonthIdx = parseInt(monthStr, 10) - 1;
+
+		for (let i = 0; i < 12; i++) {
+			const current = yield* getCalendarMonth(page);
+			if (!current) {
+				return yield* Effect.fail(
+					new WizardStepError({
+						step: 'read-slots',
+						message: 'Could not determine calendar month',
+					}),
+				);
+			}
+
+			if (current.month === targetMonthIdx && current.year === targetYear) return;
+
+			const currentFirst = new Date(current.year, current.month, 1);
+			const targetFirst = new Date(targetYear, targetMonthIdx, 1);
+			const direction = targetFirst > currentFirst ? 'next' : 'prev';
+			const selectors = direction === 'prev' ? Selectors.calendarPrev : Selectors.calendarNext;
+
+			const btn = yield* resolveSelector(page, selectors, 3000).pipe(
+				Effect.catchTag('SelectorError', () =>
+					Effect.fail(
+						new WizardStepError({
+							step: 'read-slots',
+							message: `Calendar ${direction} button not found`,
+						}),
+					),
+				),
+			);
+
+			yield* Effect.tryPromise({
+				try: async () => {
+					await btn.element.click();
+					await page.waitForTimeout(500);
+				},
+				catch: (e) =>
+					new WizardStepError({
+						step: 'read-slots',
+						message: `Calendar nav failed: ${e instanceof Error ? e.message : String(e)}`,
+						cause: e,
+					}),
+			});
+		}
+	});
+
+const getCalendarMonth = (
+	page: Page,
+): Effect.Effect<{ month: number; year: number } | null, never> =>
+	Effect.gen(function* () {
+		// Wait for calendar month label to appear
+		yield* Effect.tryPromise({
+			try: () => page.waitForSelector(Selectors.calendarMonth[0], { timeout: 5000 }),
+			catch: () => null,
+		}).pipe(Effect.orElseSucceed(() => null));
+
+		// Retry up to 3 times — React may still be rendering
+		for (let retry = 0; retry < 3; retry++) {
+			const info = yield* Effect.tryPromise({
+				try: async () => {
+					for (const selector of Selectors.calendarMonth) {
+						const text = await page.$eval(selector, (el) => el.textContent?.trim() ?? null).catch(() => null);
+						if (text) {
+							const match = text.match(/([A-Za-z]+)\s*(\d{4})/);
+							if (match) {
+								const monthIndex = MONTH_NAMES.indexOf(match[1].toLowerCase());
+								if (monthIndex >= 0) {
+									return { month: monthIndex, year: parseInt(match[2], 10) };
+								}
+							}
+						}
+					}
+					// Also try innerText which resolves visibility better than textContent
+					for (const selector of Selectors.calendarMonth) {
+						const text = await page.$eval(selector, (el) => (el as HTMLElement).innerText?.trim() ?? null).catch(() => null);
+						if (text) {
+							const match = text.match(/([A-Za-z]+)\s*(\d{4})/);
+							if (match) {
+								const monthIndex = MONTH_NAMES.indexOf(match[1].toLowerCase());
+								if (monthIndex >= 0) {
+									return { month: monthIndex, year: parseInt(match[2], 10) };
+								}
+							}
+						}
+					}
+					return null;
+				},
+				catch: () => null,
+			}).pipe(Effect.orElseSucceed(() => null));
+
+			if (info) return info;
+
+			// Wait before retrying
+			yield* Effect.tryPromise({
+				try: () => page.waitForTimeout(1000),
+				catch: () => null,
+			}).pipe(Effect.orElseSucceed(() => null));
+		}
+
+		return null;
+	});
+
+/**
+ * Click the calendar tile for a specific day number.
+ */
+const clickDay = (page: Page, dayOfMonth: number): Effect.Effect<void, WizardStepError> =>
+	Effect.gen(function* () {
+		const clicked = yield* Effect.tryPromise({
+			try: async () => {
+				const tiles = await page.$$(Selectors.calendarDay[0]);
+				for (const tile of tiles) {
+					const isDisabled = await tile.evaluate((el) => (el as HTMLButtonElement).disabled);
+					if (isDisabled) continue;
+
+					const classes = (await tile.getAttribute('class')) ?? '';
+					if (classes.includes('neighboringMonth')) continue;
+
+					const text = await tile.textContent();
+					const num = parseInt(text?.trim() ?? '', 10);
+					if (num === dayOfMonth) {
+						await tile.click();
+						return true;
+					}
+				}
+				return false;
+			},
+			catch: (e) =>
+				new WizardStepError({
+					step: 'read-slots',
+					message: `Error clicking day ${dayOfMonth}: ${e instanceof Error ? e.message : String(e)}`,
+					cause: e,
+				}),
+		});
+
+		if (!clicked) {
+			return yield* Effect.fail(
+				new WizardStepError({
+					step: 'read-slots',
+					message: `Day ${dayOfMonth} not available on calendar`,
+				}),
+			);
+		}
+
+		// Wait for time slots to appear
+		yield* resolveSelector(page, Selectors.timeSlotContainer, 10000).pipe(
+			Effect.catchTag('SelectorError', () =>
+				Effect.fail(
+					new WizardStepError({
+						step: 'read-slots',
+						message: 'Time slots did not appear after clicking day',
+					}),
+				),
+			),
+		);
+	});
+
 /**
  * Read all time slot buttons and return structured data.
- * Uses parseSlotText to properly extract time from "10:00 AM1 spot left".
+ * Slot text format: "10:00 AM1 spot left" or "2:30 PM"
  */
 const readSlotButtons = (
 	page: Page,
@@ -108,10 +365,14 @@ const readSlotButtons = (
 				const text = await slot.textContent();
 				if (!text) continue;
 
-				const parsed = parseSlotText(text);
-				if (!parsed) continue;
+				// Extract time from slot text: "10:00 AM1 spot left" → "10:00 AM"
+				const timeMatch = text.trim().match(/^(\d{1,2}:\d{2}\s*[AP]M)/i);
+				if (!timeMatch) continue;
 
-				const datetime = buildIsoDatetime(dateStr, parsed.time);
+				const timeStr = timeMatch[1].trim();
+
+				// Convert to ISO 8601 datetime
+				const datetime = buildIsoDatetime(dateStr, timeStr);
 				results.push({ datetime, available: true });
 			}
 
@@ -124,3 +385,21 @@ const readSlotButtons = (
 				cause: e,
 			}),
 	});
+
+/**
+ * Build ISO datetime from date string and time string.
+ * "2026-03-15" + "10:00 AM" → "2026-03-15T10:00:00"
+ */
+const buildIsoDatetime = (dateStr: string, timeStr: string): string => {
+	const match = timeStr.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i);
+	if (!match) return `${dateStr}T00:00:00`;
+
+	let hours = parseInt(match[1], 10);
+	const minutes = match[2];
+	const ampm = match[3].toUpperCase();
+
+	if (ampm === 'PM' && hours !== 12) hours += 12;
+	if (ampm === 'AM' && hours === 12) hours = 0;
+
+	return `${dateStr}T${String(hours).padStart(2, '0')}:${minutes}:00`;
+};

--- a/src/middleware/steps/read-via-url.ts
+++ b/src/middleware/steps/read-via-url.ts
@@ -13,7 +13,7 @@ import { Effect, Scope } from 'effect';
 import { BrowserService } from '../browser-service.js';
 import { WizardStepError } from '../errors.js';
 import { Selectors } from '../selectors.js';
-import { parseSlotText } from '../slot-parser.js';
+import { parseSlotText, buildIsoDatetime } from '../slot-parser.js';
 
 // =============================================================================
 // TYPES
@@ -169,11 +169,11 @@ export const readSlotsViaUrl = (
 			catch: (e) => new WizardStepError({ step: 'read-slots', message: `Slots read failed: ${e}` }),
 		});
 
-		// Parse slot text to extract clean time (strip "1 spot left" etc.)
+		// Parse slot text and build full ISO datetime (e.g., "4:00 PM" → "2026-04-01T16:00:00")
 		return slots.map(s => {
 			const parsed = parseSlotText(s.datetime);
 			return {
-				datetime: parsed ? parsed.time : s.datetime,
+				datetime: parsed ? buildIsoDatetime(date, parsed.time) : s.datetime,
 				available: s.available,
 			};
 		});


### PR DESCRIPTION
## Summary
- Complete fp-ts → Effect migration across all adapters and middleware
- Resilient service resolution with fuzzy matching and cache warming
- Structured NDJSON logging + tiered selector health checks
- Wizard fixes: category selection, intake textareas, payment timeouts
- IEEE paper updated for Effect unification
- CI fix: remove `pnpm-workspace.yaml` that broke npm publish
- Concurrent request handling bumped to 3

## Changes (29 commits)
- **Architecture**: fp-ts fully removed, Effect throughout, types consolidated from scheduling-kit
- **Resilience**: unified resolveServiceName, auto cache warming, BUSINESS extraction fallback
- **Wizard**: category page handling, intake textarea fill, payment timeout increase
- **CI**: publish workflow fixed, dual-publish to npm + GitHub Packages
- **Paper**: updated with code listings, TikZ diagrams, Effect coverage

## Test plan
- [ ] CI publish succeeds on merge (pnpm-workspace.yaml removed)
- [ ] Middleware health check returns OK
- [ ] Booking flow works end-to-end on beta