### PR TITLE
[codex] Deduplicate CI push vs PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- stop running middleware CI on every feature-branch push
- keep push-triggered CI only on `main`
- rely on `pull_request` for feature-branch validation

## Why
- the temporary `honey` self-hosted runners are being wasted by duplicate `push` + `pull_request` runs on the same PR head
- this preserves main-branch push coverage without duplicating PR validation work
