### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.2.0",
+    version = "0.3.0",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.2.0",
+    version = "0.3.0",
     compatibility_level = 1,
 )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump for first publish as `@tummycrypt/scheduling-bridge`.

After merge, push `v0.3.0` tag to trigger CI publish.