### PR TITLE
chore(release): align bridge runtime truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  PNPM_VERSION: 9.15.9
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -28,7 +31,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Typecheck
         run: pnpm typecheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,10 @@ on:
         type: boolean
         default: false
 
+env:
+  PNPM_VERSION: 9.15.9
+  DEFAULT_NODE_VERSION: '22'
+
 jobs:
   test:
     name: Test & Build
@@ -20,12 +24,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
           cache: 'pnpm'
-      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm build
 
@@ -41,14 +45,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
           scope: '@tummycrypt'
-      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Publish to npmjs.com
         env:
@@ -67,12 +71,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
           cache: 'pnpm'
-      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Configure GitHub Packages auth
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS
+
+## Purpose
+
+`acuity-middleware` publishes `@tummycrypt/scheduling-bridge`.
+
+This repo is the canonical owner of:
+
+- Acuity browser automation
+- the remote scheduling bridge protocol
+- Modal runtime execution for the Acuity path
+- bridge runtime health and release metadata
+
+It is not the owner of:
+
+- homegrown scheduling backend behavior
+- adopter-specific payment policy
+- site-specific booking UX
+
+## Cross-Repo Boundary
+
+### `scheduling-kit`
+
+Owns:
+
+- homegrown backend
+- shared scheduling and payment primitives
+- generic reusable UI components
+
+This repo must not absorb those concerns.
+
+### `MassageIthaca`
+
+Owns:
+
+- business settings
+- admin/operator UX
+- explicit site policy
+- composition of bridge and package contracts into public booking surfaces
+
+This repo must not require app-local shims to define Acuity behavior.
+
+## Hard Rules
+
+1. All Acuity scheduling semantics must be bridge-owned.
+2. Modal runtime truth must be visible enough for downstream rollout checks.
+3. Bazel metadata, package metadata, and runtime release metadata must not
+   drift.
+4. Downstream adopters must be able to assert the expected bridge version and
+   release tuple.
+
+## Current Reset State
+
+- Local Bazel metadata was aligned to package version `0.3.1`.
+- Modal deploy is still not a first-class CI/CD release unit.
+- The next required step is explicit bridge protocol and runtime release truth,
+  not more implicit rollout assumptions.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.3.0",
+    version = "0.3.2",
     visibility = ["//visibility:public"],
 )
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,17 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
 WORKDIR /app
 
 # Copy package files for dependency install
-COPY package.json ./
+COPY package.json pnpm-lock.yaml ./
 
-# Install production dependencies only (playwright comes from base image)
-RUN pnpm install --no-frozen-lockfile --prod
+# Install dependencies needed to build the dist/server/handler.js artifact
+RUN pnpm install --frozen-lockfile
 
 # Copy source
 COPY src/ ./src/
 COPY tsconfig.json ./
 
-# Pre-compile with tsx for faster startup
-RUN pnpm add tsx
+# Build the production server artifact, then prune devDependencies
+RUN pnpm build && pnpm prune --prod
 
 # Non-root user for security
 RUN useradd -m -s /bin/bash middleware
@@ -50,4 +50,4 @@ ENV PLAYWRIGHT_TIMEOUT=30000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3001/health', (r) => r.statusCode === 200 ? process.exit(0) : process.exit(1))"
 
-CMD ["node", "--import", "tsx/esm", "src/middleware/server.ts"]
+CMD ["node", "dist/server/handler.js"]

--- a/LLMS.txt
+++ b/LLMS.txt
@@ -1,0 +1,17 @@
+acuity-middleware / @tummycrypt/scheduling-bridge owns Acuity automation.
+
+Authoritative boundary:
+- Owns Acuity service/date/slot/booking automation semantics.
+- Owns the remote bridge protocol and Modal runtime behavior.
+- Does not own the homegrown backend or adopter-specific payment policy.
+
+Critical anti-duplication rules:
+- Do not let adopter apps redefine Acuity flow semantics.
+- Do not let Bazel metadata drift from package metadata.
+- Make runtime release truth visible enough for downstream rollout checks.
+
+Current reset state:
+- Package version is `0.3.1`.
+- Bazel metadata was aligned back to `0.3.1`.
+- Modal deployment is still separate from app deploy and must become part of a
+  truthful release tuple.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.3.0",
+    version = "0.3.2",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ An HTTP server wrapping Playwright wizard flows that automate the Acuity booking
 
 ```
 HTTP Request
-  -> server.ts (route matching, auth, JSON serialization)
+  -> server/handler.ts (route matching, auth, JSON serialization)
+    -> acuity-service-catalog.ts (static env catalog -> BUSINESS -> scraper fallback)
     -> steps/ (Effect TS programs for each wizard stage)
       -> browser-service.ts (Playwright lifecycle via Effect Layer)
         -> selectors.ts (CSS selector registry with fallback chains)
@@ -18,20 +19,21 @@ HTTP Request
 
 ### Key Components
 
-- **server.ts** -- Standalone Node.js HTTP server with Bearer token auth
+- **server/handler.ts** -- Standalone Node.js HTTP server with Bearer token auth
+- **acuity-service-catalog.ts** -- Shared service source order and cache for static config, BUSINESS extraction, and scraper fallback
 - **browser-service.ts** -- Effect TS Layer managing Playwright browser/page lifecycle
 - **acuity-wizard.ts** -- Full `SchedulingAdapter` implementation (local Playwright or remote HTTP proxy)
 - **remote-adapter.ts** -- HTTP client adapter for proxying to a remote middleware instance
 - **selectors.ts** -- Single source of truth for all Acuity DOM selectors
-- **steps/** -- Individual wizard step programs (navigate, fill-form, bypass-payment, submit, extract)
-- **acuity-scraper.ts** -- Read-only scraper for services, dates, and time slots
+- **steps/** -- Individual wizard step programs plus BUSINESS extraction helpers
+- **acuity-scraper.ts** -- Deprecated read fallback for services, dates, and time slots
 
 ## Endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/health` | Health check (no auth required) |
-| GET | `/services` | List all appointment types |
+| GET | `/services` | List appointment types via `SERVICES_JSON` -> BUSINESS -> scraper fallback |
 | GET | `/services/:id` | Get a specific service |
 | POST | `/availability/dates` | Available dates for a service |
 | POST | `/availability/slots` | Time slots for a specific date |
@@ -51,6 +53,7 @@ HTTP Request
 | `PLAYWRIGHT_TIMEOUT` | No | `30000` | Page operation timeout (ms) |
 | `CHROMIUM_EXECUTABLE_PATH` | No | -- | Custom Chromium path (for Lambda/serverless) |
 | `CHROMIUM_LAUNCH_ARGS` | No | -- | Comma-separated Chromium args |
+| `SERVICES_JSON` | No | -- | Optional static service catalog to bypass live Acuity reads |
 
 ## Deployment
 
@@ -58,9 +61,9 @@ HTTP Request
 
 ```bash
 pnpm install
-pnpm dev           # Development with tsx
+pnpm dev           # Development with tsx against src/server/handler.ts
 # or
-pnpm build && pnpm start  # Production
+pnpm build && pnpm start  # Production via dist/server/handler.js
 ```
 
 ### Docker
@@ -79,6 +82,7 @@ docker run -p 3001:3001 \
 ```bash
 # Set secrets in Modal dashboard first:
 #   AUTH_TOKEN, ACUITY_BASE_URL, ACUITY_BYPASS_COUPON
+# The Modal image builds the same dist/server/handler.js artifact used by pnpm start.
 modal deploy modal-app.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@ Backend-agnostic scheduling adapter hub. Currently bridges Acuity Scheduling via
 
 > Formerly `acuity-middleware`. The GitHub repo and npm package history retain the old name.
 
+## Ownership Boundary
+
+`@tummycrypt/scheduling-bridge` is the canonical owner of the Acuity path:
+
+- Acuity browser automation
+- service/date/slot/booking semantics for the Acuity backend
+- remote bridge protocol
+- Modal runtime behavior and release metadata
+
+It does **not** own:
+
+- the homegrown backend
+- adopter-specific payment policy
+- site-specific booking UX
+
+Those belong to:
+
+- `@tummycrypt/scheduling-kit` for the reusable homegrown scheduling platform
+- adopter apps such as `MassageIthaca` for explicit site policy and composition
+
 ## Architecture
 
 An HTTP server wrapping Playwright wizard flows that automate the Acuity booking UI. The bridge uses Effect TS for resource lifecycle management (browser/page acquisition and release).
@@ -85,6 +105,15 @@ docker run -p 3001:3001 \
 # The Modal image builds the same dist/server/handler.js artifact used by pnpm start.
 modal deploy modal-app.py
 ```
+
+Current truth: Modal deploy is still a separate release lane from package
+publish and adopter app deploy. Downstream apps must treat the live system as a
+release tuple:
+
+- app commit
+- consumed package versions
+- bridge package version
+- Modal release SHA
 
 ### Nix
 

--- a/modal-app.py
+++ b/modal-app.py
@@ -1,7 +1,7 @@
 """
-Modal Labs deployment for the scheduling middleware server.
+Modal Labs deployment for the scheduling bridge server.
 
-Runs the Node.js middleware server with Playwright + Chromium
+Runs the Node.js bridge server with Playwright + Chromium
 inside a Modal container with GPU-free compute.
 
 Usage:
@@ -38,24 +38,14 @@ image = (
         "apt-get clean && rm -rf /var/lib/apt/lists/*",
     )
     .add_local_file("package.json", "/app/package.json", copy=True)
+    .add_local_file("pnpm-lock.yaml", "/app/pnpm-lock.yaml", copy=True)
     .add_local_dir("src", "/app/src", copy=True)
     .add_local_file("tsconfig.json", "/app/tsconfig.json", copy=True)
     .run_commands(
-        # Install all deps then compile TS → JS with esbuild (bundler handles fp-ts resolution)
-        "cd /app && pnpm install --no-frozen-lockfile",
-        "cd /app && pnpm add esbuild",
-        # Bundle middleware server to a single JS file with all deps inlined
-        # External: playwright (runtime dep), tinyland-auth-pg (not used by middleware)
-        "cd /app && npx esbuild src/middleware/server.ts"
-        " --bundle --platform=node --format=esm --outfile=dist/server.mjs"
-        " --external:playwright-core --external:playwright"
-        " --external:@playwright/test"
-        " --external:@tummycrypt/tinyland-auth-pg"
-        " --external:@tummycrypt/tinyland-auth-pg/*"
-        " --external:@neondatabase/serverless"
-        " --external:drizzle-orm --external:drizzle-orm/*"
-        " --external:@skeletonlabs/* --external:svelte --external:svelte/*",
-        "ls -la /app/dist/server.mjs",
+        # Build the same dist/server/handler.js artifact used by pnpm start.
+        "cd /app && pnpm install --frozen-lockfile",
+        "cd /app && pnpm build",
+        "ls -la /app/dist/server/handler.js",
     )
 )
 
@@ -77,7 +67,7 @@ def server():
     import subprocess
 
     subprocess.Popen(
-        ["node", "dist/server.mjs"],
+        ["node", "dist/server/handler.js"],
         cwd="/app",
         env={
             **__import__("os").environ,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
@@ -38,9 +38,9 @@
     "paper:dev": "node docs/paper/watch.mjs"
   },
   "dependencies": {
-    "@tummycrypt/scheduling-kit": "^0.6.1",
+    "@tummycrypt/scheduling-kit": "^0.6.2",
     "playwright-core": "1.58.1",
-    "effect": "^3.19.14"
+    "effect": "^3.21.0"
   },
   "devDependencies": {
     "typescript": "^5.9.0",
@@ -53,7 +53,7 @@
   },
   "pnpm": {
     "overrides": {
-      "effect": "^3.19.14"
+      "effect": "^3.21.0"
     }
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.3.0",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
+  "packageManager": "pnpm@9.15.9",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Jesssullivan/acuity-middleware.git"
+    "url": "git+https://github.com/Jesssullivan/acuity-middleware.git"
   },
   "exports": {
     ".": {
@@ -37,7 +38,7 @@
     "paper:dev": "node docs/paper/watch.mjs"
   },
   "dependencies": {
-    "@tummycrypt/scheduling-kit": "^0.4.0",
+    "@tummycrypt/scheduling-kit": "^0.6.1",
     "playwright-core": "1.58.1",
     "effect": "^3.19.14"
   },
@@ -56,6 +57,6 @@
     }
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20 <25"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@tummycrypt/scheduling-kit':
-        specifier: ^0.4.0
-        version: 0.4.0(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)
+        specifier: ^0.6.1
+        version: 0.6.1(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)
       effect:
         specifier: ^3.19.14
         version: 3.21.0
@@ -347,8 +347,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@tummycrypt/scheduling-kit@0.4.0':
-    resolution: {integrity: sha512-VuhIbCx7+DtjajjuDZwK498IiDDQeOp6NZJL1cNN+9UzaexFbbxOEKBLiQm/U5p+QS5DeXU950Og8sM7GDk36Q==}
+  '@tummycrypt/scheduling-kit@0.6.1':
+    resolution: {integrity: sha512-5Plq6GMmeKjIFE/BqCOXfHBExVSLtrk0QpYws2rL2hRJWo+d4OPzMMO9MaVzgJdB33kDA5FBvInNG4fXe7T65g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@skeletonlabs/skeleton': ^4.0.0
@@ -1221,7 +1221,7 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tummycrypt/scheduling-kit@0.4.0(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)':
+  '@tummycrypt/scheduling-kit@0.6.1(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)':
     dependencies:
       '@tummycrypt/tinyland-auth-pg': 0.1.0(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)
       drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)

--- a/src/adapters/acuity/wizard.ts
+++ b/src/adapters/acuity/wizard.ts
@@ -18,15 +18,17 @@
 import { Effect, pipe } from 'effect';
 
 import type { SchedulingAdapter } from '../types.js';
-import { createScraperAdapter, type ScraperConfig } from './scraper.js';
+import type { ScraperConfig } from './scraper.js';
 import type {
 	Booking,
 	BookingRequest,
 	Service,
+	SchedulingError,
 	SchedulingResult,
 } from '../../core/types.js';
 import { Errors } from '../../core/types.js';
 import { BrowserServiceLive, type BrowserConfig, defaultBrowserConfig } from '../../shared/browser-service.js';
+import { createAcuityServiceCatalog } from '../../shared/acuity-service-catalog.js';
 import { toSchedulingError, type MiddlewareError } from './errors.js';
 import { createRemoteWizardAdapter, type RemoteAdapterConfig } from '../../shared/remote-adapter.js';
 import {
@@ -174,6 +176,17 @@ const createBookingProgram = (request: BookingRequest, serviceName?: string) =>
 		}),
 	);
 
+const isSchedulingError = (error: unknown): error is SchedulingError =>
+	typeof error === 'object' && error !== null && '_tag' in error;
+
+const toCatalogError = (error: unknown): SchedulingError =>
+	isSchedulingError(error)
+		? error
+		: Errors.infrastructure(
+				'UNKNOWN',
+				error instanceof Error ? error.message : 'Service catalog lookup failed',
+			);
+
 // =============================================================================
 // ADAPTER FACTORY
 // =============================================================================
@@ -181,7 +194,7 @@ const createBookingProgram = (request: BookingRequest, serviceName?: string) =>
 /**
  * Create a full SchedulingAdapter that puppeteers the Acuity wizard.
  *
- * Read operations delegate to the existing scraper.
+ * Read operations resolve through the shared Acuity service catalog.
  * Write operations use Effect TS middleware via Playwright.
  */
 export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdapter => {
@@ -215,10 +228,8 @@ export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdap
 			Effect.mapError(toSchedulingError),
 		);
 
-	// Static services from config (avoids browser launch for service listing)
 	const staticServices: Service[] | null = config.services ? [...config.services] : null;
 
-	// Scraper fallback for services if no static list provided
 	const scraperConfig: ScraperConfig = {
 		baseUrl: config.baseUrl,
 		headless: browserConfig.headless,
@@ -227,14 +238,12 @@ export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdap
 		executablePath: browserConfig.executablePath,
 		launchArgs: browserConfig.launchArgs ? [...browserConfig.launchArgs] : undefined,
 	};
-	const scraper = createScraperAdapter(scraperConfig);
-
-	// Cache services for getService lookups
-	let cachedServices: Service[] | null = staticServices;
-
-	// Helper: resolve service name from ID using cached services
-	const resolveServiceName = (serviceId: string): string | undefined =>
-		cachedServices?.find((s) => s.id === serviceId)?.name;
+	const serviceCatalog = createAcuityServiceCatalog({
+		baseUrl: config.baseUrl,
+		staticServices,
+		scraperConfig,
+		logger: console,
+	});
 
 	return {
 		name: 'acuity-wizard',
@@ -243,39 +252,24 @@ export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdap
 		// Read operations
 		// -----------------------------------------------------------------------
 
-		getServices: () => {
-			if (staticServices) {
-				return Effect.succeed(staticServices);
-			}
-			// Fallback to scraper (may fail with broken selectors)
-			return pipe(
-				scraper.getServices(),
-				Effect.tap((services) =>
-					Effect.sync(() => {
-						cachedServices = services;
-					}),
-				),
-			);
-		},
+		getServices: () =>
+			Effect.tryPromise({
+				try: () => serviceCatalog.getServices(),
+				catch: toCatalogError,
+			}),
 
-		getService: (serviceId: string) => {
-			if (cachedServices) {
-				const found = cachedServices.find((s) => s.id === serviceId);
-				return found
-					? Effect.succeed(found)
-					: Effect.fail(Errors.acuity('NOT_FOUND', `Service ${serviceId} not found`));
-			}
-			return pipe(
-				scraper.getServices(),
-				Effect.flatMap((services) => {
-					cachedServices = services;
-					const found = services.find((s) => s.id === serviceId);
-					return found
-						? Effect.succeed(found)
-						: Effect.fail(Errors.acuity('NOT_FOUND', `Service ${serviceId} not found`));
+		getService: (serviceId: string) =>
+			pipe(
+				Effect.tryPromise({
+					try: () => serviceCatalog.getService(serviceId),
+					catch: toCatalogError,
 				}),
-			);
-		},
+				Effect.flatMap((found) =>
+					found
+						? Effect.succeed(found)
+						: Effect.fail(Errors.acuity('NOT_FOUND', `Service ${serviceId} not found`)),
+				),
+			),
 
 		getProviders: () =>
 			Effect.succeed([
@@ -309,56 +303,59 @@ export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdap
 			]),
 
 		getAvailableDates: (params) => {
-			const serviceName = resolveServiceName(params.serviceId);
-			if (!serviceName) {
-				return Effect.fail(
-					Errors.acuity('NOT_FOUND', `Cannot resolve service name for ID ${params.serviceId}. Provide static services in config.`),
-				);
-			}
-			return runWizard(
-				Effect.scoped(
-					readAvailableDates({
-						serviceName,
-						// Don't pass appointmentTypeId — our internal IDs don't match Acuity URL IDs
-						targetMonth: params.startDate?.slice(0, 7),
-						monthsToScan: 2,
-					}),
-				) as Effect.Effect<Array<{ date: string; slots: number }>, MiddlewareError>,
+			return pipe(
+				Effect.tryPromise({
+					try: () => serviceCatalog.resolveServiceName(params.serviceId),
+					catch: toCatalogError,
+				}),
+				Effect.flatMap((serviceName) =>
+					runWizard(
+						Effect.scoped(
+							readAvailableDates({
+								serviceName,
+								targetMonth: params.startDate?.slice(0, 7),
+								monthsToScan: 2,
+							}),
+						) as Effect.Effect<Array<{ date: string; slots: number }>, MiddlewareError>,
+					),
+				),
 			);
 		},
 
 		getAvailableSlots: (params) => {
-			const serviceName = resolveServiceName(params.serviceId);
-			if (!serviceName) {
-				return Effect.fail(
-					Errors.acuity('NOT_FOUND', `Cannot resolve service name for ID ${params.serviceId}. Provide static services in config.`),
-				);
-			}
-			return runWizard(
-				Effect.scoped(
-					readTimeSlots({
-						serviceName,
-						date: params.date,
-					}),
-				) as Effect.Effect<Array<{ datetime: string; available: boolean }>, MiddlewareError>,
+			return pipe(
+				Effect.tryPromise({
+					try: () => serviceCatalog.resolveServiceName(params.serviceId),
+					catch: toCatalogError,
+				}),
+				Effect.flatMap((serviceName) =>
+					runWizard(
+						Effect.scoped(
+							readTimeSlots({
+								serviceName,
+								date: params.date,
+							}),
+						) as Effect.Effect<Array<{ datetime: string; available: boolean }>, MiddlewareError>,
+					),
+				),
 			);
 		},
 
 		checkSlotAvailability: (params) => {
-			const serviceName = resolveServiceName(params.serviceId);
-			if (!serviceName) {
-				return Effect.fail(
-					Errors.acuity('NOT_FOUND', `Cannot resolve service name for ID ${params.serviceId}`),
-				);
-			}
 			return pipe(
-				runWizard(
-					Effect.scoped(
-						readTimeSlots({
-							serviceName,
-							date: params.datetime.split('T')[0],
-						}),
-					) as Effect.Effect<Array<{ datetime: string; available: boolean }>, MiddlewareError>,
+				Effect.tryPromise({
+					try: () => serviceCatalog.resolveServiceName(params.serviceId),
+					catch: toCatalogError,
+				}),
+				Effect.flatMap((serviceName) =>
+					runWizard(
+						Effect.scoped(
+							readTimeSlots({
+								serviceName,
+								date: params.datetime.split('T')[0],
+							}),
+						) as Effect.Effect<Array<{ datetime: string; available: boolean }>, MiddlewareError>,
+					),
 				),
 				Effect.map((slots) => {
 					// Slots return local time (no TZ suffix: "2026-03-07T14:00:00").
@@ -390,7 +387,7 @@ export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdap
 		// -----------------------------------------------------------------------
 
 		createBooking: (request) => {
-			const serviceName = cachedServices?.find((s) => s.id === request.serviceId)?.name;
+			const serviceName = serviceCatalog.getCachedService(request.serviceId)?.name;
 			return runWizard(
 				createBookingProgram(request, serviceName) as Effect.Effect<Booking, MiddlewareError>,
 			);
@@ -398,7 +395,7 @@ export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdap
 
 		createBookingWithPaymentRef: (request, paymentRef, paymentProcessor) => {
 			const coupon = config.couponCode ?? generateCouponCode(paymentRef, paymentProcessor);
-			const service = cachedServices?.find((s) => s.id === request.serviceId);
+			const service = serviceCatalog.getCachedService(request.serviceId);
 
 			return runWizard(
 				createBookingWithPaymentRefProgram(

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /**
  * Entry point - re-exports the middleware HTTP server.
- * When run directly, the server auto-starts (see middleware/server.ts).
+ * The runnable server implementation lives in src/server/handler.ts.
  */
 export { server } from './server/handler.js';

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -7,7 +7,7 @@
  *
  * Endpoints:
  *   GET  /health                    - Health check
- *   GET  /services                  - List services (scraper)
+ *   GET  /services                  - List services (static/BUSINESS/scraper)
  *   GET  /services/:id              - Get service by ID
  *   POST /availability/dates        - Available dates for a service
  *   POST /availability/slots        - Time slots for a date
@@ -31,8 +31,12 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { Effect, Exit, Cause, Scope } from 'effect';
-import { createScraperAdapter, type ScraperConfig } from '../adapters/acuity/scraper.js';
+import type { ScraperConfig } from '../adapters/acuity/scraper.js';
 import { BrowserService, BrowserServiceLive, type BrowserConfig, defaultBrowserConfig } from '../shared/browser-service.js';
+import {
+	createAcuityServiceCatalog,
+	parseStaticServicesJson,
+} from '../shared/acuity-service-catalog.js';
 import { toSchedulingError, type MiddlewareError } from '../adapters/acuity/errors.js';
 import {
 	navigateToBooking,
@@ -44,8 +48,6 @@ import {
 	toBooking,
 	readAvailableDates,
 	readTimeSlots,
-	fetchBusinessData,
-	businessToServices,
 } from '../adapters/acuity/steps/index.js';
 import type {
 	Booking,
@@ -150,80 +152,26 @@ const runEffect = async <A>(
 	return { ok: false, error: { _tag: 'InfrastructureError', code: 'UNKNOWN', message: Cause.pretty(exit.cause) } };
 };
 
-/** Run a SchedulingResult (Effect) and return Result */
-const runSchedulingEffect = async <A>(
-	effect: Effect.Effect<A, SchedulingError>,
-): Promise<Result<A>> => {
-	const exit = await Effect.runPromiseExit(effect);
-	if (Exit.isSuccess(exit)) {
-		return { ok: true, value: exit.value };
-	}
-	const failure = Cause.failureOption(exit.cause);
-	if (failure._tag === 'Some') {
-		return { ok: false, error: failure.value };
-	}
-	return { ok: false, error: { _tag: 'InfrastructureError', code: 'UNKNOWN', message: Cause.pretty(exit.cause) } };
-};
+const serviceCatalog = createAcuityServiceCatalog({
+	baseUrl: ACUITY_BASE_URL,
+	staticServices: parseStaticServicesJson(process.env.SERVICES_JSON),
+	scraperConfig,
+	logger: console,
+});
 
-// =============================================================================
-// SCRAPER (cached)
-// =============================================================================
+const isSchedulingError = (error: unknown): error is SchedulingError =>
+	typeof error === 'object' && error !== null && '_tag' in error;
 
-let scraper: ReturnType<typeof createScraperAdapter> | null = null;
-
-const getScraper = () => {
-	if (!scraper) {
-		scraper = createScraperAdapter(scraperConfig);
-	}
-	return scraper;
-};
-
-let cachedServices: Service[] | null = null;
-
-// Static services from SERVICES_JSON env var (avoids scraper dependency)
-const STATIC_SERVICES: Service[] | null = (() => {
-	const raw = process.env.SERVICES_JSON;
-	if (!raw) return null;
-	try {
-		return JSON.parse(raw) as Service[];
-	} catch (e) {
-		console.error('[middleware-server] Failed to parse SERVICES_JSON:', e);
-		return null;
-	}
-})();
-
-if (STATIC_SERVICES) {
-	cachedServices = STATIC_SERVICES;
-	console.log(`[middleware-server] Loaded ${STATIC_SERVICES.length} static services from SERVICES_JSON`);
-}
-
-// =============================================================================
-// SERVICE NAME RESOLUTION
-// =============================================================================
-
-/**
- * Resolve a service ID to its display name for wizard navigation.
- * Ensures cachedServices is populated (via BUSINESS extraction) before lookup.
- * Rejects numeric-only serviceName (remote adapter fallback) and resolves from cache.
- */
 const resolveServiceName = async (serviceId: string, serviceName?: string): Promise<string> => {
-	// If caller provided a real (non-numeric) name, use it
-	if (serviceName && !/^\d+$/.test(serviceName)) return serviceName;
-
-	// Ensure services are cached
-	if (!cachedServices) {
-		try {
-			const business = await fetchBusinessData(ACUITY_BASE_URL);
-			if (business) {
-				cachedServices = businessToServices(business);
-				console.log(`[resolve] Warmed service cache: ${cachedServices.length} services`);
-			}
-		} catch (e) {
-			console.warn('[resolve] Service cache warm failed:', e instanceof Error ? e.message : e);
-		}
+	try {
+		return await serviceCatalog.resolveServiceName(serviceId, serviceName);
+	} catch (error) {
+		console.warn(
+			`[middleware-server] Service name resolution failed for ${serviceId}:`,
+			error,
+		);
+		return serviceName && !/^\d+$/.test(serviceName) ? serviceName : serviceId;
 	}
-
-	return cachedServices?.find((s) => s.id === serviceId)?.name ?? serviceId;
 };
 
 // =============================================================================
@@ -236,74 +184,54 @@ const handleHealth = (_req: IncomingMessage, res: ServerResponse) => {
 		baseUrl: ACUITY_BASE_URL,
 		hasCoupon: !!COUPON_CODE,
 		headless: browserConfig.headless,
-		staticServices: STATIC_SERVICES ? STATIC_SERVICES.length : 0,
+		staticServices: serviceCatalog.staticServicesCount,
 		timestamp: new Date().toISOString(),
 	});
 };
 
 
 const handleGetServices = async (_req: IncomingMessage, res: ServerResponse) => {
-	// 1. Prefer static services from env (always reliable, no network needed)
-	if (STATIC_SERVICES) {
-		console.log('[services] source: SERVICES_JSON env');
-		cachedServices = STATIC_SERVICES;
-		return sendSuccess(res, STATIC_SERVICES);
-	}
-
-	// 2. Extract from BUSINESS object (HTTP fetch + regex, no browser)
 	try {
-		const business = await fetchBusinessData(ACUITY_BASE_URL);
-		if (business) {
-			const services = businessToServices(business);
-			if (services.length > 0) {
-				console.log(`[services] source: BUSINESS object (${services.length} services)`);
-				cachedServices = services;
-				return sendSuccess(res, services);
-			}
-			console.warn('[services] BUSINESS object found but 0 active services');
+		const services = await serviceCatalog.getServices();
+		sendSuccess(res, services);
+	} catch (error) {
+		if (isSchedulingError(error)) {
+			return sendError(res, 500, error);
 		}
-	} catch (e) {
-		console.warn('[services] BUSINESS extraction failed:', e instanceof Error ? e.message : e);
+		return sendJson(res, 500, {
+			success: false,
+			error: {
+				tag: 'InfrastructureError',
+				code: 'UNKNOWN',
+				message: error instanceof Error ? error.message : 'Service lookup failed',
+			},
+		});
 	}
-
-	// 3. Deprecated fallback: DOM scraper (may return [] — Acuity is React SPA)
-	console.warn('[services] falling back to DOM scraper (deprecated)');
-	const result = await runSchedulingEffect(getScraper().getServices());
-	if (!result.ok) return sendError(res, 500, result.error);
-	if (result.value.length === 0) {
-		console.error('[services] all sources exhausted — returning empty []');
-	}
-	cachedServices = result.value;
-	sendSuccess(res, result.value);
 };
 
 const handleGetService = async (serviceId: string, res: ServerResponse) => {
-	if (!cachedServices) {
-		// Prefer BUSINESS extraction (HTTP, no browser) over DOM scraper
-		try {
-			const business = await fetchBusinessData(ACUITY_BASE_URL);
-			if (business) {
-				cachedServices = businessToServices(business);
-				console.log(`[service] Warmed cache via BUSINESS: ${cachedServices.length} services`);
-			}
-		} catch (e) {
-			console.warn('[service] BUSINESS extraction failed:', e instanceof Error ? e.message : e);
+	try {
+		const found = await serviceCatalog.getService(serviceId);
+		if (!found) {
+			return sendJson(res, 404, {
+				success: false,
+				error: { tag: 'AcuityError', code: 'NOT_FOUND', message: `Service ${serviceId} not found` },
+			});
 		}
-		// Fallback to scraper if BUSINESS failed
-		if (!cachedServices) {
-			const result = await runSchedulingEffect(getScraper().getServices());
-			if (!result.ok) return sendError(res, 500, result.error);
-			cachedServices = result.value;
+		sendSuccess(res, found);
+	} catch (error) {
+		if (isSchedulingError(error)) {
+			return sendError(res, 500, error);
 		}
-	}
-	const found = cachedServices!.find((s) => s.id === serviceId);
-	if (!found) {
-		return sendJson(res, 404, {
+		return sendJson(res, 500, {
 			success: false,
-			error: { tag: 'AcuityError', code: 'NOT_FOUND', message: `Service ${serviceId} not found` },
+			error: {
+				tag: 'InfrastructureError',
+				code: 'UNKNOWN',
+				message: error instanceof Error ? error.message : 'Service lookup failed',
+			},
 		});
 	}
-	sendSuccess(res, found);
 };
 
 const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse) => {
@@ -421,7 +349,7 @@ const handleCreateBookingWithPayment = async (req: IncomingMessage, res: ServerR
 	}
 
 	const serviceName = await resolveServiceName(request.serviceId);
-	const service = cachedServices?.find((s) => s.id === request.serviceId);
+	const service = serviceCatalog.getCachedService(request.serviceId);
 
 	const result = await runEffect(
 		Effect.gen(function* () {

--- a/src/shared/__tests__/acuity-service-catalog.test.ts
+++ b/src/shared/__tests__/acuity-service-catalog.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	createAcuityServiceCatalog,
+	parseStaticServicesJson,
+	type ServiceCatalogLogger,
+} from '../acuity-service-catalog.js';
+import type { Service } from '../../core/types.js';
+import type { AcuityBusinessData } from '../../adapters/acuity/steps/index.js';
+
+const services: Service[] = [
+	{
+		id: 'svc-1',
+		name: 'Urgent Care Massage',
+		duration: 60,
+		price: 15500,
+		currency: 'USD',
+		category: 'Urgent Care',
+		active: true,
+	},
+	{
+		id: 'svc-2',
+		name: 'TMD Tuneup',
+		duration: 75,
+		price: 18500,
+		currency: 'USD',
+		category: 'TMD',
+		active: true,
+	},
+];
+
+const makeLogger = (): Required<ServiceCatalogLogger> => ({
+	log: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+});
+
+describe('parseStaticServicesJson', () => {
+	it('returns null and logs when SERVICES_JSON is invalid', () => {
+		const logger = makeLogger();
+		const result = parseStaticServicesJson('{not-json', logger);
+
+		expect(result).toBeNull();
+		expect(logger.error).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('createAcuityServiceCatalog', () => {
+	it('uses static services without touching live loaders', async () => {
+		const fetchBusiness = vi.fn();
+		const loadScraperServices = vi.fn();
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://example.com',
+			staticServices: services,
+			fetchBusinessData: fetchBusiness,
+			loadScraperServices,
+			logger: makeLogger(),
+		});
+
+		await expect(catalog.getServices()).resolves.toEqual(services);
+		await expect(catalog.getService('svc-2')).resolves.toEqual(services[1]);
+		await expect(catalog.resolveServiceName('svc-1')).resolves.toBe('Urgent Care Massage');
+		expect(fetchBusiness).not.toHaveBeenCalled();
+		expect(loadScraperServices).not.toHaveBeenCalled();
+	});
+
+	it('deduplicates concurrent live loads and caches the result', async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const fetchBusinessData = vi.fn(async () => {
+			await gate;
+			return {} as AcuityBusinessData;
+		});
+		const businessToServices = vi.fn(() => services);
+		const loadScraperServices = vi.fn();
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://example.com',
+			fetchBusinessData,
+			businessToServices,
+			loadScraperServices,
+			logger: makeLogger(),
+		});
+
+		const pending = Promise.all([catalog.getServices(), catalog.getServices()]);
+		release();
+
+		await expect(pending).resolves.toEqual([services, services]);
+		expect(fetchBusinessData).toHaveBeenCalledTimes(1);
+		expect(businessToServices).toHaveBeenCalledTimes(1);
+		expect(loadScraperServices).not.toHaveBeenCalled();
+		expect(catalog.getCachedService('svc-1')).toEqual(services[0]);
+	});
+
+	it('falls back to scraper services when BUSINESS is unavailable', async () => {
+		const loadScraperServices = vi.fn(async () => services);
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://example.com',
+			fetchBusinessData: vi.fn(async () => null),
+			loadScraperServices,
+			logger: makeLogger(),
+		});
+
+		await expect(catalog.getServices()).resolves.toEqual(services);
+		await expect(catalog.resolveServiceName('svc-2')).resolves.toBe('TMD Tuneup');
+		expect(loadScraperServices).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/shared/acuity-service-catalog.ts
+++ b/src/shared/acuity-service-catalog.ts
@@ -1,0 +1,187 @@
+import { Cause, Effect, Exit } from 'effect';
+import { createScraperAdapter, type ScraperConfig } from '../adapters/acuity/scraper.js';
+import {
+	businessToServices,
+	fetchBusinessData,
+	type AcuityBusinessData,
+} from '../adapters/acuity/steps/index.js';
+import { Errors, type SchedulingError, type Service } from '../core/types.js';
+
+export interface ServiceCatalogLogger {
+	readonly log?: (...args: unknown[]) => void;
+	readonly warn?: (...args: unknown[]) => void;
+	readonly error?: (...args: unknown[]) => void;
+}
+
+export interface AcuityServiceCatalog {
+	readonly staticServicesCount: number;
+	readonly getServices: () => Promise<Service[]>;
+	readonly getService: (serviceId: string) => Promise<Service | null>;
+	readonly getCachedService: (serviceId: string) => Service | undefined;
+	readonly resolveServiceName: (serviceId: string, serviceName?: string) => Promise<string>;
+}
+
+export interface AcuityServiceCatalogConfig {
+	readonly baseUrl: string;
+	readonly staticServices?: readonly Service[] | null;
+	readonly scraperConfig?: ScraperConfig;
+	readonly logger?: ServiceCatalogLogger;
+	readonly fetchBusinessData?: (baseUrl: string) => Promise<AcuityBusinessData | null>;
+	readonly businessToServices?: (business: AcuityBusinessData) => Service[];
+	readonly loadScraperServices?: () => Promise<readonly Service[]>;
+}
+
+const cloneService = (service: Service): Service => ({ ...service });
+
+const cloneServices = (services: readonly Service[]): Service[] =>
+	services.map(cloneService);
+
+const describeError = (error: unknown): string =>
+	error instanceof Error ? error.message : String(error);
+
+export const parseStaticServicesJson = (
+	raw: string | undefined,
+	logger: ServiceCatalogLogger = console,
+): Service[] | null => {
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as Service[];
+	} catch (error) {
+		logger.error?.(
+			`[acuity-service-catalog] Failed to parse SERVICES_JSON: ${describeError(error)}`,
+		);
+		return null;
+	}
+};
+
+const isNonNumericServiceName = (serviceName?: string): serviceName is string =>
+	!!serviceName && !/^\d+$/.test(serviceName);
+
+export const createAcuityServiceCatalog = (
+	config: AcuityServiceCatalogConfig,
+): AcuityServiceCatalog => {
+	const logger = config.logger ?? console;
+	const staticServices = config.staticServices ? cloneServices(config.staticServices) : null;
+	const fetchBusinessDataImpl = config.fetchBusinessData ?? fetchBusinessData;
+	const businessToServicesImpl = config.businessToServices ?? businessToServices;
+	const injectedScraperLoader = config.loadScraperServices;
+
+	let scraper: ReturnType<typeof createScraperAdapter> | null = null;
+	let cachedServices: Service[] | null = staticServices;
+	let loadInFlight: Promise<Service[]> | null = null;
+
+	if (staticServices) {
+		logger.log?.(
+			`[acuity-service-catalog] Loaded ${staticServices.length} static services`,
+		);
+	}
+
+	const setCachedServices = (services: readonly Service[]): Service[] => {
+		cachedServices = cloneServices(services);
+		return cachedServices;
+	};
+
+	const loadBusinessServices = async (): Promise<Service[] | null> => {
+		try {
+			const business = await fetchBusinessDataImpl(config.baseUrl);
+			if (!business) return null;
+
+			const services = businessToServicesImpl(business);
+			if (services.length === 0) {
+				logger.warn?.(
+					'[acuity-service-catalog] BUSINESS object found but 0 active services',
+				);
+				return null;
+			}
+
+			logger.log?.(
+				`[acuity-service-catalog] Loaded ${services.length} services from BUSINESS`,
+			);
+			return cloneServices(services);
+		} catch (error) {
+			logger.warn?.(
+				`[acuity-service-catalog] BUSINESS extraction failed: ${describeError(error)}`,
+			);
+			return null;
+		}
+	};
+
+	const loadScraperServices = injectedScraperLoader
+		? async () => cloneServices(await injectedScraperLoader())
+		: async () => {
+				if (!config.scraperConfig) {
+					throw Errors.infrastructure(
+						'UNKNOWN',
+						'Scraper config is required when no loadScraperServices override is provided',
+					);
+				}
+
+				if (!scraper) {
+					scraper = createScraperAdapter(config.scraperConfig);
+				}
+
+				const exit = await Effect.runPromiseExit(scraper.getServices());
+				if (Exit.isSuccess(exit)) {
+					return cloneServices(exit.value);
+				}
+
+				const failure = Cause.failureOption(exit.cause);
+				if (failure._tag === 'Some') {
+					throw failure.value;
+				}
+
+				throw Errors.infrastructure('UNKNOWN', Cause.pretty(exit.cause));
+			};
+
+	const refreshServices = async (): Promise<Service[]> => {
+		if (staticServices) {
+			return cloneServices(staticServices);
+		}
+
+		const liveServices = await loadBusinessServices();
+		if (liveServices) {
+			return cloneServices(setCachedServices(liveServices));
+		}
+
+		const fallbackServices = await loadScraperServices();
+		if (fallbackServices.length === 0) {
+			logger.error?.(
+				'[acuity-service-catalog] All service sources exhausted; returning empty catalog',
+			);
+		}
+		return cloneServices(setCachedServices(fallbackServices));
+	};
+
+	const runRefresh = async (): Promise<Service[]> => {
+		if (!loadInFlight) {
+			loadInFlight = refreshServices().finally(() => {
+				loadInFlight = null;
+			});
+		}
+		return cloneServices(await loadInFlight);
+	};
+
+	const ensureServices = async (): Promise<Service[]> =>
+		cachedServices ? cloneServices(cachedServices) : runRefresh();
+
+	return {
+		staticServicesCount: staticServices?.length ?? 0,
+		getServices: () => runRefresh(),
+		getService: async (serviceId) => {
+			const services = await ensureServices();
+			return services.find((service) => service.id === serviceId) ?? null;
+		},
+		getCachedService: (serviceId) => {
+			const service = cachedServices?.find((candidate) => candidate.id === serviceId);
+			return service ? cloneService(service) : undefined;
+		},
+		resolveServiceName: async (serviceId, serviceName) => {
+			if (isNonNumericServiceName(serviceName)) {
+				return serviceName;
+			}
+
+			const services = await ensureServices();
+			return services.find((service) => service.id === serviceId)?.name ?? serviceId;
+		},
+	};
+};


### PR DESCRIPTION
## Summary
- align package metadata and Bazel metadata on `@tummycrypt/scheduling-bridge@0.3.2`
- update bridge dependencies to `@tummycrypt/scheduling-kit@^0.6.2` and `effect@^3.21.0`
- add repo-boundary docs (`AGENTS.md`, `LLMS.txt`) and tighten README around release-tuple truth

## Why
This is part of the cross-repo contract reset. The bridge repo must make its package/runtime truth explicit so the app can verify the real release tuple instead of relying on branch names or memory.

## Validation
- `pnpm typecheck`
- `pnpm build`
- `npm publish --access public --dry-run`

Refs: #21 #23