### PR TITLE
[codex] Route CI to honey self-hosted runner stopgap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     strategy:
       matrix:
         node-version: [20, 22]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   test:
     name: Test & Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -54,7 +54,7 @@ jobs:
 
   publish-npm:
     name: Publish → npmjs.com
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     needs: [test]
     if: ${{ !inputs.dry_run }}
     permissions:
@@ -80,7 +80,7 @@ jobs:
 
   publish-github:
     name: Publish → GitHub Packages
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     needs: [test]
     if: ${{ !inputs.dry_run }}
     permissions:


### PR DESCRIPTION
## Summary
- route core CI and publish jobs through `PRIMARY_LINUX_RUNNER_LABELS_JSON`
- default to `ubuntu-latest` when the repo variable is absent
- enable the temporary honey self-hosted runner stopgap for this repo

## Notes
- repo variable set in GitHub: `["self-hosted","Linux","X64","honey","acuity-middleware","nix"]`
- temporary repo runner is live as `honey-am-1`
- this is an interim lane until the local/lab-managed runner stack is finalized
