### PR TITLE
fix: propagate release metadata into modal deploys

### DIFF
--- a/.github/workflows/deploy-modal.yml
+++ b/.github/workflows/deploy-modal.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Resolve deploy target
         run: |
           echo "MODAL_APP_NAME=${INPUT_DEPLOYMENT_NAME:-scheduling-middleware}" >> "$GITHUB_ENV"
+          echo "MIDDLEWARE_RELEASE_VERSION=$(node -p "require('./package.json').version")" >> "$GITHUB_ENV"
+          echo "MIDDLEWARE_RELEASE_BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
           if [ -n "${INPUT_MODAL_ENVIRONMENT}" ]; then
             echo "MODAL_ENVIRONMENT=${INPUT_MODAL_ENVIRONMENT}" >> "$GITHUB_ENV"
           fi
@@ -75,3 +77,5 @@ jobs:
           MODAL_ENVIRONMENT: ${{ env.MODAL_ENVIRONMENT }}
           MIDDLEWARE_RELEASE_SHA: ${{ github.sha }}
           MIDDLEWARE_RELEASE_REF: ${{ github.ref_name }}
+          MIDDLEWARE_RELEASE_VERSION: ${{ env.MIDDLEWARE_RELEASE_VERSION }}
+          MIDDLEWARE_RELEASE_BUILT_AT: ${{ env.MIDDLEWARE_RELEASE_BUILT_AT }}

--- a/modal-app.py
+++ b/modal-app.py
@@ -24,6 +24,8 @@ import modal
 APP_NAME = os.environ.get("MODAL_APP_NAME", "scheduling-middleware")
 RELEASE_SHA = os.environ.get("MIDDLEWARE_RELEASE_SHA", "local")
 RELEASE_REF = os.environ.get("MIDDLEWARE_RELEASE_REF", "local")
+RELEASE_VERSION = os.environ.get("MIDDLEWARE_RELEASE_VERSION", "local")
+RELEASE_BUILT_AT = os.environ.get("MIDDLEWARE_RELEASE_BUILT_AT", "")
 
 app = modal.App(APP_NAME)
 
@@ -36,6 +38,8 @@ image = (
     .env({
         "MIDDLEWARE_RELEASE_SHA": RELEASE_SHA,
         "MIDDLEWARE_RELEASE_REF": RELEASE_REF,
+        "MIDDLEWARE_RELEASE_VERSION": RELEASE_VERSION,
+        "MIDDLEWARE_RELEASE_BUILT_AT": RELEASE_BUILT_AT,
     })
     .run_commands(
         # Remove Node 24 from Playwright image, install Node 22 LTS


### PR DESCRIPTION
## Summary
- pass release version and build timestamp into the Modal image env
- export release metadata from the deploy workflow before invoking Modal
- keep the bridge health contract aligned with the actual deployed runtime metadata

## Validation
- python3 -m py_compile modal-app.py
