### PR TITLE
[codex] import payment capability types from scheduling-kit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,18 @@ jobs:
     strategy:
       matrix:
         node-version: [20, 22]
+    env:
+      CHECKOUT_PATH: repo-${{ github.run_id }}-${{ matrix.node-version }}
+      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-${{ matrix.node-version }}/.pnpm-store
 
     steps:
       - uses: actions/checkout@v6
         with:
           clean: false
+          path: ${{ env.CHECKOUT_PATH }}
 
       - name: Clean stale packaged artifacts
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: |
           chmod -R u+w pkg bazel-bin bazel-out bazel-testlogs 2>/dev/null || true
           rm -rf pkg bazel-bin bazel-out bazel-testlogs
@@ -38,20 +43,24 @@ jobs:
         run: corepack enable
 
       - name: Configure workspace pnpm store
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm config set store-dir "$PNPM_STORE_PATH"
 
       - uses: actions/cache@v5
         with:
           path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', env.CHECKOUT_PATH)) }}
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm install --frozen-lockfile
 
       - name: Typecheck
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm typecheck
 
       - name: Build
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          clean: false
+
+      - name: Clean stale packaged artifacts
+        run: |
+          chmod -R u+w pkg bazel-bin bazel-out bazel-testlogs 2>/dev/null || true
+          rm -rf pkg bazel-bin bazel-out bazel-testlogs
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,12 @@ jobs:
     runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          clean: false
+      - name: Clean stale packaged artifacts
+        run: |
+          chmod -R u+w pkg bazel-bin bazel-out bazel-testlogs 2>/dev/null || true
+          rm -rf pkg bazel-bin bazel-out bazel-testlogs
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,16 @@ jobs:
   test:
     name: Test & Build
     runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
+    env:
+      CHECKOUT_PATH: repo-${{ github.run_id }}-${{ env.DEFAULT_NODE_VERSION }}
+      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-${{ env.DEFAULT_NODE_VERSION }}/.pnpm-store
     steps:
       - uses: actions/checkout@v6
         with:
           clean: false
+          path: ${{ env.CHECKOUT_PATH }}
       - name: Clean stale packaged artifacts
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: |
           chmod -R u+w pkg bazel-bin bazel-out bazel-testlogs 2>/dev/null || true
           rm -rf pkg bazel-bin bazel-out bazel-testlogs
@@ -35,28 +40,35 @@ jobs:
           package-manager-cache: false
       - run: corepack enable
       - name: Configure workspace pnpm store
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm config set store-dir "$PNPM_STORE_PATH"
       - uses: actions/cache@v5
         with:
           path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', env.CHECKOUT_PATH)) }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
-      - run: pnpm install --frozen-lockfile
+      - working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm install --frozen-lockfile
       - name: Validate Bazel package artifact
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: npx --yes @bazel/bazelisk build //:pkg
       - name: Validate Bazel npm package contents
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: npm pack --dry-run ./bazel-bin/pkg
       - name: Archive Bazel package artifact
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: tar -czf bazel-pkg.tgz -C bazel-bin pkg
       - name: Upload Bazel package artifact
         uses: actions/upload-artifact@v4
         with:
           name: bazel-pkg
-          path: bazel-pkg.tgz
+          path: ${{ env.CHECKOUT_PATH }}/bazel-pkg.tgz
           if-no-files-found: error
-      - run: pnpm typecheck
-      - run: pnpm build
+      - working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm typecheck
+      - working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm build
 
   publish-npm:
     name: Publish → npmjs.com

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -4,37 +4,12 @@
  * This is the canonical extraction logic used by downstream booking surfaces
  * to produce consistent payment method availability.
  */
-
-// TODO: import from @tummycrypt/scheduling-kit/payments once 0.7.0 is published
-interface PaymentMethodOption {
-  readonly id: string;
-  readonly name: string;
-  readonly displayName: string;
-  readonly icon?: string;
-  readonly description?: string;
-  readonly available: boolean;
-  readonly processingFee?: number;
-  readonly processingFeePercent?: number;
-}
-
-interface StripeCapability {
-  readonly available: boolean;
-  readonly publishableKey: string;
-  readonly connectedAccountId?: string;
-}
-
-interface VenmoCapability {
-  readonly available: boolean;
-  readonly clientId: string;
-  readonly environment: 'sandbox' | 'production';
-}
-
-interface PaymentCapabilities {
-  readonly methods: PaymentMethodOption[];
-  readonly stripe: StripeCapability | null;
-  readonly venmo: VenmoCapability | null;
-  readonly cash: false;
-}
+import type {
+  PaymentCapabilities,
+  PaymentMethodOption,
+  StripeCapability,
+  VenmoCapability,
+} from '@tummycrypt/scheduling-kit/payments';
 
 /**
  * Extract payment capabilities from practitioner settings and platform env vars.

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { extractCapabilities } from '../src/capabilities.js';
+import type { PaymentCapabilities } from '@tummycrypt/scheduling-kit/payments';
 
 describe('extractCapabilities', () => {
   it('should return empty capabilities when nothing is configured', () => {
-    const caps = extractCapabilities({}, {});
+    const caps: PaymentCapabilities = extractCapabilities({}, {});
     expect(caps.methods).toEqual([]);
     expect(caps.stripe).toBeNull();
     expect(caps.venmo).toBeNull();


### PR DESCRIPTION
## Summary
- import the canonical payment capability types from scheduling-kit payments
- remove the stale local duplicate interfaces and TODO from src/capabilities.ts
- add a compile-time assertion in the capabilities test so the bridge result stays assignable to the canonical contract

## Validation
- pnpm install --frozen-lockfile
- pnpm test -- tests/capabilities.test.ts
- pnpm typecheck
- pnpm build

Closes #36