### PR TITLE
fix(ci): make github package artifact writable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,7 +104,9 @@ jobs:
       - name: Extract Bazel package artifact
         run: tar -xzf bazel-pkg.tgz
       - name: Prepare GitHub Packages publish directory
-        run: cp -R pkg pkg-github
+        run: |
+          cp -R pkg pkg-github
+          chmod -R u+w pkg-github
       - name: Configure GitHub Packages auth
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
       - name: Publish to GitHub Packages as @jesssullivan


### PR DESCRIPTION
## Summary
- make the copied pkg-github directory writable after extracting the Bazel artifact
- avoid EACCES when the GitHub Packages sidecar rewrites package.json on self-hosted runners
- keep the npmjs.com publish lane and GitHub Packages sidecar consistent

## Validation
- workflow-only change
- based on the failing self-hosted publish log from run 24515451422
