### PR TITLE
[codex] Isolate pnpm store on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   PNPM_VERSION: 9.15.9
+  PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
 
 jobs:
   build:
@@ -29,13 +30,12 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Resolve pnpm store path
-        id: pnpm-store
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Configure workspace pnpm store
+        run: pnpm config set store-dir "$PNPM_STORE_PATH"
 
       - uses: actions/cache@v5
         with:
-          path: ${{ steps.pnpm-store.outputs.path }}
+          path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ on:
 env:
   PNPM_VERSION: 9.15.9
   DEFAULT_NODE_VERSION: '22'
+  PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
 
 jobs:
   test:
@@ -27,12 +28,11 @@ jobs:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
           package-manager-cache: false
       - run: corepack enable
-      - name: Resolve pnpm store path
-        id: pnpm-store
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Configure workspace pnpm store
+        run: pnpm config set store-dir "$PNPM_STORE_PATH"
       - uses: actions/cache@v5
         with:
-          path: ${{ steps.pnpm-store.outputs.path }}
+          path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-


### PR DESCRIPTION
## Summary
- isolate pnpm cache/store to the workspace on self-hosted runners
- avoid collisions in the shared home-directory pnpm store on honey
- apply the same fix pattern already proven in MassageIthaca

## Testing
- CI on this PR
