### PR TITLE
feat: extractCapabilities for PaymentCapabilities contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,0 +1,97 @@
+/**
+ * Payment capability extraction from practitioner settings and platform env vars.
+ *
+ * This is the canonical extraction logic used by downstream booking surfaces
+ * to produce consistent payment method availability.
+ */
+
+// TODO: import from @tummycrypt/scheduling-kit/payments once 0.7.0 is published
+interface PaymentMethodOption {
+  readonly id: string;
+  readonly name: string;
+  readonly displayName: string;
+  readonly icon?: string;
+  readonly description?: string;
+  readonly available: boolean;
+  readonly processingFee?: number;
+  readonly processingFeePercent?: number;
+}
+
+interface StripeCapability {
+  readonly available: boolean;
+  readonly publishableKey: string;
+  readonly connectedAccountId?: string;
+}
+
+interface VenmoCapability {
+  readonly available: boolean;
+  readonly clientId: string;
+  readonly environment: 'sandbox' | 'production';
+}
+
+interface PaymentCapabilities {
+  readonly methods: PaymentMethodOption[];
+  readonly stripe: StripeCapability | null;
+  readonly venmo: VenmoCapability | null;
+  readonly cash: false;
+}
+
+/**
+ * Extract payment capabilities from practitioner settings and platform env vars.
+ *
+ * Priority hierarchy: practitioner settings (DB) > platform env vars > disabled.
+ * Cash at Visit is structurally excluded (cash: false).
+ *
+ * @param settings - Practitioner-specific settings from database
+ * @param env - Platform environment variables
+ * @returns PaymentCapabilities contract for booking surfaces
+ */
+export const extractCapabilities = (
+  settings: Record<string, string>,
+  env: Record<string, string>,
+): PaymentCapabilities => {
+  const methods: PaymentMethodOption[] = [];
+
+  // --- Stripe ---
+  const stripeKey = settings.stripe_publishable_key || env.PUBLIC_STRIPE_PUBLISHABLE_KEY || '';
+  const stripeConnectId = settings.stripe_connect_account_id || env.STRIPE_CONNECT_ACCOUNT_ID || '';
+  let stripe: StripeCapability | null = null;
+
+  if (stripeKey) {
+    stripe = {
+      available: true,
+      publishableKey: stripeKey,
+      ...(stripeConnectId ? { connectedAccountId: stripeConnectId } : {}),
+    };
+    methods.push({
+      id: 'card',
+      name: 'card',
+      displayName: 'Credit/Debit Card',
+      icon: 'card',
+      available: true,
+    });
+  }
+
+  // --- Venmo/PayPal ---
+  const paypalClientId = env.PUBLIC_PAYPAL_CLIENT_ID || '';
+  const payeeEmail = settings.paypal_payee_email || env.PAYPAL_PAYEE_EMAIL || '';
+  const paypalEnv: 'sandbox' | 'production' = env.PAYPAL_ENVIRONMENT === 'production' ? 'production' : 'sandbox';
+  let venmo: VenmoCapability | null = null;
+
+  if (paypalClientId && payeeEmail) {
+    venmo = {
+      available: true,
+      clientId: paypalClientId,
+      environment: paypalEnv,
+    };
+    methods.push({
+      id: 'venmo',
+      name: 'venmo',
+      displayName: 'Venmo',
+      icon: 'venmo',
+      available: true,
+    });
+  }
+
+  return { methods, stripe, venmo, cash: false };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,3 +81,6 @@ export {
 
 // Server
 export { server } from './server/handler.js';
+
+// Payment capabilities extraction
+export { extractCapabilities } from './capabilities.js';

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { extractCapabilities } from '../src/capabilities.js';
+
+describe('extractCapabilities', () => {
+  it('should return empty capabilities when nothing is configured', () => {
+    const caps = extractCapabilities({}, {});
+    expect(caps.methods).toEqual([]);
+    expect(caps.stripe).toBeNull();
+    expect(caps.venmo).toBeNull();
+    expect(caps.cash).toBe(false);
+  });
+
+  it('should detect Stripe from practitioner settings', () => {
+    const settings = { stripe_publishable_key: 'pk_test_123' };
+    const caps = extractCapabilities(settings, {});
+    expect(caps.stripe).not.toBeNull();
+    expect(caps.stripe!.available).toBe(true);
+    expect(caps.stripe!.publishableKey).toBe('pk_test_123');
+    expect(caps.methods).toContainEqual(expect.objectContaining({ id: 'card', available: true }));
+  });
+
+  it('should detect Stripe from env var fallback', () => {
+    const env = { PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_test_env' };
+    const caps = extractCapabilities({}, env);
+    expect(caps.stripe!.publishableKey).toBe('pk_test_env');
+  });
+
+  it('should prefer practitioner settings over env vars for Stripe', () => {
+    const settings = { stripe_publishable_key: 'pk_practitioner' };
+    const env = { PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_platform' };
+    const caps = extractCapabilities(settings, env);
+    expect(caps.stripe!.publishableKey).toBe('pk_practitioner');
+  });
+
+  it('should detect Venmo when client ID and payee email both exist', () => {
+    const settings = { paypal_payee_email: 'jen@example.com' };
+    const env = { PUBLIC_PAYPAL_CLIENT_ID: 'paypal_123', PAYPAL_ENVIRONMENT: 'sandbox' };
+    const caps = extractCapabilities(settings, env);
+    expect(caps.venmo).not.toBeNull();
+    expect(caps.venmo!.available).toBe(true);
+    expect(caps.venmo!.clientId).toBe('paypal_123');
+    expect(caps.venmo!.environment).toBe('sandbox');
+    expect(caps.methods).toContainEqual(expect.objectContaining({ id: 'venmo', available: true }));
+  });
+
+  it('should NOT enable Venmo when payee email is missing', () => {
+    const env = { PUBLIC_PAYPAL_CLIENT_ID: 'paypal_123' };
+    const caps = extractCapabilities({}, env);
+    expect(caps.venmo).toBeNull();
+    expect(caps.methods).not.toContainEqual(expect.objectContaining({ id: 'venmo' }));
+  });
+
+  it('should return both Stripe and Venmo when both configured', () => {
+    const settings = {
+      stripe_publishable_key: 'pk_test_123',
+      paypal_payee_email: 'jen@example.com',
+    };
+    const env = { PUBLIC_PAYPAL_CLIENT_ID: 'paypal_123', PAYPAL_ENVIRONMENT: 'production' };
+    const caps = extractCapabilities(settings, env);
+    expect(caps.stripe!.available).toBe(true);
+    expect(caps.venmo!.available).toBe(true);
+    expect(caps.venmo!.environment).toBe('production');
+    expect(caps.methods).toHaveLength(2);
+  });
+
+  it('should never enable cash', () => {
+    const settings = { allow_cash: 'true', cash_enabled: 'true' };
+    const caps = extractCapabilities(settings, {});
+    expect(caps.cash).toBe(false);
+    expect(caps.methods).not.toContainEqual(expect.objectContaining({ id: 'cash' }));
+  });
+
+  it('should include connected account ID when available', () => {
+    const settings = {
+      stripe_publishable_key: 'pk_test_123',
+      stripe_connect_account_id: 'acct_123',
+    };
+    const caps = extractCapabilities(settings, {});
+    expect(caps.stripe!.connectedAccountId).toBe('acct_123');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['src/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
+		include: ['src/**/*.test.ts', 'src/**/__tests__/**/*.test.ts', 'tests/**/*.test.ts'],
 		environment: 'node',
 		globals: true,
 		testTimeout: 10000,


### PR DESCRIPTION
## Summary

- New `extractCapabilities(settings, env)` function in `src/capabilities.ts`
- Converts practitioner DB settings + platform env vars into `PaymentCapabilities` contract
- Priority hierarchy: practitioner settings > env vars > disabled
- Cash at Visit structurally excluded (`cash: false`)
- Bump to 0.4.0

## Test Plan

- [x] `pnpm vitest run` — 85 tests pass (6 files)
- [x] `pnpm build` — clean tsc build
- [x] 9 capability extraction tests: empty, Stripe, Venmo, priority, cash exclusion

## Downstream

- MassageIthaca PR #122 consumes this release (TIN-85, TIN-97)
- Depends on scheduling-kit@0.7.0 types (currently using local type defs)