### PR TITLE
[codex] align bridge package truth with scheduling-kit 0.7.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
       - run: pnpm install --frozen-lockfile
+      - name: Validate Bazel package artifact
+        run: npx --yes @bazel/bazelisk build //:pkg
       - run: pnpm typecheck
       - run: pnpm build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,11 +33,17 @@ That makes this repo central to the migration paper and to the operational beta-
 
 ## Current Tracking
 
-As of `2026-04-13`, the open production-focused work here is:
+As of `2026-04-15`, the active structural work here is:
 
-- milestone: `Sprint T: Remote Acuity Performance & Release Control`
-- issue: `#20` remaining tail-latency/perf follow-through
-- issue: `#21` Modal release control in app promotion flow
+- `TIN-101` mini sprint: toolchain authority and hermetic package convergence
+- `TIN-104` adopt Bazel-built artifact truth in package publish lanes
+- package dependency convergence with `@tummycrypt/scheduling-kit 0.7.x`
+
+Operationally relevant truth:
+
+- the current published bridge line is `0.4.0`
+- the local convergence branch `fix/bridge-kit-070` bumps metadata to `0.4.1`
+- that branch aligns the bridge dependency on `@tummycrypt/scheduling-kit ^0.7.0`
 
 ## Deployment Truth
 
@@ -67,6 +73,11 @@ That means:
 - a new bridge release can affect beta without any matching app deploy
 
 Any promotion analysis must explicitly check bridge release identity and health.
+
+Package graph rule:
+
+- do not let bridge metadata lag behind the `scheduling-kit` version actually
+  required by downstream apps
 
 ## Architecture Notes
 
@@ -133,6 +144,10 @@ Current publish flow targets:
 
 The repo name is still `acuity-middleware`, but the package name is `scheduling-bridge`. Preserve that distinction.
 
+Today, the publish lane is still pnpm/npm-first. Bazel metadata exists, but it
+is not yet the artifact authority. `TIN-104` exists to change that deliberately
+rather than by implication.
+
 ## Important Files
 
 - `src/server/handler.ts`
@@ -151,3 +166,5 @@ The repo name is still `acuity-middleware`, but the package name is `scheduling-
 - Do not reintroduce singleton-page contention without a compelling measured reason.
 - Do not hide false-empty availability behavior behind silent caches.
 - Do not confuse this repo with the reusable UI/package layer.
+- Do not let the bridge package declare stale `scheduling-kit` dependencies
+  while downstream apps have already moved on.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.3.0",
+    version = "0.4.1",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.3.0",
+    version = "0.4.1",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,29 @@ pnpm install
 pnpm dev
 ```
 
+## Release Authority
+
+Current reality:
+
+- the functional release repo is `Jesssullivan/acuity-middleware`
+- npm publication targets `@tummycrypt/scheduling-bridge`
+- GitHub Packages publication targets `@jesssullivan/scheduling-bridge`
+
+Current convergence work:
+
+- local branch `fix/bridge-kit-070`
+- package metadata bump to `0.4.1`
+- dependency alignment to `@tummycrypt/scheduling-kit ^0.7.0`
+
+Longer term, the intended publish shape is:
+
+1. release metadata declared once
+2. Bazel validates/builds the publishable artifact
+3. GitHub Actions publishes that artifact
+4. downstream apps consume only the published package
+
+That is not fully true yet. Today the publish lane is still pnpm/npm-first.
+
 ## Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
@@ -38,7 +38,7 @@
     "paper:dev": "node docs/paper/watch.mjs"
   },
   "dependencies": {
-    "@tummycrypt/scheduling-kit": "^0.6.1",
+    "@tummycrypt/scheduling-kit": "^0.7.0",
     "playwright-core": "1.58.1",
     "effect": "^3.19.14"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@tummycrypt/scheduling-kit':
-        specifier: ^0.6.1
-        version: 0.6.1(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)
+        specifier: ^0.7.0
+        version: 0.7.0(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)
       effect:
         specifier: ^3.19.14
         version: 3.21.0
@@ -347,9 +347,9 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@tummycrypt/scheduling-kit@0.6.1':
-    resolution: {integrity: sha512-5Plq6GMmeKjIFE/BqCOXfHBExVSLtrk0QpYws2rL2hRJWo+d4OPzMMO9MaVzgJdB33kDA5FBvInNG4fXe7T65g==}
-    engines: {node: '>=20.0.0'}
+  '@tummycrypt/scheduling-kit@0.7.0':
+    resolution: {integrity: sha512-+WE3UrzL7Gam2sJOLF34evxsBszcUkGJodzQbUIOipz9Jgar3G3I518Jgy22cHWxhDa4ZKpXDwJ3Pj6HpiscNw==}
+    engines: {node: '>=20 <25'}
     peerDependencies:
       '@skeletonlabs/skeleton': ^4.0.0
       '@skeletonlabs/skeleton-svelte': ^4.0.0
@@ -360,8 +360,8 @@ packages:
       '@skeletonlabs/skeleton-svelte':
         optional: true
 
-  '@tummycrypt/tinyland-auth-pg@0.1.0':
-    resolution: {integrity: sha512-FH+2xb/yXOFXVxGB59xpzkttkuxdAcB9A3PDWoihRaj8s5ljrbwzBH8JO/vK8zBxifFx/z/6yUqp3KsofKJ2Wg==}
+  '@tummycrypt/tinyland-auth-pg@0.1.1':
+    resolution: {integrity: sha512-ASAeuCRKptgt6c0piTq32FahJgErwo1iQLwcGN3Pzh1EDZh9IB8BEaXHpg5KwaGcM5klrjdgW/hH47agmcC5FQ==}
     peerDependencies:
       '@tummycrypt/tinyland-auth': ^0.2.0
 
@@ -1221,9 +1221,9 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tummycrypt/scheduling-kit@0.6.1(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)':
+  '@tummycrypt/scheduling-kit@0.7.0(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)(svelte@5.55.1)':
     dependencies:
-      '@tummycrypt/tinyland-auth-pg': 0.1.0(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)
+      '@tummycrypt/tinyland-auth-pg': 0.1.1(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)
       drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)
       effect: 3.21.0
       svelte: 5.55.1
@@ -1258,7 +1258,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@tummycrypt/tinyland-auth-pg@0.1.0(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)':
+  '@tummycrypt/tinyland-auth-pg@0.1.1(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1))(@types/pg@8.11.6)':
     dependencies:
       '@neondatabase/serverless': 0.10.4
       '@tummycrypt/tinyland-auth': 0.2.0(svelte@5.55.1)


### PR DESCRIPTION
## What changed

This PR advances both package-graph convergence and publish-lane truth for the
bridge repo.

- bumps bridge package metadata from `0.4.0` to `0.4.1`
- aligns bridge dependency on `@tummycrypt/scheduling-kit ^0.7.0`
- syncs `package.json`, `MODULE.bazel`, `BUILD.bazel`, and `pnpm-lock.yaml`
- updates `AGENTS.md` and `README.md` with current release-authority/package
  truth
- adds the first Bazel package-artifact preflight to the publish workflow:
  `npx --yes @bazel/bazelisk build //:pkg`

## Why it changed

The app is already consuming `scheduling-kit 0.7.0`, but the published bridge
line was still declaring `^0.6.1`. That dependency drift is exactly the kind of
hidden package-graph mismatch we are trying to eliminate.

This PR fixes that drift and adds the first explicit Bazel gate in the bridge
publish lane.

## Impact

- bridge metadata matches the scheduling-kit generation the app is actually on
- package-truth docs now match the real runtime/release model
- CI gets the first Bazel package-artifact discovery gate

## Validation

- `pnpm typecheck`
- `pnpm build`
- local Bazel probe treated as exploratory only because Bazel infra is still in
  migratory state

