### PR TITLE
feat(ci): harden scheduling-bridge release truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     needs: workspace
     env:
-      CHECKOUT_PATH: repo-${{ github.run_id }}-${{ env.DEFAULT_NODE_VERSION }}
-      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-${{ env.DEFAULT_NODE_VERSION }}/.pnpm-store
+      CHECKOUT_PATH: repo-${{ github.run_id }}-22
+      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-22/.pnpm-store
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,11 @@ on:
 
 env:
   PNPM_VERSION: 9.15.9
+  DEFAULT_NODE_VERSION: 22
   PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
 
 jobs:
-  build:
+  workspace:
     runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     strategy:
       matrix:
@@ -27,11 +28,11 @@ jobs:
           clean: false
           path: ${{ env.CHECKOUT_PATH }}
 
-      - name: Clean stale packaged artifacts
+      - name: Clean stale workspace artifacts
         working-directory: ${{ env.CHECKOUT_PATH }}
         run: |
-          chmod -R u+w pkg bazel-bin bazel-out bazel-testlogs 2>/dev/null || true
-          rm -rf pkg bazel-bin bazel-out bazel-testlogs
+          chmod -R u+w dist node_modules bazel-bin bazel-out bazel-testlogs .pnpm-store 2>/dev/null || true
+          rm -rf dist node_modules bazel-bin bazel-out bazel-testlogs .pnpm-store MODULE.bazel.lock
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
@@ -57,10 +58,85 @@ jobs:
         working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm install --frozen-lockfile
 
+      - name: Verify release metadata
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm check:release-metadata
+
       - name: Typecheck
         working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm typecheck
 
+      - name: Unit tests
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm test
+
       - name: Build
         working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm build
+
+  package:
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
+    needs: workspace
+    env:
+      CHECKOUT_PATH: repo-${{ github.run_id }}-${{ env.DEFAULT_NODE_VERSION }}
+      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-${{ env.DEFAULT_NODE_VERSION }}/.pnpm-store
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: false
+          path: ${{ env.CHECKOUT_PATH }}
+
+      - name: Clean stale workspace artifacts
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: |
+          chmod -R u+w dist node_modules pkg bazel-bin bazel-out bazel-testlogs .pnpm-store 2>/dev/null || true
+          rm -rf dist node_modules pkg bazel-bin bazel-out bazel-testlogs .pnpm-store MODULE.bazel.lock
+
+      - name: Setup Node.js ${{ env.DEFAULT_NODE_VERSION }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          package-manager-cache: false
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Configure workspace pnpm store
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm config set store-dir "$PNPM_STORE_PATH"
+
+      - uses: actions/cache@v5
+        with:
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', env.CHECKOUT_PATH)) }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
+
+      - name: Install dependencies
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify release metadata
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm check:release-metadata
+
+      - name: Build package
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm build
+
+      - name: Validate package surface
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm check:package
+
+      - name: Validate Bazel package artifact
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: npx --yes @bazel/bazelisk build //:pkg
+
+      - name: Validate Bazel npm package contents
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: npm pack --dry-run ./bazel-bin/pkg
+
+      - name: Validate Bazel npm publish dry run
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: npm publish --dry-run --ignore-scripts --access public ./bazel-bin/pkg

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,6 +117,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@tummycrypt'
 
+      - name: Clean stale publish artifacts
+        run: |
+          chmod -R u+w pkg pkg-github bazel-pkg.tgz 2>/dev/null || true
+          rm -rf pkg pkg-github bazel-pkg.tgz
+
       - name: Download Bazel package artifact
         uses: actions/download-artifact@v4
         with:
@@ -158,6 +163,11 @@ jobs:
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
           package-manager-cache: false
+
+      - name: Clean stale publish artifacts
+        run: |
+          chmod -R u+w pkg pkg-github bazel-pkg.tgz 2>/dev/null || true
+          rm -rf pkg pkg-github bazel-pkg.tgz
 
       - name: Download Bazel package artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
         description: 'Dry run (no actual publish)'
         required: false
         type: boolean
-        default: false
+        default: true
 
 env:
   PNPM_VERSION: 9.15.9
@@ -18,8 +18,8 @@ env:
   PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
 
 jobs:
-  test:
-    name: Test & Build
+  package:
+    name: Test, Validate, & Package
     runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     env:
       CHECKOUT_PATH: repo-${{ github.run_id }}-${{ env.DEFAULT_NODE_VERSION }}
@@ -29,52 +29,83 @@ jobs:
         with:
           clean: false
           path: ${{ env.CHECKOUT_PATH }}
-      - name: Clean stale packaged artifacts
+
+      - name: Clean stale workspace artifacts
         working-directory: ${{ env.CHECKOUT_PATH }}
         run: |
-          chmod -R u+w pkg bazel-bin bazel-out bazel-testlogs 2>/dev/null || true
-          rm -rf pkg bazel-bin bazel-out bazel-testlogs
+          chmod -R u+w dist node_modules pkg pkg-github bazel-bin bazel-out bazel-testlogs .pnpm-store 2>/dev/null || true
+          rm -rf dist node_modules pkg pkg-github bazel-bin bazel-out bazel-testlogs .pnpm-store MODULE.bazel.lock
+
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
           package-manager-cache: false
-      - run: corepack enable
+
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Configure workspace pnpm store
         working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm config set store-dir "$PNPM_STORE_PATH"
+
       - uses: actions/cache@v5
         with:
           path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', env.CHECKOUT_PATH)) }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
-      - working-directory: ${{ env.CHECKOUT_PATH }}
+
+      - name: Install dependencies
+        working-directory: ${{ env.CHECKOUT_PATH }}
         run: pnpm install --frozen-lockfile
+
+      - name: Verify release metadata
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm check:release-metadata
+
+      - name: Typecheck
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm typecheck
+
+      - name: Unit tests
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm test
+
+      - name: Build package
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm build
+
+      - name: Validate package surface
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: pnpm check:package
+
       - name: Validate Bazel package artifact
         working-directory: ${{ env.CHECKOUT_PATH }}
         run: npx --yes @bazel/bazelisk build //:pkg
+
       - name: Validate Bazel npm package contents
         working-directory: ${{ env.CHECKOUT_PATH }}
         run: npm pack --dry-run ./bazel-bin/pkg
+
+      - name: Validate Bazel npm publish dry run
+        working-directory: ${{ env.CHECKOUT_PATH }}
+        run: npm publish --dry-run --ignore-scripts --access public ./bazel-bin/pkg
+
       - name: Archive Bazel package artifact
         working-directory: ${{ env.CHECKOUT_PATH }}
         run: tar -czf bazel-pkg.tgz -C bazel-bin pkg
+
       - name: Upload Bazel package artifact
         uses: actions/upload-artifact@v4
         with:
           name: bazel-pkg
           path: ${{ env.CHECKOUT_PATH }}/bazel-pkg.tgz
           if-no-files-found: error
-      - working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm typecheck
-      - working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm build
 
   publish-npm:
     name: Publish → npmjs.com
     runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
-    needs: [test]
-    if: ${{ !inputs.dry_run }}
+    needs: [package]
     permissions:
       contents: read
       id-token: write
@@ -85,28 +116,40 @@ jobs:
           package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
           scope: '@tummycrypt'
+
       - name: Download Bazel package artifact
         uses: actions/download-artifact@v4
         with:
           name: bazel-pkg
+
       - name: Extract Bazel package artifact
         run: tar -xzf bazel-pkg.tgz
+
+      - name: Normalize Bazel package permissions
+        run: chmod -R u+w pkg
+
       - name: Publish to npmjs.com
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           if [ "$RUNNER_ENVIRONMENT" = "self-hosted" ]; then
-            npm publish ./pkg --access public
+            npm publish ./pkg --access public --ignore-scripts
           else
-            npm publish ./pkg --access public --provenance
+            npm publish ./pkg --access public --provenance --ignore-scripts
           fi
+
+      - name: Publish dry run
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        run: npm publish ./pkg --access public --dry-run --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-github:
     name: Publish → GitHub Packages
     runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
-    needs: [test]
-    if: ${{ !inputs.dry_run }}
+    needs: [package]
     permissions:
       contents: read
       packages: write
@@ -115,27 +158,45 @@ jobs:
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
           package-manager-cache: false
+
       - name: Download Bazel package artifact
         uses: actions/download-artifact@v4
         with:
           name: bazel-pkg
+
       - name: Extract Bazel package artifact
         run: tar -xzf bazel-pkg.tgz
+
       - name: Prepare GitHub Packages publish directory
         run: |
           cp -R pkg pkg-github
           chmod -R u+w pkg-github
+
       - name: Configure GitHub Packages auth
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
+
       - name: Publish to GitHub Packages as @jesssullivan
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # GitHub Packages requires scope to match the GitHub owner
-          # Rewrite package name for GitHub Packages only
           node -e "
             const pkg = require('./pkg-github/package.json');
             pkg.name = '@jesssullivan/scheduling-bridge';
+            pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
             require('fs').writeFileSync('./pkg-github/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
-          npm publish ./pkg-github --registry https://npm.pkg.github.com --access public
+          npm publish ./pkg-github --registry https://npm.pkg.github.com --access public --ignore-scripts
+
+      - name: Publish dry run
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node -e "
+            const pkg = require('./pkg-github/package.json');
+            pkg.name = '@jesssullivan/scheduling-bridge';
+            pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
+            require('fs').writeFileSync('./pkg-github/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          npm publish ./pkg-github --registry https://npm.pkg.github.com --access public --dry-run --ignore-scripts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,8 @@ jobs:
     name: Test, Validate, & Package
     runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     env:
-      CHECKOUT_PATH: repo-${{ github.run_id }}-${{ env.DEFAULT_NODE_VERSION }}
-      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-${{ env.DEFAULT_NODE_VERSION }}/.pnpm-store
+      CHECKOUT_PATH: repo-${{ github.run_id }}-22
+      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-22/.pnpm-store
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 coverage/
 .vitest/
 out/
+MODULE.bazel.lock
+bazel-*

--- a/README.md
+++ b/README.md
@@ -138,14 +138,15 @@ Current convergence work:
 - package metadata bump to `0.4.2`
 - dependency alignment to `@tummycrypt/scheduling-kit ^0.7.0`
 
-Longer term, the intended publish shape is:
+The current publish shape is now:
 
 1. release metadata declared once
 2. Bazel validates/builds the publishable artifact
-3. GitHub Actions publishes that artifact
-4. downstream apps consume only the published package
+3. CI dry-runs the extracted Bazel package surface before release
+4. GitHub Actions publishes that extracted artifact
+5. downstream apps consume only the published package
 
-That is not fully true yet. Today the publish lane is still pnpm/npm-first.
+The remaining risk is operational, not structural: release truth still depends on disciplined tag/release handling in GitHub Actions.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "license": "MIT",
+  "homepage": "https://github.com/Jesssullivan/acuity-middleware",
+  "bugs": {
+    "url": "https://github.com/Jesssullivan/acuity-middleware/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Jesssullivan/acuity-middleware.git"
@@ -28,11 +32,13 @@
   ],
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "tsc",
+    "prepublishOnly": "pnpm check:release-metadata && pnpm build && pnpm check:package",
     "start": "node dist/server/handler.js",
     "dev": "tsx src/server/handler.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
+    "check:release-metadata": "node scripts/check-release-metadata.mjs",
+    "check:package": "publint",
     "clean": "rm -rf dist",
     "paper:build": "cd docs/paper && tectonic acuity-middleware-paper.tex",
     "paper:dev": "node docs/paper/watch.mjs"
@@ -46,7 +52,8 @@
     "typescript": "^5.9.0",
     "tsx": "^4.0.0",
     "vitest": "^4.0.0",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "publint": "^0.3.18"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      publint:
+        specifier: ^0.3.18
+        version: 0.3.18
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -246,6 +249,10 @@ packages:
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
@@ -727,6 +734,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -757,6 +768,9 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -819,6 +833,11 @@ packages:
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
+  publint@0.3.18:
+    resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
@@ -841,6 +860,10 @@ packages:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -1162,6 +1185,8 @@ snapshots:
       '@otplib/plugin-thirty-two': 12.0.1
 
   '@oxc-project/types@0.122.0': {}
+
+  '@publint/pack@0.1.4': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
@@ -1556,6 +1581,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mri@1.2.0: {}
+
   nanoid@3.3.11: {}
 
   nanoid@5.1.7: {}
@@ -1579,6 +1606,8 @@ snapshots:
       p-limit: 2.3.0
 
   p-try@2.2.0: {}
+
+  package-manager-detector@1.6.0: {}
 
   path-exists@4.0.0: {}
 
@@ -1626,6 +1655,13 @@ snapshots:
 
   postgres-range@1.1.4: {}
 
+  publint@0.3.18:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   pure-rand@6.1.0: {}
 
   qrcode@1.5.4:
@@ -1663,6 +1699,10 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   set-blocking@2.0.0: {}
 

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+
+const read = (relativePath) =>
+	readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+
+const packageJson = JSON.parse(read('../package.json'));
+const moduleBazel = read('../MODULE.bazel');
+const buildBazel = read('../BUILD.bazel');
+const expectedPnpmVersion = packageJson.packageManager?.replace(/^pnpm@/, '');
+
+const extract = (source, pattern, label) => {
+	const match = source.match(pattern);
+	if (!match?.[1]) {
+		throw new Error(`Unable to find ${label}`);
+	}
+	return match[1];
+};
+
+const checks = [
+	{
+		label: 'MODULE.bazel version',
+		actual: extract(moduleBazel, /module\([\s\S]*?version = "([^"]+)"/m, 'module version'),
+		expected: packageJson.version,
+	},
+	{
+		label: 'BUILD.bazel npm_package version',
+		actual: extract(buildBazel, /npm_package\([\s\S]*?version = "([^"]+)"/m, 'npm_package version'),
+		expected: packageJson.version,
+	},
+	{
+		label: 'BUILD.bazel npm_package name',
+		actual: extract(buildBazel, /npm_package\([\s\S]*?package = "([^"]+)"/m, 'npm_package name'),
+		expected: packageJson.name,
+	},
+	{
+		label: 'MODULE.bazel pnpm version',
+		actual: extract(moduleBazel, /pnpm_version = "([^"]+)"/, 'pnpm_version'),
+		expected: expectedPnpmVersion,
+	},
+];
+
+const failures = checks.filter((check) => check.actual !== check.expected);
+
+if (failures.length > 0) {
+	for (const failure of failures) {
+		console.error(
+			`${failure.label} mismatch: expected "${failure.expected}", found "${failure.actual}"`,
+		);
+	}
+	process.exit(1);
+}
+
+console.log(
+	`release metadata aligned for ${packageJson.name}@${packageJson.version} (pnpm ${expectedPnpmVersion})`,
+);


### PR DESCRIPTION
## Summary
- add release-metadata parity checks and package-surface validation to normal CI
- make publish dry runs exercise the extracted Bazel artifact path instead of skipping publish jobs
- harden Bazel artifact permission normalization and explicit GitHub Packages rewrite behavior

## Why
The bridge repo's raw Bazel package artifact was already structurally good. The remaining TIN-104 risk was governance: thin CI, no metadata parity enforcement, and a fake manual dry-run path in publish.

## Validation
- pnpm check:release-metadata
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm check:package
- workflow YAML parse
- bazel build //:pkg
- npm pack --dry-run ./bazel-bin/pkg
- npm publish --dry-run --ignore-scripts --access public ./bazel-bin/pkg
- GitHub Packages rewrite dry-run against extracted Bazel artifact copy

Refs TIN-104
Refs TIN-101
Refs TIN-89