### PR TITLE
build(bazel): publish bridge from bazel artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,16 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Validate Bazel package artifact
         run: npx --yes @bazel/bazelisk build //:pkg
+      - name: Validate Bazel npm package contents
+        run: npm pack --dry-run ./bazel-bin/pkg
+      - name: Archive Bazel package artifact
+        run: tar -czf bazel-pkg.tgz -C bazel-bin pkg
+      - name: Upload Bazel package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bazel-pkg
+          path: bazel-pkg.tgz
+          if-no-files-found: error
       - run: pnpm typecheck
       - run: pnpm build
 
@@ -51,29 +61,22 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
           package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
           scope: '@tummycrypt'
-      - run: corepack enable
-      - name: Resolve pnpm store path
-        id: pnpm-store
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v5
+      - name: Download Bazel package artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+          name: bazel-pkg
+      - name: Extract Bazel package artifact
+        run: tar -xzf bazel-pkg.tgz
       - name: Publish to npmjs.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance || echo "May already exist at this version"
+        run: npm publish ./pkg --access public --provenance || echo "May already exist at this version"
 
   publish-github:
     name: Publish → GitHub Packages
@@ -84,23 +87,16 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
           package-manager-cache: false
-      - run: corepack enable
-      - name: Resolve pnpm store path
-        id: pnpm-store
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v5
+      - name: Download Bazel package artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+          name: bazel-pkg
+      - name: Extract Bazel package artifact
+        run: tar -xzf bazel-pkg.tgz
       - name: Configure GitHub Packages auth
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
       - name: Publish to GitHub Packages as @jesssullivan
@@ -110,8 +106,8 @@ jobs:
           # GitHub Packages requires scope to match the GitHub owner
           # Rewrite package name for GitHub Packages only
           node -e "
-            const pkg = require('./package.json');
+            const pkg = require('./pkg/package.json');
             pkg.name = '@jesssullivan/scheduling-bridge';
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+            require('fs').writeFileSync('./pkg/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
-          npm publish --registry https://npm.pkg.github.com --access public || echo "May already exist at this version"
+          npm publish ./pkg --registry https://npm.pkg.github.com --access public || echo "May already exist at this version"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Tinyland, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "access": "public"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ],
     "overrides": {
       "effect": "^3.19.14"
     }


### PR DESCRIPTION
## Summary
- add the missing MIT `LICENSE` expected by the Bazel package rule
- validate the Bazel-built package with `npm pack --dry-run ./bazel-bin/pkg`
- archive and publish the Bazel package artifact instead of rebuilding from source in publish jobs

## Validation
- `npx --yes @bazel/bazelisk build //:pkg`
- `npx --yes @bazel/bazelisk cquery //:pkg --output=files`
- `npm pack --dry-run ./bazel-bin/pkg`