### PR TITLE
[codex] adopt shared Bazel package workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@51b1727b6977aa26b82604d7e6455f6d1ef1e9f2
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@4e47e5ae0f8edfb30ada209120d9779fc9a127fe
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@690597d7540e17671a8d74a51f6719bf7e659044
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@aaf87d046cd261d3f7bfa0b00750c758c5e24a99
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,136 +7,23 @@ on:
     branches: [main]
   workflow_dispatch:
 
-env:
-  PNPM_VERSION: 9.15.9
-  DEFAULT_NODE_VERSION: 22
-  PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
-
 jobs:
-  workspace:
-    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
-    strategy:
-      matrix:
-        node-version: [20, 22]
-    env:
-      CHECKOUT_PATH: repo-${{ github.run_id }}-${{ matrix.node-version }}
-      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-${{ matrix.node-version }}/.pnpm-store
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-          path: ${{ env.CHECKOUT_PATH }}
-
-      - name: Clean stale workspace artifacts
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: |
-          chmod -R u+w dist node_modules bazel-bin bazel-out bazel-testlogs .pnpm-store 2>/dev/null || true
-          rm -rf dist node_modules bazel-bin bazel-out bazel-testlogs .pnpm-store MODULE.bazel.lock
-
-      - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node-version }}
-          package-manager-cache: false
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Configure workspace pnpm store
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm config set store-dir "$PNPM_STORE_PATH"
-
-      - uses: actions/cache@v5
-        with:
-          path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', env.CHECKOUT_PATH)) }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-
-
-      - name: Install dependencies
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm install --frozen-lockfile
-
-      - name: Verify release metadata
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm check:release-metadata
-
-      - name: Typecheck
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm typecheck
-
-      - name: Unit tests
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm test
-
-      - name: Build
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm build
-
   package:
-    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
-    needs: workspace
-    env:
-      CHECKOUT_PATH: repo-${{ github.run_id }}-22
-      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-22/.pnpm-store
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-          path: ${{ env.CHECKOUT_PATH }}
-
-      - name: Clean stale workspace artifacts
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: |
-          chmod -R u+w dist node_modules pkg bazel-bin bazel-out bazel-testlogs .pnpm-store 2>/dev/null || true
-          rm -rf dist node_modules pkg bazel-bin bazel-out bazel-testlogs .pnpm-store MODULE.bazel.lock
-
-      - name: Setup Node.js ${{ env.DEFAULT_NODE_VERSION }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
-          package-manager-cache: false
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Configure workspace pnpm store
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm config set store-dir "$PNPM_STORE_PATH"
-
-      - uses: actions/cache@v5
-        with:
-          path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', env.CHECKOUT_PATH)) }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
-
-      - name: Install dependencies
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm install --frozen-lockfile
-
-      - name: Verify release metadata
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm check:release-metadata
-
-      - name: Build package
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm build
-
-      - name: Validate package surface
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm check:package
-
-      - name: Validate Bazel package artifact
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: npx --yes @bazel/bazelisk build //:pkg
-
-      - name: Validate Bazel npm package contents
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: npm pack --dry-run ./bazel-bin/pkg
-
-      - name: Validate Bazel npm publish dry run
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: npm publish --dry-run --ignore-scripts --access public ./bazel-bin/pkg
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
+    with:
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
+      node_versions: '["20", "22"]'
+      publish_node_version: "22"
+      pnpm_version: "9.15.9"
+      cleanup_paths: "dist node_modules pkg pkg-github bazel-bin bazel-out bazel-testlogs .pnpm-store bazel-pkg.tgz MODULE.bazel.lock"
+      metadata_check_command: pnpm check:release-metadata
+      typecheck_command: pnpm typecheck
+      unit_test_command: pnpm test
+      build_command: pnpm build
+      package_check_command: pnpm check:package
+      bazel_targets: "//:pkg"
+      package_dir: ./bazel-bin/pkg
+      npm_access: public
+      github_package_name: "@jesssullivan/scheduling-bridge"
+      dry_run: true
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@4e47e5ae0f8edfb30ada209120d9779fc9a127fe
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@690597d7540e17671a8d74a51f6719bf7e659044
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@51b1727b6977aa26b82604d7e6455f6d1ef1e9f2
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@bcf25551b2a608f3c4169930bfdd7e12e51fd661
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@dde8c378815e47aa027c163278430c0d98ae007b
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@aaf87d046cd261d3f7bfa0b00750c758c5e24a99
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@bcf25551b2a608f3c4169930bfdd7e12e51fd661
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@aaf87d046cd261d3f7bfa0b00750c758c5e24a99
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@bcf25551b2a608f3c4169930bfdd7e12e51fd661
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@bcf25551b2a608f3c4169930bfdd7e12e51fd661
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@dde8c378815e47aa027c163278430c0d98ae007b
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@4e47e5ae0f8edfb30ada209120d9779fc9a127fe
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@690597d7540e17671a8d74a51f6719bf7e659044
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,201 +12,23 @@ on:
         type: boolean
         default: true
 
-env:
-  PNPM_VERSION: 9.15.9
-  DEFAULT_NODE_VERSION: '22'
-  PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
-
 jobs:
   package:
-    name: Test, Validate, & Package
-    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
-    env:
-      CHECKOUT_PATH: repo-${{ github.run_id }}-22
-      PNPM_STORE_PATH: ${{ github.workspace }}/repo-${{ github.run_id }}-22/.pnpm-store
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-          path: ${{ env.CHECKOUT_PATH }}
-
-      - name: Clean stale workspace artifacts
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: |
-          chmod -R u+w dist node_modules pkg pkg-github bazel-bin bazel-out bazel-testlogs .pnpm-store 2>/dev/null || true
-          rm -rf dist node_modules pkg pkg-github bazel-bin bazel-out bazel-testlogs .pnpm-store MODULE.bazel.lock
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
-          package-manager-cache: false
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Configure workspace pnpm store
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm config set store-dir "$PNPM_STORE_PATH"
-
-      - uses: actions/cache@v5
-        with:
-          path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', env.CHECKOUT_PATH)) }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
-
-      - name: Install dependencies
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm install --frozen-lockfile
-
-      - name: Verify release metadata
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm check:release-metadata
-
-      - name: Typecheck
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm typecheck
-
-      - name: Unit tests
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm test
-
-      - name: Build package
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm build
-
-      - name: Validate package surface
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: pnpm check:package
-
-      - name: Validate Bazel package artifact
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: npx --yes @bazel/bazelisk build //:pkg
-
-      - name: Validate Bazel npm package contents
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: npm pack --dry-run ./bazel-bin/pkg
-
-      - name: Validate Bazel npm publish dry run
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: npm publish --dry-run --ignore-scripts --access public ./bazel-bin/pkg
-
-      - name: Archive Bazel package artifact
-        working-directory: ${{ env.CHECKOUT_PATH }}
-        run: tar -czf bazel-pkg.tgz -C bazel-bin pkg
-
-      - name: Upload Bazel package artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: bazel-pkg
-          path: ${{ env.CHECKOUT_PATH }}/bazel-pkg.tgz
-          if-no-files-found: error
-
-  publish-npm:
-    name: Publish → npmjs.com
-    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
-    needs: [package]
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
-          package-manager-cache: false
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@tummycrypt'
-
-      - name: Clean stale publish artifacts
-        run: |
-          chmod -R u+w pkg pkg-github bazel-pkg.tgz 2>/dev/null || true
-          rm -rf pkg pkg-github bazel-pkg.tgz
-
-      - name: Download Bazel package artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: bazel-pkg
-
-      - name: Extract Bazel package artifact
-        run: tar -xzf bazel-pkg.tgz
-
-      - name: Normalize Bazel package permissions
-        run: chmod -R u+w pkg
-
-      - name: Publish to npmjs.com
-        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          RUNNER_ENVIRONMENT: ${{ runner.environment }}
-        run: |
-          if [ "$RUNNER_ENVIRONMENT" = "self-hosted" ]; then
-            npm publish ./pkg --access public --ignore-scripts
-          else
-            npm publish ./pkg --access public --provenance --ignore-scripts
-          fi
-
-      - name: Publish dry run
-        if: ${{ github.event.inputs.dry_run == 'true' }}
-        run: npm publish ./pkg --access public --dry-run --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  publish-github:
-    name: Publish → GitHub Packages
-    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
-    needs: [package]
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
-          package-manager-cache: false
-
-      - name: Clean stale publish artifacts
-        run: |
-          chmod -R u+w pkg pkg-github bazel-pkg.tgz 2>/dev/null || true
-          rm -rf pkg pkg-github bazel-pkg.tgz
-
-      - name: Download Bazel package artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: bazel-pkg
-
-      - name: Extract Bazel package artifact
-        run: tar -xzf bazel-pkg.tgz
-
-      - name: Prepare GitHub Packages publish directory
-        run: |
-          cp -R pkg pkg-github
-          chmod -R u+w pkg-github
-
-      - name: Configure GitHub Packages auth
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
-
-      - name: Publish to GitHub Packages as @jesssullivan
-        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          node -e "
-            const pkg = require('./pkg-github/package.json');
-            pkg.name = '@jesssullivan/scheduling-bridge';
-            pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
-            require('fs').writeFileSync('./pkg-github/package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          npm publish ./pkg-github --registry https://npm.pkg.github.com --access public --ignore-scripts
-
-      - name: Publish dry run
-        if: ${{ github.event.inputs.dry_run == 'true' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          node -e "
-            const pkg = require('./pkg-github/package.json');
-            pkg.name = '@jesssullivan/scheduling-bridge';
-            pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
-            require('fs').writeFileSync('./pkg-github/package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          npm publish ./pkg-github --registry https://npm.pkg.github.com --access public --dry-run --ignore-scripts
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
+    with:
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
+      node_versions: '["20", "22"]'
+      publish_node_version: "22"
+      pnpm_version: "9.15.9"
+      cleanup_paths: "dist node_modules pkg pkg-github bazel-bin bazel-out bazel-testlogs .pnpm-store bazel-pkg.tgz MODULE.bazel.lock"
+      metadata_check_command: pnpm check:release-metadata
+      typecheck_command: pnpm typecheck
+      unit_test_command: pnpm test
+      build_command: pnpm build
+      package_check_command: pnpm check:package
+      bazel_targets: "//:pkg"
+      package_dir: ./bazel-bin/pkg
+      npm_access: public
+      github_package_name: "@jesssullivan/scheduling-bridge"
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@51b1727b6977aa26b82604d7e6455f6d1ef1e9f2
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@4e47e5ae0f8edfb30ada209120d9779fc9a127fe
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@51b1727b6977aa26b82604d7e6455f6d1ef1e9f2
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@690597d7540e17671a8d74a51f6719bf7e659044
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@aaf87d046cd261d3f7bfa0b00750c758c5e24a99
     with:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
       node_versions: '["20", "22"]'


### PR DESCRIPTION
## Summary

- migrate the bridge repo to the shared Bazel JS package workflow
- preserve self-hosted runner routing, manual dry-run publish dispatch, and Bazel-artifact npm publication
- preserve GitHub Packages publication as `@jesssullivan/scheduling-bridge`
- pin the reusable workflow reference to the reviewed `ci-templates` commit

## Why

The bridge repo was carrying a large amount of package-validation and publish duplication that now belongs in the shared workflow. This keeps the release lane consistent with the other package repos while preserving the repo-specific publication behavior.

## Validation

- parsed `.github/workflows/ci.yml`
- parsed `.github/workflows/publish.yml`
