### PR TITLE
fix(build): publish bridge as esm from bazel artifact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ As of `2026-04-15`, the active structural work here is:
 
 Operationally relevant truth:
 
-- the current published bridge line is `0.4.0`
-- the local convergence branch `fix/bridge-kit-070` bumps metadata to `0.4.1`
+- the current published bridge line is `0.4.1`
+- the current ESM artifact fix bumps metadata to `0.4.2`
 - that branch aligns the bridge dependency on `@tummycrypt/scheduling-kit ^0.7.0`
 
 ## Deployment Truth

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.1",
+    version = "0.4.2",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.1",
+    version = "0.4.2",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Current reality:
 Current convergence work:
 
 - local branch `fix/bridge-kit-070`
-- package metadata bump to `0.4.1`
+- package metadata bump to `0.4.2`
 - dependency alignment to `@tummycrypt/scheduling-kit ^0.7.0`
 
 Longer term, the intended publish shape is:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -16,7 +16,7 @@ describe('bridge health payload', () => {
 			serviceCacheTtlMs: 300000,
 			releaseSha: 'abc123',
 			releaseRef: 'refs/heads/main',
-			releaseVersion: '0.4.1',
+			releaseVersion: '0.4.2',
 			releaseBuiltAt: '2026-04-16T12:00:00.000Z',
 			modalEnvironment: 'main',
 			timestamp: '2026-04-16T12:34:56.000Z',
@@ -26,7 +26,7 @@ describe('bridge health payload', () => {
 		expect(payload.release).toEqual({
 			sha: 'abc123',
 			ref: 'refs/heads/main',
-			version: '0.4.1',
+			version: '0.4.2',
 			builtAt: '2026-04-16T12:00:00.000Z',
 			modalEnvironment: 'main',
 		});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM"],
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary
- make the bridge TypeScript build emit ESM regardless of whether package.json is visible to the compiler
- bump package metadata from 0.4.1 to 0.4.2 for the fixed artifact
- keep the Bazel-built //:pkg output aligned with the runtime package contract

## Validation
- pnpm install --frozen-lockfile
- pnpm build
- pnpm typecheck
- pnpm test -- tests/health.test.ts
- npx --yes @bazel/bazelisk build //:pkg
- verified bazel-bin/pkg/dist/index.js is ESM and bazel-bin/pkg/package.json reports 0.4.2

Fixes the package-format regression exposed by MassageIthaca#143.