### PR TITLE
perf: warm browser runtime and cache services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   PNPM_VERSION: 9.15.9
@@ -17,18 +18,27 @@ jobs:
         node-version: [20, 22]
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: pnpm
+          package-manager-cache: false
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,14 +21,21 @@ jobs:
     name: Test & Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
-          cache: 'pnpm'
+          package-manager-cache: false
+      - run: corepack enable
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm build
@@ -42,16 +49,23 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
-          cache: 'pnpm'
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
           scope: '@tummycrypt'
+      - run: corepack enable
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Publish to npmjs.com
@@ -68,14 +82,21 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
-          cache: 'pnpm'
+          package-manager-cache: false
+      - run: corepack enable
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Configure GitHub Packages auth

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ HTTP Request
 
 - **server/handler.ts** -- Standalone Node.js HTTP server with Bearer token auth
 - **acuity-service-catalog.ts** -- Shared service source order and cache for static config, BUSINESS extraction, and scraper fallback
-- **browser-service.ts** -- Effect TS Layer managing Playwright browser/page lifecycle
+- **browser-service.ts** -- Effect TS Layers for a warm shared browser process plus request-scoped page sessions
 - **acuity-wizard.ts** -- Full `SchedulingAdapter` implementation (local Playwright or remote HTTP proxy)
 - **remote-adapter.ts** -- HTTP client adapter for proxying to a remote middleware instance
 - **selectors.ts** -- Single source of truth for all Acuity DOM selectors
@@ -54,6 +54,7 @@ HTTP Request
 | `CHROMIUM_EXECUTABLE_PATH` | No | -- | Custom Chromium path (for Lambda/serverless) |
 | `CHROMIUM_LAUNCH_ARGS` | No | -- | Comma-separated Chromium args |
 | `SERVICES_JSON` | No | -- | Optional static service catalog to bypass live Acuity reads |
+| `ACUITY_SERVICE_CACHE_TTL_MS` | No | `300000` | TTL for cached live service catalogs before BUSINESS/scraper refresh |
 
 ## Deployment
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,15 @@ export {
 
 // Shared: browser service (Playwright lifecycle)
 export {
+	BrowserProcess,
+	BrowserProcessLive,
 	BrowserService,
+	BrowserSessionLive,
 	BrowserServiceLive,
 	BrowserServiceTest,
 	defaultBrowserConfig,
 	type BrowserConfig,
+	type BrowserProcessShape,
 	type BrowserServiceShape,
 } from './shared/browser-service.js';
 

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -30,9 +30,15 @@
  */
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { Effect, Exit, Cause, Scope } from 'effect';
+import { Effect, Exit, Cause, ManagedRuntime, Scope } from 'effect';
 import type { ScraperConfig } from '../adapters/acuity/scraper.js';
-import { BrowserService, BrowserServiceLive, type BrowserConfig, defaultBrowserConfig } from '../shared/browser-service.js';
+import {
+	BrowserProcessLive,
+	BrowserService,
+	BrowserSessionLive,
+	type BrowserConfig,
+	defaultBrowserConfig,
+} from '../shared/browser-service.js';
 import {
 	createAcuityServiceCatalog,
 	parseStaticServicesJson,
@@ -64,6 +70,10 @@ const PORT = Number(process.env.PORT ?? 3001);
 const AUTH_TOKEN = process.env.AUTH_TOKEN;
 const ACUITY_BASE_URL = process.env.ACUITY_BASE_URL ?? 'https://MassageIthaca.as.me';
 const COUPON_CODE = process.env.ACUITY_BYPASS_COUPON;
+const SERVICE_CACHE_TTL_MS = (() => {
+	const parsed = Number(process.env.ACUITY_SERVICE_CACHE_TTL_MS ?? 5 * 60_000);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5 * 60_000;
+})();
 
 const browserConfig: BrowserConfig = {
 	...defaultBrowserConfig,
@@ -132,15 +142,15 @@ const parseBody = async (req: IncomingMessage): Promise<unknown> => {
 // EFFECT RUNNER
 // =============================================================================
 
-const layer = BrowserServiceLive(browserConfig);
+const browserRuntime = ManagedRuntime.make(BrowserProcessLive(browserConfig));
 
 type Result<A> = { ok: true; value: A } | { ok: false; error: SchedulingError };
 
 const runEffect = async <A>(
 	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
 ): Promise<Result<A>> => {
-	const exit = await Effect.runPromiseExit(
-		Effect.scoped(effect.pipe(Effect.provide(layer))),
+	const exit = await browserRuntime.runPromiseExit(
+		Effect.scoped(effect.pipe(Effect.provide(BrowserSessionLive))),
 	);
 	if (Exit.isSuccess(exit)) {
 		return { ok: true, value: exit.value };
@@ -154,6 +164,7 @@ const runEffect = async <A>(
 
 const serviceCatalog = createAcuityServiceCatalog({
 	baseUrl: ACUITY_BASE_URL,
+	cacheTtlMs: SERVICE_CACHE_TTL_MS,
 	staticServices: parseStaticServicesJson(process.env.SERVICES_JSON),
 	scraperConfig,
 	logger: console,
@@ -185,6 +196,7 @@ const handleHealth = (_req: IncomingMessage, res: ServerResponse) => {
 		hasCoupon: !!COUPON_CODE,
 		headless: browserConfig.headless,
 		staticServices: serviceCatalog.staticServicesCount,
+		serviceCacheTtlMs: SERVICE_CACHE_TTL_MS,
 		timestamp: new Date().toISOString(),
 	});
 };
@@ -441,6 +453,18 @@ const server = createServer(async (req, res) => {
 		});
 	}
 });
+
+let browserRuntimeDisposed = false;
+
+const disposeBrowserRuntime = () => {
+	if (browserRuntimeDisposed) return;
+	browserRuntimeDisposed = true;
+	void browserRuntime.dispose().catch((error) => {
+		console.error('[middleware-server] Failed to dispose browser runtime:', error);
+	});
+};
+
+server.on('close', disposeBrowserRuntime);
 
 // Only start listening when this file is executed directly (not imported)
 if (process.argv[1]?.match(/handler\.(ts|js|mjs)$/)) {

--- a/src/shared/__tests__/acuity-service-catalog.test.ts
+++ b/src/shared/__tests__/acuity-service-catalog.test.ts
@@ -92,6 +92,40 @@ describe('createAcuityServiceCatalog', () => {
 		expect(catalog.getCachedService('svc-1')).toEqual(services[0]);
 	});
 
+	it('reuses the cached catalog within the TTL window', async () => {
+		const fetchBusinessData = vi.fn(async () => ({} as AcuityBusinessData));
+		const businessToServices = vi.fn(() => services);
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://example.com',
+			cacheTtlMs: 60_000,
+			fetchBusinessData,
+			businessToServices,
+			logger: makeLogger(),
+		});
+
+		await expect(catalog.getServices()).resolves.toEqual(services);
+		await expect(catalog.getServices()).resolves.toEqual(services);
+		expect(fetchBusinessData).toHaveBeenCalledTimes(1);
+		expect(businessToServices).toHaveBeenCalledTimes(1);
+	});
+
+	it('refreshes the catalog immediately when TTL is zero', async () => {
+		const fetchBusinessData = vi.fn(async () => ({} as AcuityBusinessData));
+		const businessToServices = vi.fn(() => services);
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://example.com',
+			cacheTtlMs: 0,
+			fetchBusinessData,
+			businessToServices,
+			logger: makeLogger(),
+		});
+
+		await expect(catalog.getServices()).resolves.toEqual(services);
+		await expect(catalog.getServices()).resolves.toEqual(services);
+		expect(fetchBusinessData).toHaveBeenCalledTimes(2);
+		expect(businessToServices).toHaveBeenCalledTimes(2);
+	});
+
 	it('falls back to scraper services when BUSINESS is unavailable', async () => {
 		const loadScraperServices = vi.fn(async () => services);
 		const catalog = createAcuityServiceCatalog({

--- a/src/shared/acuity-service-catalog.ts
+++ b/src/shared/acuity-service-catalog.ts
@@ -24,11 +24,13 @@ export interface AcuityServiceCatalog {
 export interface AcuityServiceCatalogConfig {
 	readonly baseUrl: string;
 	readonly staticServices?: readonly Service[] | null;
+	readonly cacheTtlMs?: number;
 	readonly scraperConfig?: ScraperConfig;
 	readonly logger?: ServiceCatalogLogger;
 	readonly fetchBusinessData?: (baseUrl: string) => Promise<AcuityBusinessData | null>;
 	readonly businessToServices?: (business: AcuityBusinessData) => Service[];
 	readonly loadScraperServices?: () => Promise<readonly Service[]>;
+	readonly now?: () => number;
 }
 
 const cloneService = (service: Service): Service => ({ ...service });
@@ -65,10 +67,13 @@ export const createAcuityServiceCatalog = (
 	const fetchBusinessDataImpl = config.fetchBusinessData ?? fetchBusinessData;
 	const businessToServicesImpl = config.businessToServices ?? businessToServices;
 	const injectedScraperLoader = config.loadScraperServices;
+	const now = config.now ?? Date.now;
+	const cacheTtlMs = Math.max(0, config.cacheTtlMs ?? 5 * 60_000);
 
 	let scraper: ReturnType<typeof createScraperAdapter> | null = null;
 	let cachedServices: Service[] | null = staticServices;
 	let loadInFlight: Promise<Service[]> | null = null;
+	let cacheUpdatedAt = staticServices ? now() : 0;
 
 	if (staticServices) {
 		logger.log?.(
@@ -78,8 +83,12 @@ export const createAcuityServiceCatalog = (
 
 	const setCachedServices = (services: readonly Service[]): Service[] => {
 		cachedServices = cloneServices(services);
+		cacheUpdatedAt = now();
 		return cachedServices;
 	};
+
+	const hasFreshCache = (): boolean =>
+		cachedServices !== null && (staticServices !== null || now() - cacheUpdatedAt < cacheTtlMs);
 
 	const loadBusinessServices = async (): Promise<Service[] | null> => {
 		try {
@@ -162,11 +171,11 @@ export const createAcuityServiceCatalog = (
 	};
 
 	const ensureServices = async (): Promise<Service[]> =>
-		cachedServices ? cloneServices(cachedServices) : runRefresh();
+		hasFreshCache() ? cloneServices(cachedServices ?? []) : runRefresh();
 
 	return {
 		staticServicesCount: staticServices?.length ?? 0,
-		getServices: () => runRefresh(),
+		getServices: () => ensureServices(),
 		getService: async (serviceId) => {
 			const services = await ensureServices();
 			return services.find((service) => service.id === serviceId) ?? null;

--- a/src/shared/browser-service.ts
+++ b/src/shared/browser-service.ts
@@ -61,47 +61,56 @@ export class BrowserService extends Context.Tag('scheduling-kit/BrowserService')
 	BrowserServiceShape
 >() {}
 
+export interface BrowserProcessShape {
+	readonly browser: Browser;
+	readonly config: BrowserConfig;
+}
+
+export class BrowserProcess extends Context.Tag('scheduling-kit/BrowserProcess')<
+	BrowserProcess,
+	BrowserProcessShape
+>() {}
+
 // =============================================================================
 // LIVE IMPLEMENTATION
 // =============================================================================
 
+const loadChromium = Effect.tryPromise({
+	try: async (): Promise<typeof import('playwright-core').chromium> => {
+		try {
+			const pw = await import('playwright-core');
+			return pw.chromium;
+		} catch {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const pw = await (import('playwright-core') as any);
+			return pw.chromium;
+		}
+	},
+	catch: () =>
+		new BrowserError({
+			reason: 'PLAYWRIGHT_MISSING',
+			cause: new Error(
+				'playwright-core or playwright is required for the wizard middleware. ' +
+					'Install with: pnpm add playwright-core',
+			),
+		}),
+});
+
 /**
- * Create a live BrowserService layer backed by Playwright Chromium.
- * The browser is launched once when the layer is created and closed
- * when the layer scope ends.
+ * Launch and hold a browser process for the lifetime of the surrounding runtime.
+ * This is the expensive part of the Playwright lifecycle and is safe to reuse
+ * across requests as long as pages remain request-scoped.
  */
-export const BrowserServiceLive = (
+export const BrowserProcessLive = (
 	config: Partial<BrowserConfig> = {},
-): Layer.Layer<BrowserService, BrowserError> => {
+): Layer.Layer<BrowserProcess, BrowserError> => {
 	const cfg: BrowserConfig = { ...defaultBrowserConfig, ...config };
 
 	return Layer.scoped(
-		BrowserService,
+		BrowserProcess,
 		Effect.gen(function* () {
-			// Dynamic import - try playwright-core first (lighter, no bundled browsers),
-			// fall back to full playwright which includes its own Chromium
-			const chromium = yield* Effect.tryPromise({
-				try: async (): Promise<typeof import('playwright-core').chromium> => {
-					try {
-						const pw = await import('playwright-core');
-						return pw.chromium;
-					} catch {
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						const pw = await (import('playwright-core') as any);
-						return pw.chromium;
-					}
-				},
-				catch: () =>
-					new BrowserError({
-						reason: 'PLAYWRIGHT_MISSING',
-						cause: new Error(
-							'playwright-core or playwright is required for the wizard middleware. ' +
-								'Install with: pnpm add playwright-core',
-						),
-					}),
-			});
+			const chromium = yield* loadChromium;
 
-			// Launch browser (released when scope ends)
 			const browser: Browser = yield* Effect.acquireRelease(
 				Effect.tryPromise({
 					try: () =>
@@ -112,52 +121,67 @@ export const BrowserServiceLive = (
 						}),
 					catch: (e) => new BrowserError({ reason: 'LAUNCH_FAILED', cause: e }),
 				}),
-				(browser) =>
-					Effect.promise(() => browser.close()).pipe(Effect.ignoreLogged),
+				(browser) => Effect.promise(() => browser.close()).pipe(Effect.ignoreLogged),
 			);
 
-			// Create a single managed page for the layer's lifetime.
-			// All step programs share this page within a scope.
-			const page: Page = yield* Effect.acquireRelease(
-				Effect.tryPromise({
-					try: async () => {
-						const p = await browser.newPage({ userAgent: cfg.userAgent });
-						p.setDefaultTimeout(cfg.timeout);
-						return p;
-					},
-					catch: (e) => new BrowserError({ reason: 'PAGE_FAILED', cause: e }),
-				}),
-				(p) =>
-					Effect.promise(() => p.close()).pipe(Effect.ignoreLogged),
-			);
-
-			// acquirePage returns the singleton page — cleanup is handled by the
-			// layer scope above. The no-op release keeps the Scope type requirement
-			// so callers still need Effect.scoped.
-			const acquirePage = Effect.acquireRelease(
-				Effect.succeed(page),
-				() => Effect.void,
-			);
-
-			const screenshot = (label: string) =>
-				Effect.tryPromise({
-					try: async () => {
-						if (page.isClosed()) {
-							throw new Error('No active page for screenshot');
-						}
-						const buffer = await page.screenshot({
-							path: `${cfg.screenshotDir}/${label}-${Date.now()}.png`,
-							fullPage: true,
-						});
-						return buffer;
-					},
-					catch: (e) => new BrowserError({ reason: 'SCREENSHOT_FAILED', cause: e }),
-				});
-
-			return { acquirePage, screenshot, config: cfg };
+			return { browser, config: cfg };
 		}),
 	);
 };
+
+/**
+ * Create a request-scoped BrowserService from a shared browser process.
+ * Each scope gets its own page, while the underlying Chromium process can stay warm.
+ */
+export const BrowserSessionLive = Layer.scoped(
+	BrowserService,
+	Effect.gen(function* () {
+		const { browser, config } = yield* BrowserProcess;
+
+		const page: Page = yield* Effect.acquireRelease(
+			Effect.tryPromise({
+				try: async () => {
+					const p = await browser.newPage({ userAgent: config.userAgent });
+					p.setDefaultTimeout(config.timeout);
+					return p;
+				},
+				catch: (e) => new BrowserError({ reason: 'PAGE_FAILED', cause: e }),
+			}),
+			(p) => Effect.promise(() => p.close()).pipe(Effect.ignoreLogged),
+		);
+
+		const acquirePage = Effect.acquireRelease(
+			Effect.succeed(page),
+			() => Effect.void,
+		);
+
+		const screenshot = (label: string) =>
+			Effect.tryPromise({
+				try: async () => {
+					if (page.isClosed()) {
+						throw new Error('No active page for screenshot');
+					}
+					const buffer = await page.screenshot({
+						path: `${config.screenshotDir}/${label}-${Date.now()}.png`,
+						fullPage: true,
+					});
+					return buffer;
+				},
+				catch: (e) => new BrowserError({ reason: 'SCREENSHOT_FAILED', cause: e }),
+			});
+
+		return { acquirePage, screenshot, config };
+	}),
+);
+
+/**
+ * Standalone BrowserService layer for call sites that do not manage a shared runtime.
+ * This keeps the existing API intact by composing a browser process + request session.
+ */
+export const BrowserServiceLive = (
+	config: Partial<BrowserConfig> = {},
+): Layer.Layer<BrowserService, BrowserError> =>
+	Layer.provide(BrowserSessionLive, BrowserProcessLive(config));
 
 // =============================================================================
 // TEST IMPLEMENTATION


### PR DESCRIPTION
## Summary
- keep a warm shared browser process while making pages request-scoped via Effect layers/runtime
- add TTL-backed service-catalog caching with `ACUITY_SERVICE_CACHE_TTL_MS`
- modernize CI and publish workflows to `corepack`, `actions/cache@v5`, and `actions/setup-node@v6`
- document the new cache env var and browser/session model

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`