### PR TITLE
[codex] Version bridge health protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ HTTP Request
 | POST | `/booking/create` | Create a booking (standard) |
 | POST | `/booking/create-with-payment` | Create booking with payment bypass (coupon) |
 
+### Health Contract
+
+`GET /health` is the stable downstream runtime-truth surface.
+
+In addition to basic runtime data, it now publishes:
+
+- release tuple:
+  - `releaseSha`
+  - `releaseRef`
+  - `releaseVersion`
+  - `releaseBuiltAt`
+  - nested `release.{ sha, ref, version, builtAt, modalEnvironment }`
+- protocol tuple:
+  - `protocolVersion`
+  - nested `protocol.version`
+  - `protocol.flowOwner = "scheduling-bridge"`
+  - `protocol.backend = "acuity"`
+  - `protocol.transport = "http-json"`
+  - `protocol.endpoints`
+  - `protocol.capabilities`
+
+Downstream apps should use this tuple to assert which bridge release and protocol
+surface they are talking to during beta validation and rollout claims.
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |
@@ -55,6 +79,11 @@ HTTP Request
 | `CHROMIUM_LAUNCH_ARGS` | No | -- | Comma-separated Chromium args |
 | `SERVICES_JSON` | No | -- | Optional static service catalog to bypass live Acuity reads |
 | `ACUITY_SERVICE_CACHE_TTL_MS` | No | `300000` | TTL for cached live service catalogs before BUSINESS/scraper refresh |
+| `MIDDLEWARE_RELEASE_SHA` | No | -- | Release commit SHA exposed via `/health` |
+| `MIDDLEWARE_RELEASE_REF` | No | -- | Release ref/tag exposed via `/health` |
+| `MIDDLEWARE_RELEASE_VERSION` | No | -- | Release version exposed via `/health` |
+| `MIDDLEWARE_RELEASE_BUILT_AT` | No | -- | Build timestamp exposed via `/health` |
+| `MIDDLEWARE_BUILD_TIMESTAMP` | No | -- | Legacy fallback build timestamp for `/health` |
 
 ## Deployment
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,11 @@ export {
 
 // Server
 export { server } from './server/handler.js';
+export {
+	BRIDGE_PROTOCOL_VERSION,
+	BRIDGE_PROTOCOL_ENDPOINTS,
+	BRIDGE_PROTOCOL_CAPABILITIES,
+} from './server/health.js';
 
 // Payment capabilities extraction
 export { extractCapabilities } from './capabilities.js';

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -59,6 +59,7 @@ import {
 	readDatesViaUrl,
 	readSlotsViaUrl,
 } from '../adapters/acuity/steps/read-via-url.js';
+import { buildHealthPayload } from './health.js';
 import type {
 	Booking,
 	BookingRequest,
@@ -196,18 +197,21 @@ const isAcuityAppointmentTypeId = (serviceId: string): boolean => /^\d+$/.test(s
 // =============================================================================
 
 const handleHealth = (_req: IncomingMessage, res: ServerResponse) => {
-	sendSuccess(res, {
-		status: 'ok',
-		baseUrl: ACUITY_BASE_URL,
-		hasCoupon: !!COUPON_CODE,
-		headless: browserConfig.headless,
-		staticServices: serviceCatalog.staticServicesCount,
-		serviceCacheTtlMs: SERVICE_CACHE_TTL_MS,
-		releaseSha: process.env.MIDDLEWARE_RELEASE_SHA ?? 'unknown',
-		releaseRef: process.env.MIDDLEWARE_RELEASE_REF ?? 'unknown',
-		modalEnvironment: process.env.MODAL_ENVIRONMENT ?? null,
-		timestamp: new Date().toISOString(),
-	});
+	sendSuccess(
+		res,
+		buildHealthPayload({
+			baseUrl: ACUITY_BASE_URL,
+			hasCoupon: !!COUPON_CODE,
+			headless: browserConfig.headless,
+			staticServices: serviceCatalog.staticServicesCount,
+			serviceCacheTtlMs: SERVICE_CACHE_TTL_MS,
+			releaseSha: process.env.MIDDLEWARE_RELEASE_SHA,
+			releaseRef: process.env.MIDDLEWARE_RELEASE_REF,
+			releaseVersion: process.env.MIDDLEWARE_RELEASE_VERSION ?? process.env.npm_package_version,
+			releaseBuiltAt: process.env.MIDDLEWARE_RELEASE_BUILT_AT ?? process.env.MIDDLEWARE_BUILD_TIMESTAMP,
+			modalEnvironment: process.env.MODAL_ENVIRONMENT,
+		}),
+	);
 };
 
 

--- a/src/server/health.ts
+++ b/src/server/health.ts
@@ -1,0 +1,83 @@
+export const BRIDGE_PROTOCOL_VERSION = '1.0.0' as const;
+
+export const BRIDGE_PROTOCOL_ENDPOINTS = {
+	health: '/health',
+	services: '/services',
+	service: '/services/:id',
+	availabilityDates: '/availability/dates',
+	availabilitySlots: '/availability/slots',
+	availabilityCheck: '/availability/check',
+	bookingCreate: '/booking/create',
+	bookingCreateWithPayment: '/booking/create-with-payment',
+} as const;
+
+export const BRIDGE_PROTOCOL_CAPABILITIES = [
+	'services:list',
+	'services:get',
+	'availability:dates',
+	'availability:slots',
+	'availability:check',
+	'booking:create',
+	'booking:create-with-payment',
+	'service-catalog:static-fallback',
+	'service-catalog:business-extract',
+	'service-catalog:scraper-fallback',
+	'payment:bypass-coupon',
+] as const;
+
+export interface BuildHealthPayloadOptions {
+	baseUrl: string;
+	hasCoupon: boolean;
+	headless: boolean;
+	staticServices: number;
+	serviceCacheTtlMs: number;
+	releaseSha?: string | null;
+	releaseRef?: string | null;
+	releaseVersion?: string | null;
+	releaseBuiltAt?: string | null;
+	modalEnvironment?: string | null;
+	timestamp?: string;
+}
+
+export const buildHealthPayload = ({
+	baseUrl,
+	hasCoupon,
+	headless,
+	staticServices,
+	serviceCacheTtlMs,
+	releaseSha,
+	releaseRef,
+	releaseVersion,
+	releaseBuiltAt,
+	modalEnvironment,
+	timestamp = new Date().toISOString(),
+}: BuildHealthPayloadOptions) => ({
+	status: 'ok' as const,
+	baseUrl,
+	hasCoupon,
+	headless,
+	staticServices,
+	serviceCacheTtlMs,
+	releaseSha: releaseSha ?? 'unknown',
+	releaseRef: releaseRef ?? 'unknown',
+	releaseVersion: releaseVersion ?? 'unknown',
+	releaseBuiltAt: releaseBuiltAt ?? null,
+	modalEnvironment: modalEnvironment ?? null,
+	protocolVersion: BRIDGE_PROTOCOL_VERSION,
+	release: {
+		sha: releaseSha ?? 'unknown',
+		ref: releaseRef ?? 'unknown',
+		version: releaseVersion ?? 'unknown',
+		builtAt: releaseBuiltAt ?? null,
+		modalEnvironment: modalEnvironment ?? null,
+	},
+	protocol: {
+		version: BRIDGE_PROTOCOL_VERSION,
+		flowOwner: 'scheduling-bridge' as const,
+		backend: 'acuity' as const,
+		transport: 'http-json' as const,
+		endpoints: BRIDGE_PROTOCOL_ENDPOINTS,
+		capabilities: [...BRIDGE_PROTOCOL_CAPABILITIES],
+	},
+	timestamp,
+});

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+	BRIDGE_PROTOCOL_CAPABILITIES,
+	BRIDGE_PROTOCOL_ENDPOINTS,
+	BRIDGE_PROTOCOL_VERSION,
+	buildHealthPayload,
+} from '../src/server/health.js';
+
+describe('bridge health payload', () => {
+	it('exposes release truth and versioned protocol metadata', () => {
+		const payload = buildHealthPayload({
+			baseUrl: 'https://MassageIthaca.as.me',
+			hasCoupon: true,
+			headless: true,
+			staticServices: 8,
+			serviceCacheTtlMs: 300000,
+			releaseSha: 'abc123',
+			releaseRef: 'refs/heads/main',
+			releaseVersion: '0.4.1',
+			releaseBuiltAt: '2026-04-16T12:00:00.000Z',
+			modalEnvironment: 'main',
+			timestamp: '2026-04-16T12:34:56.000Z',
+		});
+
+		expect(payload.protocolVersion).toBe(BRIDGE_PROTOCOL_VERSION);
+		expect(payload.release).toEqual({
+			sha: 'abc123',
+			ref: 'refs/heads/main',
+			version: '0.4.1',
+			builtAt: '2026-04-16T12:00:00.000Z',
+			modalEnvironment: 'main',
+		});
+		expect(payload.protocol).toEqual({
+			version: BRIDGE_PROTOCOL_VERSION,
+			flowOwner: 'scheduling-bridge',
+			backend: 'acuity',
+			transport: 'http-json',
+			endpoints: BRIDGE_PROTOCOL_ENDPOINTS,
+			capabilities: [...BRIDGE_PROTOCOL_CAPABILITIES],
+		});
+		expect(payload.timestamp).toBe('2026-04-16T12:34:56.000Z');
+	});
+
+	it('falls back to unknown release metadata when release env is absent', () => {
+		const payload = buildHealthPayload({
+			baseUrl: 'https://MassageIthaca.as.me',
+			hasCoupon: false,
+			headless: true,
+			staticServices: 0,
+			serviceCacheTtlMs: 300000,
+			timestamp: '2026-04-16T12:34:56.000Z',
+		});
+
+		expect(payload.releaseSha).toBe('unknown');
+		expect(payload.releaseRef).toBe('unknown');
+		expect(payload.releaseVersion).toBe('unknown');
+		expect(payload.releaseBuiltAt).toBeNull();
+		expect(payload.release).toEqual({
+			sha: 'unknown',
+			ref: 'unknown',
+			version: 'unknown',
+			builtAt: null,
+			modalEnvironment: null,
+		});
+	});
+});


### PR DESCRIPTION
Summary
- add a versioned bridge protocol tuple to the health endpoint
- expose release version and build timestamp alongside release sha/ref
- export bridge protocol constants from the package and cover the health payload with tests

Testing
- pnpm install --frozen-lockfile
- pnpm test -- tests/health.test.ts
- pnpm typecheck
- pnpm build
