### PR TITLE
perf(acuity): profile cold slot read phases

### DIFF
--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -15,6 +15,12 @@ import { BrowserService } from '../../../shared/browser-service.js';
 import { WizardStepError } from '../errors.js';
 import { Selectors } from '../selectors.js';
 import { parseSlotText, buildIsoDatetime } from '../slot-parser.js';
+import {
+	createSlotReadProfile,
+	formatSlotReadProfileLog,
+	getSlotReadProfileConfig,
+	shouldLogSlotReadProfile,
+} from './slot-read-profile.js';
 
 // =============================================================================
 // TYPES
@@ -143,37 +149,60 @@ export const readSlotsViaUrl = (
 ): Effect.Effect<UrlSlotResult[], WizardStepError, BrowserService | Scope.Scope> =>
 	Effect.gen(function* () {
 		const { acquirePage, config } = yield* BrowserService;
+		const profileConfig = getSlotReadProfileConfig();
 		const page = yield* acquirePage.pipe(
 			Effect.mapError((e) => new WizardStepError({ step: 'read-slots', message: `Browser error: ${e._tag}` })),
 		);
+
+		let navigationMs = 0;
+		let calendarReadyMs = 0;
+		let dateSelectMs = 0;
+		let postClickSettleMs = 0;
+		let slotWaitMs = 0;
+		let slotDomReadMs = 0;
+		let parseMs = 0;
+		let calendarTileCount = 0;
+		let matchedDateFound = false;
 
 		const url = new URL(config.baseUrl);
 		url.searchParams.set('appointmentType', serviceId);
 		url.searchParams.set('date', date);
 
+		const navigationStartedAt = Date.now();
 		yield* Effect.tryPromise({
 			try: () => page.goto(url.toString(), { waitUntil: 'networkidle', timeout: config.timeout }),
 			catch: (e) => new WizardStepError({ step: 'read-slots', message: `Navigation failed: ${e}` }),
 		});
+		navigationMs = Date.now() - navigationStartedAt;
 
 		// Click the target date on the calendar
 		const tileSelector = Selectors.calendarDay[0];
 		yield* Effect.tryPromise({
 			try: async () => {
+				const calendarReadyStartedAt = Date.now();
 				await page.waitForSelector(tileSelector, { timeout: 10000 }).catch(() => {});
+				calendarReadyMs = Date.now() - calendarReadyStartedAt;
+
+				const dateSelectStartedAt = Date.now();
 				const tiles = await page.$$(tileSelector);
+				calendarTileCount = tiles.length;
 				for (const tile of tiles) {
 					const abbr = await tile.$('abbr');
 					const label = await abbr?.getAttribute('aria-label');
 					if (label) {
 						const d = new Date(label);
 						if (d.toISOString().slice(0, 10) === date) {
+							matchedDateFound = true;
 							await tile.click();
 							break;
 						}
 					}
 				}
+				dateSelectMs = Date.now() - dateSelectStartedAt;
+
+				const settleStartedAt = Date.now();
 				await page.waitForTimeout(2000);
+				postClickSettleMs = Date.now() - settleStartedAt;
 			},
 			catch: (e) => new WizardStepError({ step: 'read-slots', message: `Date click failed: ${e}` }),
 		});
@@ -181,11 +210,14 @@ export const readSlotsViaUrl = (
 		// Read time slots using the Selectors registry
 		const slotSelector = Selectors.timeSlot[0]; // button.time-selection
 		const fallbackSelector = Selectors.timeSlot.join(', ');
+		const slotWaitStartedAt = Date.now();
 		yield* Effect.tryPromise({
 			try: () => page.waitForSelector(fallbackSelector, { timeout: 10000 }),
 			catch: () => null,
 		}).pipe(Effect.ignore);
+		slotWaitMs = Date.now() - slotWaitStartedAt;
 
+		const slotDomReadStartedAt = Date.now();
 		const slots = yield* Effect.tryPromise({
 			try: () => page.evaluate((sel) => {
 				const results: Array<{ datetime: string; available: boolean }> = [];
@@ -200,13 +232,42 @@ export const readSlotsViaUrl = (
 			}, slotSelector),
 			catch: (e) => new WizardStepError({ step: 'read-slots', message: `Slots read failed: ${e}` }),
 		});
+		slotDomReadMs = Date.now() - slotDomReadStartedAt;
 
 		// Parse slot text and build full ISO datetime (e.g., "4:00 PM" → "2026-04-01T16:00:00")
-		return slots.map(s => {
+		const parseStartedAt = Date.now();
+		let parsedSlotCount = 0;
+		const parsedSlots = slots.map(s => {
 			const parsed = parseSlotText(s.datetime);
+			if (parsed) parsedSlotCount += 1;
 			return {
 				datetime: parsed ? buildIsoDatetime(date, parsed.time) : s.datetime,
 				available: s.available,
 			};
 		});
+		parseMs = Date.now() - parseStartedAt;
+		const profile = createSlotReadProfile({
+			serviceId,
+			date,
+			thresholdMs: profileConfig.thresholdMs,
+			calendarTileCount,
+			matchedDateFound,
+			slotCount: slots.length,
+			parsedSlotCount,
+			phases: {
+				navigationMs,
+				calendarReadyMs,
+				dateSelectMs,
+				postClickSettleMs,
+				slotWaitMs,
+				slotDomReadMs,
+				parseMs,
+			},
+		});
+
+		if (shouldLogSlotReadProfile(profile, profileConfig)) {
+			console.log(formatSlotReadProfileLog(profile));
+		}
+
+		return parsedSlots;
 	});

--- a/src/adapters/acuity/steps/slot-read-profile.ts
+++ b/src/adapters/acuity/steps/slot-read-profile.ts
@@ -1,0 +1,91 @@
+export interface SlotReadPhaseTimings {
+	readonly navigationMs: number;
+	readonly calendarReadyMs: number;
+	readonly dateSelectMs: number;
+	readonly postClickSettleMs: number;
+	readonly slotWaitMs: number;
+	readonly slotDomReadMs: number;
+	readonly parseMs: number;
+}
+
+export interface SlotReadProfile {
+	readonly serviceId: string;
+	readonly date: string;
+	readonly totalMs: number;
+	readonly thresholdMs: number;
+	readonly longTail: boolean;
+	readonly calendarTileCount: number;
+	readonly matchedDateFound: boolean;
+	readonly slotCount: number;
+	readonly parsedSlotCount: number;
+	readonly unparsedSlotCount: number;
+	readonly phases: SlotReadPhaseTimings;
+}
+
+export interface SlotReadProfileConfig {
+	readonly thresholdMs: number;
+	readonly forceLog: boolean;
+}
+
+const DEFAULT_THRESHOLD_MS = 1500;
+const FORCE_LOG_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export const getSlotReadProfileConfig = (
+	env: Record<string, string | undefined> = process.env,
+): SlotReadProfileConfig => {
+	const parsedThreshold = Number.parseInt(env.SCHEDULING_BRIDGE_SLOT_PROFILE_THRESHOLD_MS ?? '', 10);
+
+	return {
+		thresholdMs:
+			Number.isFinite(parsedThreshold) && parsedThreshold > 0
+				? parsedThreshold
+				: DEFAULT_THRESHOLD_MS,
+		forceLog: FORCE_LOG_VALUES.has((env.SCHEDULING_BRIDGE_PROFILE_SLOT_READS ?? '').toLowerCase()),
+	};
+};
+
+export interface CreateSlotReadProfileInput {
+	readonly serviceId: string;
+	readonly date: string;
+	readonly thresholdMs: number;
+	readonly calendarTileCount: number;
+	readonly matchedDateFound: boolean;
+	readonly slotCount: number;
+	readonly parsedSlotCount: number;
+	readonly phases: SlotReadPhaseTimings;
+}
+
+export const createSlotReadProfile = (
+	input: CreateSlotReadProfileInput,
+): SlotReadProfile => {
+	const totalMs =
+		input.phases.navigationMs +
+		input.phases.calendarReadyMs +
+		input.phases.dateSelectMs +
+		input.phases.postClickSettleMs +
+		input.phases.slotWaitMs +
+		input.phases.slotDomReadMs +
+		input.phases.parseMs;
+
+	return {
+		serviceId: input.serviceId,
+		date: input.date,
+		totalMs,
+		thresholdMs: input.thresholdMs,
+		longTail: totalMs >= input.thresholdMs,
+		calendarTileCount: input.calendarTileCount,
+		matchedDateFound: input.matchedDateFound,
+		slotCount: input.slotCount,
+		parsedSlotCount: input.parsedSlotCount,
+		unparsedSlotCount: Math.max(0, input.slotCount - input.parsedSlotCount),
+		phases: input.phases,
+	};
+};
+
+export const shouldLogSlotReadProfile = (
+	profile: SlotReadProfile,
+	config: SlotReadProfileConfig,
+): boolean => config.forceLog || profile.longTail;
+
+export const formatSlotReadProfileLog = (profile: SlotReadProfile): string =>
+	`[availability/slots][profile] ${JSON.stringify(profile)}`;

--- a/tests/slot-read-profile.test.ts
+++ b/tests/slot-read-profile.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createSlotReadProfile,
+	formatSlotReadProfileLog,
+	getSlotReadProfileConfig,
+	shouldLogSlotReadProfile,
+} from '../src/adapters/acuity/steps/slot-read-profile.js';
+
+describe('slot read profiling helpers', () => {
+	it('builds a long-tail profile with phase totals and parsed counts', () => {
+		const profile = createSlotReadProfile({
+			serviceId: '53178494',
+			date: '2026-04-25',
+			thresholdMs: 1500,
+			calendarTileCount: 28,
+			matchedDateFound: true,
+			slotCount: 4,
+			parsedSlotCount: 3,
+			phases: {
+				navigationMs: 900,
+				calendarReadyMs: 40,
+				dateSelectMs: 120,
+				postClickSettleMs: 2000,
+				slotWaitMs: 300,
+				slotDomReadMs: 180,
+				parseMs: 10,
+			},
+		});
+
+		expect(profile.totalMs).toBe(3550);
+		expect(profile.longTail).toBe(true);
+		expect(profile.unparsedSlotCount).toBe(1);
+		expect(profile.matchedDateFound).toBe(true);
+		expect(profile.phases.postClickSettleMs).toBe(2000);
+	});
+
+	it('reads threshold and force-log config from env', () => {
+		const config = getSlotReadProfileConfig({
+			SCHEDULING_BRIDGE_SLOT_PROFILE_THRESHOLD_MS: '2200',
+			SCHEDULING_BRIDGE_PROFILE_SLOT_READS: 'true',
+		});
+
+		expect(config.thresholdMs).toBe(2200);
+		expect(config.forceLog).toBe(true);
+	});
+
+	it('falls back to defaults when env values are absent or invalid', () => {
+		const config = getSlotReadProfileConfig({
+			SCHEDULING_BRIDGE_SLOT_PROFILE_THRESHOLD_MS: 'nope',
+			SCHEDULING_BRIDGE_PROFILE_SLOT_READS: '0',
+		});
+
+		expect(config.thresholdMs).toBe(1500);
+		expect(config.forceLog).toBe(false);
+	});
+
+	it('only logs non-long-tail reads when force logging is enabled', () => {
+		const profile = createSlotReadProfile({
+			serviceId: '53178494',
+			date: '2026-04-15',
+			thresholdMs: 1500,
+			calendarTileCount: 21,
+			matchedDateFound: true,
+			slotCount: 2,
+			parsedSlotCount: 2,
+			phases: {
+				navigationMs: 200,
+				calendarReadyMs: 30,
+				dateSelectMs: 40,
+				postClickSettleMs: 250,
+				slotWaitMs: 50,
+				slotDomReadMs: 20,
+				parseMs: 5,
+			},
+		});
+
+		expect(shouldLogSlotReadProfile(profile, { thresholdMs: 1500, forceLog: false })).toBe(false);
+		expect(shouldLogSlotReadProfile(profile, { thresholdMs: 1500, forceLog: true })).toBe(true);
+		expect(formatSlotReadProfileLog(profile)).toContain('[availability/slots][profile]');
+	});
+});


### PR DESCRIPTION
## Summary
- add a pure slot-read profiling helper with threshold and force-log config
- instrument `readSlotsViaUrl` with phase timings for navigation, calendar readiness, date selection, post-click settle, slot wait, DOM read, and parse
- emit a structured log entry for long-tail slot reads, with optional verbose logging via env
- add unit coverage for the profiling helper

## Why
This is the next concrete slice for `#20`. The main gap is no longer correctness on the primary beta path; it is understanding why later uncached dates can still show long cold slot latency. This change adds the phase-level visibility needed to tell whether the tail is dominated by navigation, date selection, fixed settle time, slot wait, or DOM extraction.

## Logging behavior
- default: only logs long-tail reads at or above `1500ms`
- configurable threshold: `SCHEDULING_BRIDGE_SLOT_PROFILE_THRESHOLD_MS`
- force log every slot read: `SCHEDULING_BRIDGE_PROFILE_SLOT_READS=1`

## Validation
- `pnpm test -- tests/slot-read-profile.test.ts tests/health.test.ts tests/capabilities.test.ts`
- `pnpm typecheck`
- `pnpm build`

Closes #20
