### PR TITLE
feat(cache): Redis L2 SETNX single-flight + prom-client SLIs (phase 1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,15 +45,17 @@
   },
   "dependencies": {
     "@tummycrypt/scheduling-kit": "^0.7.1",
+    "effect": "^3.19.14",
+    "ioredis": "^5",
     "playwright-core": "1.58.1",
-    "effect": "^3.19.14"
+    "prom-client": "^15"
   },
   "devDependencies": {
-    "typescript": "^5.9.0",
-    "tsx": "^4.0.0",
-    "vitest": "^4.0.0",
     "@types/node": "^22.0.0",
-    "publint": "^0.3.18"
+    "publint": "^0.3.18",
+    "tsx": "^4.0.0",
+    "typescript": "^5.9.0",
+    "vitest": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "ioredis-mock": "^8.13.1",
     "publint": "^0.3.18",
     "tsx": "^4.0.0",
     "typescript": "^5.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,19 @@ importers:
     dependencies:
       '@tummycrypt/scheduling-kit':
         specifier: ^0.7.1
-        version: 0.7.1(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
+        version: 0.7.1(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
       effect:
         specifier: ^3.19.14
         version: 3.21.0
+      ioredis:
+        specifier: ^5
+        version: 5.10.1
       playwright-core:
         specifier: 1.58.1
         version: 1.58.1
+      prom-client:
+        specifier: ^15
+        version: 15.1.3
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -35,7 +41,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.0
-        version: 4.1.2(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 
@@ -204,6 +210,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -228,6 +237,10 @@ packages:
 
   '@neondatabase/serverless@0.10.4':
     resolution: {integrity: sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@otplib/core@12.0.1':
     resolution: {integrity: sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==}
@@ -466,6 +479,9 @@ packages:
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -481,6 +497,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -491,9 +511,22 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -652,6 +685,10 @@ packages:
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -736,12 +773,21 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -838,6 +884,10 @@ packages:
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   publint@0.3.18:
     resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
     engines: {node: '>=18'}
@@ -850,6 +900,14 @@ packages:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -883,6 +941,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
@@ -897,6 +958,9 @@ packages:
   svelte@5.55.1:
     resolution: {integrity: sha512-QjvU7EFemf6mRzdMGlAFttMWtAAVXrax61SZYHdkD6yoVGQ89VeyKfZD4H1JrV1WLmJBxWhFch9H6ig/87VGjw==}
     engines: {node: '>=18'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   thirty-two@1.0.2:
     resolution: {integrity: sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==}
@@ -1140,6 +1204,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@ioredis/commands@1.5.1': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1169,6 +1235,8 @@ snapshots:
   '@neondatabase/serverless@0.10.4':
     dependencies:
       '@types/pg': 8.11.6
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@otplib/core@12.0.1': {}
 
@@ -1255,10 +1323,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tummycrypt/scheduling-kit@0.7.1(@neondatabase/serverless@0.10.4)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
+  '@tummycrypt/scheduling-kit@0.7.1(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
     dependencies:
-      '@tummycrypt/tinyland-auth-pg': 0.1.1(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)
+      '@tummycrypt/tinyland-auth-pg': 0.1.1(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)
       effect: 3.21.0
       svelte: 5.55.1(@typescript-eslint/types@8.58.0)
       zod: 4.3.6
@@ -1292,11 +1360,11 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@tummycrypt/tinyland-auth-pg@0.1.1(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)':
+  '@tummycrypt/tinyland-auth-pg@0.1.1(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)':
     dependencies:
       '@neondatabase/serverless': 0.10.4
       '@tummycrypt/tinyland-auth': 0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0))
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -1420,6 +1488,8 @@ snapshots:
 
   bcryptjs@2.4.3: {}
 
+  bintrees@1.0.2: {}
+
   camelcase@5.3.1: {}
 
   chai@6.2.2: {}
@@ -1432,6 +1502,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -1440,7 +1512,13 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decamelize@1.2.0: {}
+
+  denque@2.1.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -1448,9 +1526,10 @@ snapshots:
 
   dijkstrajs@1.0.3: {}
 
-  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6):
+  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6):
     optionalDependencies:
       '@neondatabase/serverless': 0.10.4
+      '@opentelemetry/api': 1.9.1
       '@types/pg': 8.11.6
 
   effect@3.21.0:
@@ -1527,6 +1606,20 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-reference@3.0.3:
@@ -1588,11 +1681,17 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   mri@1.2.0: {}
+
+  ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
@@ -1666,6 +1765,11 @@ snapshots:
 
   postgres-range@1.1.4: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   publint@0.3.18:
     dependencies:
       '@publint/pack': 0.1.4
@@ -1680,6 +1784,12 @@ snapshots:
       dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
+
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
 
   require-directory@2.1.1: {}
 
@@ -1723,6 +1833,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standard-as-callback@2.1.0: {}
+
   std-env@4.0.0: {}
 
   string-width@4.2.3:
@@ -1755,6 +1867,10 @@ snapshots:
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   thirty-two@1.0.2: {}
 
@@ -1804,7 +1920,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
@@ -1827,6 +1943,7 @@ snapshots:
       vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.17
     transitivePeerDependencies:
       - msw

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      ioredis-mock:
+        specifier: ^8.13.1
+        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.10.1))(ioredis@5.10.1)
       publint:
         specifier: ^0.3.18
         version: 0.3.18
@@ -209,6 +212,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@ioredis/as-callback@3.0.0':
+    resolution: {integrity: sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==}
 
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
@@ -408,6 +414,11 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/ioredis-mock@8.2.7':
+    resolution: {integrity: sha512-YsGiaOIYBKeVvu/7GYziAD8qX3LJem5LK00d5PKykzsQJMLysAqXA61AkNuYWCekYl64tbMTqVOMF4SYoCPbQg==}
+    peerDependencies:
+      ioredis: '>=5'
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
@@ -669,6 +680,14 @@ packages:
       picomatch:
         optional: true
 
+  fengari-interop@0.1.4:
+    resolution: {integrity: sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q==}
+    peerDependencies:
+      fengari: ^0.1.0
+
+  fengari@0.1.5:
+    resolution: {integrity: sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -684,6 +703,13 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  ioredis-mock@8.13.1:
+    resolution: {integrity: sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==}
+    engines: {node: '>=12.22'}
+    peerDependencies:
+      '@types/ioredis-mock': ^8
+      ioredis: ^5
 
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
@@ -901,6 +927,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  readline-sync@1.4.10:
+    resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
+    engines: {node: '>= 0.8.0'}
+
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -928,6 +958,11 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
@@ -937,6 +972,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -984,6 +1022,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1204,6 +1246,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@ioredis/as-callback@3.0.0': {}
+
   '@ioredis/commands@1.5.1': {}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1416,6 +1460,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/ioredis-mock@8.2.7(ioredis@5.10.1)':
+    dependencies:
+      ioredis: 5.10.1
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -1592,6 +1640,16 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fengari-interop@0.1.4(fengari@0.1.5):
+    dependencies:
+      fengari: 0.1.5
+
+  fengari@0.1.5:
+    dependencies:
+      readline-sync: 1.4.10
+      sprintf-js: 1.1.3
+      tmp: 0.2.5
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -1605,6 +1663,16 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.10.1))(ioredis@5.10.1):
+    dependencies:
+      '@ioredis/as-callback': 3.0.0
+      '@ioredis/commands': 1.5.1
+      '@types/ioredis-mock': 8.2.7(ioredis@5.10.1)
+      fengari: 0.1.5
+      fengari-interop: 0.1.4(fengari@0.1.5)
+      ioredis: 5.10.1
+      semver: 7.7.4
 
   ioredis@5.10.1:
     dependencies:
@@ -1785,6 +1853,8 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
+  readline-sync@1.4.10: {}
+
   redis-errors@1.2.0: {}
 
   redis-parser@3.0.0:
@@ -1825,11 +1895,15 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  semver@7.7.4: {}
+
   set-blocking@2.0.0: {}
 
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  sprintf-js@1.1.3: {}
 
   stackback@0.0.2: {}
 
@@ -1889,6 +1963,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  tmp@0.2.5: {}
 
   tslib@2.8.1:
     optional: true

--- a/src/adapters/acuity/scraper.ts
+++ b/src/adapters/acuity/scraper.ts
@@ -30,6 +30,7 @@ const getChromium = async () => {
 import { Effect } from 'effect';
 import type { Service, Provider, TimeSlot, AcuityError, InfrastructureError, SchedulingResult } from '../../core/types.js';
 import { Errors } from '../../core/types.js';
+import { observePageOp } from '../../shared/metrics.js';
 
 // Keep E for internal class methods (deprecated, not worth migrating)
 const E = {
@@ -145,13 +146,18 @@ export class AcuityScraper {
 
     try {
       page = await this.createPage();
-      await page.goto(this.config.baseUrl, { waitUntil: 'networkidle' });
+      // Time the entire catalog-scrape page interaction — navigation plus
+      // the selector wait that unblocks downstream DOM reads. Downstream
+      // `page.evaluate` cost is small relative to network + render.
+      await observePageOp('scrape_catalog', async () => {
+        await page!.goto(this.config.baseUrl, { waitUntil: 'networkidle' });
 
-      // Wait for appointment types to load
-      await page.waitForSelector('.select-item, .appointment-type-item, [data-testid="appointment-type"]', {
-        timeout: 10000,
-      }).catch(() => {
-        // Some Acuity pages use different selectors
+        // Wait for appointment types to load
+        await page!.waitForSelector('.select-item, .appointment-type-item, [data-testid="appointment-type"]', {
+          timeout: 10000,
+        }).catch(() => {
+          // Some Acuity pages use different selectors
+        });
       });
 
       // Try multiple selector patterns for robustness

--- a/src/adapters/acuity/steps/navigate.ts
+++ b/src/adapters/acuity/steps/navigate.ts
@@ -17,6 +17,7 @@
 import { Effect } from 'effect';
 import type { Page, ElementHandle } from 'playwright-core';
 import { BrowserService } from '../../../shared/browser-service.js';
+import { observePageOpEffect } from '../../../shared/metrics.js';
 import { WizardStepError } from '../errors.js';
 import { resolveSelector, probe, Selectors } from '../selectors.js';
 import type { ClientInfo } from '../../../core/types.js';
@@ -55,7 +56,7 @@ export interface NavigateResult {
  * Flow: Service page → Book → Calendar → Time slot → Select and continue
  */
 export const navigateToBooking = (params: NavigateParams) =>
-	Effect.gen(function* () {
+	observePageOpEffect('wizard_navigate', Effect.gen(function* () {
 		const { acquirePage, config } = yield* BrowserService;
 		const page: Page = yield* acquirePage;
 
@@ -114,7 +115,7 @@ export const navigateToBooking = (params: NavigateParams) =>
 			selectedDate: targetDate.toISOString().split('T')[0],
 			selectedTime: targetTime,
 		} satisfies NavigateResult;
-	});
+	}));
 
 // =============================================================================
 // STEP 2: SERVICE SELECTION

--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -13,6 +13,7 @@ import { Effect, Scope } from 'effect';
 import type { Page } from 'playwright-core';
 import { BrowserService } from '../../../shared/browser-service.js';
 import { ndjsonLog } from '../../../shared/logger.js';
+import { observePageOpEffect } from '../../../shared/metrics.js';
 import { WizardStepError } from '../errors.js';
 import { Selectors } from '../selectors.js';
 import { parseSlotText, buildIsoDatetime } from '../slot-parser.js';
@@ -79,7 +80,7 @@ export const readDatesViaUrl = (
 	serviceId: string,
 	targetMonth?: string,
 ): Effect.Effect<UrlDateResult[], WizardStepError, BrowserService | Scope.Scope> =>
-	Effect.gen(function* () {
+	observePageOpEffect('availability_dates', Effect.gen(function* () {
 		const { acquirePage, config } = yield* BrowserService;
 		const page = yield* acquirePage.pipe(
 			Effect.mapError((e) => new WizardStepError({ step: 'read-availability', message: `Browser error: ${e._tag}` })),
@@ -131,7 +132,7 @@ export const readDatesViaUrl = (
 		}).pipe(Effect.ignore);
 
 		return yield* readEnabledCalendarDates(page, tileSelector);
-	});
+	}));
 
 // =============================================================================
 // READ SLOTS VIA URL PARAM
@@ -150,7 +151,7 @@ export const readSlotsViaUrl = (
 	date: string,
 	context?: SlotReadProfileContext,
 ): Effect.Effect<UrlSlotResult[], WizardStepError, BrowserService | Scope.Scope> =>
-	Effect.gen(function* () {
+	observePageOpEffect('availability_slots', Effect.gen(function* () {
 		const { acquirePage, config } = yield* BrowserService;
 		const profileConfig = getSlotReadProfileConfig();
 		const page = yield* acquirePage.pipe(
@@ -274,4 +275,4 @@ export const readSlotsViaUrl = (
 		}
 
 		return parsedSlots;
-	});
+	}));

--- a/src/server/__tests__/handler.test.ts
+++ b/src/server/__tests__/handler.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for the /ready real-liveness probe.
+ *
+ * Tests are written against `runReadyChecks` and `sendReadyResponse` from
+ * `src/server/ready.ts`, which accept injected dependencies so we avoid
+ * launching a real browser or Redis connection.
+ *
+ * Integration-style HTTP tests (`GET /ready`) use the exported `server` from
+ * `handler.ts` but rely on `vi.mock` to intercept the module-level singletons
+ * before they are initialised.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { runReadyChecks, sendReadyResponse, handleReady } from '../ready.js';
+import type { ReadyDeps, ReadyChecks } from '../ready.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal deps where every check passes. */
+const happyDeps = (): ReadyDeps => ({
+	redisPing: async () => 'PONG',
+	browserConnected: async () => true,
+	catalogL1Count: () => 3,
+	catalogL2Exists: null,
+	browserTimeoutMs: 500,
+});
+
+/** Collect the JSON body written to a mock ServerResponse. */
+const makeMockResponse = () => {
+	const chunks: string[] = [];
+	return {
+		writtenStatus: 0 as number,
+		body: () => JSON.parse(chunks.join('')),
+		res: {
+			writeHead(status: number) {
+				this.writtenStatus = status;
+			},
+			end(chunk: string) {
+				chunks.push(chunk);
+			},
+		} as unknown as import('node:http').ServerResponse,
+		get writtenStatus() {
+			return (this as { _status: number })._status ?? 0;
+		},
+	};
+};
+
+// We need a response mock that tracks status separately from the object literal
+// so writtenStatus updates are visible after the call.
+interface MockRes {
+	status: number;
+	body: () => unknown;
+	raw: import('node:http').ServerResponse;
+}
+
+const makeRes = (): MockRes => {
+	let status = 0;
+	const chunks: string[] = [];
+	const raw = {
+		writeHead(s: number) {
+			status = s;
+		},
+		end(chunk: string) {
+			chunks.push(chunk);
+		},
+	} as unknown as import('node:http').ServerResponse;
+	return {
+		get status() {
+			return status;
+		},
+		body: () => JSON.parse(chunks.join('')),
+		raw,
+	};
+};
+
+// ---------------------------------------------------------------------------
+// runReadyChecks unit tests
+// ---------------------------------------------------------------------------
+
+describe('runReadyChecks', () => {
+	it('returns all ok when browser + redis + catalog are healthy (L1)', async () => {
+		const checks = await runReadyChecks(happyDeps());
+
+		expect(checks.redis).toBe('ok');
+		expect(checks.browser).toBe('ok');
+		expect(checks.catalog).toEqual({ status: 'ok', size: 3, source: 'l1' });
+	});
+
+	it('returns redis: unreachable when redis ping fails', async () => {
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			redisPing: async () => { throw new Error('ECONNREFUSED'); },
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(checks.redis).toBe('unreachable');
+		expect(checks.browser).toBe('ok');
+		expect(checks.catalog.status).toBe('ok');
+	});
+
+	it('returns browser: unavailable when browser probe returns false', async () => {
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			browserConnected: async () => false,
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(checks.redis).toBe('ok');
+		expect(checks.browser).toBe('unavailable');
+	});
+
+	it('returns browser: unavailable when browser probe rejects', async () => {
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			browserConnected: async () => { throw new Error('browser crashed'); },
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(checks.browser).toBe('unavailable');
+	});
+
+	it('returns browser: timeout when browser probe exceeds timeout', async () => {
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			browserConnected: () =>
+				new Promise((resolve) => setTimeout(() => resolve(true), 5000)),
+			browserTimeoutMs: 50,
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(checks.browser).toBe('timeout');
+	});
+
+	it('returns catalog: empty when L1 is empty and L2 is not configured', async () => {
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			catalogL1Count: () => 0,
+			catalogL2Exists: null,
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(checks.catalog).toEqual({ status: 'empty' });
+	});
+
+	it('returns catalog: empty when L1 is empty and L2 key does not exist', async () => {
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			catalogL1Count: () => 0,
+			catalogL2Exists: async () => 0,
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(checks.catalog).toEqual({ status: 'empty' });
+	});
+
+	it('returns catalog ok with source l2 when L1 is empty but L2 has data', async () => {
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			catalogL1Count: () => 0,
+			catalogL2Exists: async () => 1,
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(checks.catalog).toEqual({ status: 'ok', size: 0, source: 'l2' });
+	});
+
+	it('skips redis check when redisPing is null (local dev mode)', async () => {
+		const deps: ReadyDeps = { ...happyDeps(), redisPing: null };
+		const checks = await runReadyChecks(deps);
+
+		expect(checks.redis).toBe('ok');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// sendReadyResponse unit tests
+// ---------------------------------------------------------------------------
+
+describe('sendReadyResponse', () => {
+	it('writes HTTP 200 when all checks pass', () => {
+		const mock = makeRes();
+		const checks: ReadyChecks = {
+			redis: 'ok',
+			browser: 'ok',
+			catalog: { status: 'ok', size: 5, source: 'l1' },
+		};
+
+		sendReadyResponse(mock.raw, checks);
+
+		expect(mock.status).toBe(200);
+		expect(mock.body()).toMatchObject({ status: 'ready' });
+	});
+
+	it('writes HTTP 503 when redis is unreachable', () => {
+		const mock = makeRes();
+		const checks: ReadyChecks = {
+			redis: 'unreachable',
+			browser: 'ok',
+			catalog: { status: 'ok', size: 5, source: 'l1' },
+		};
+
+		sendReadyResponse(mock.raw, checks);
+
+		expect(mock.status).toBe(503);
+		expect(mock.body()).toMatchObject({ status: 'not_ready', checks: { redis: 'unreachable' } });
+	});
+
+	it('writes HTTP 503 when browser is unavailable', () => {
+		const mock = makeRes();
+		const checks: ReadyChecks = {
+			redis: 'ok',
+			browser: 'unavailable',
+			catalog: { status: 'ok', size: 2, source: 'l1' },
+		};
+
+		sendReadyResponse(mock.raw, checks);
+
+		expect(mock.status).toBe(503);
+		expect(mock.body()).toMatchObject({ status: 'not_ready', checks: { browser: 'unavailable' } });
+	});
+
+	it('writes HTTP 503 when catalog is empty', () => {
+		const mock = makeRes();
+		const checks: ReadyChecks = {
+			redis: 'ok',
+			browser: 'ok',
+			catalog: { status: 'empty' },
+		};
+
+		sendReadyResponse(mock.raw, checks);
+
+		expect(mock.status).toBe(503);
+		expect(mock.body()).toMatchObject({ status: 'not_ready', checks: { catalog: { status: 'empty' } } });
+	});
+
+	it('response body includes checks object', () => {
+		const mock = makeRes();
+		const checks: ReadyChecks = {
+			redis: 'ok',
+			browser: 'ok',
+			catalog: { status: 'ok', size: 7, source: 'l2' },
+		};
+
+		sendReadyResponse(mock.raw, checks);
+
+		const body = mock.body() as { status: string; checks: ReadyChecks };
+		expect(body.checks).toEqual(checks);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// handleReady integration (uses runReadyChecks + sendReadyResponse together)
+// ---------------------------------------------------------------------------
+
+describe('handleReady', () => {
+	it('returns 200 with all checks passing when browser + redis + catalog healthy', async () => {
+		const mock = makeRes();
+
+		await handleReady(mock.raw, happyDeps());
+
+		expect(mock.status).toBe(200);
+		const body = mock.body() as { status: string; checks: ReadyChecks };
+		expect(body.status).toBe('ready');
+		expect(body.checks.redis).toBe('ok');
+		expect(body.checks.browser).toBe('ok');
+		expect(body.checks.catalog).toMatchObject({ status: 'ok' });
+	});
+
+	it('returns 503 with redis: unreachable when redis ping fails', async () => {
+		const mock = makeRes();
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			redisPing: async () => { throw new Error('ECONNREFUSED'); },
+		};
+
+		await handleReady(mock.raw, deps);
+
+		expect(mock.status).toBe(503);
+		const body = mock.body() as { status: string; checks: ReadyChecks };
+		expect(body.status).toBe('not_ready');
+		expect(body.checks.redis).toBe('unreachable');
+	});
+
+	it('returns 503 with browser: unavailable when browser probe fails', async () => {
+		const mock = makeRes();
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			browserConnected: async () => false,
+		};
+
+		await handleReady(mock.raw, deps);
+
+		expect(mock.status).toBe(503);
+		const body = mock.body() as { status: string; checks: ReadyChecks };
+		expect(body.checks.browser).toBe('unavailable');
+	});
+
+	it('returns 503 with catalog: empty when catalog is empty and L2 also empty', async () => {
+		const mock = makeRes();
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			catalogL1Count: () => 0,
+			catalogL2Exists: async () => 0,
+		};
+
+		await handleReady(mock.raw, deps);
+
+		expect(mock.status).toBe(503);
+		const body = mock.body() as { status: string; checks: ReadyChecks };
+		expect(body.checks.catalog).toEqual({ status: 'empty' });
+	});
+
+	it('returns 200 with catalog.source: "l2" when L1 empty but L2 has data', async () => {
+		const mock = makeRes();
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			catalogL1Count: () => 0,
+			catalogL2Exists: async () => 1,
+		};
+
+		await handleReady(mock.raw, deps);
+
+		expect(mock.status).toBe(200);
+		const body = mock.body() as { status: string; checks: ReadyChecks };
+		expect(body.checks.catalog).toEqual({ status: 'ok', size: 0, source: 'l2' });
+	});
+});

--- a/src/server/__tests__/handler.test.ts
+++ b/src/server/__tests__/handler.test.ts
@@ -10,7 +10,7 @@
  * before they are initialised.
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { runReadyChecks, sendReadyResponse, handleReady } from '../ready.js';
 import type { ReadyDeps, ReadyChecks } from '../ready.js';
 
@@ -26,26 +26,6 @@ const happyDeps = (): ReadyDeps => ({
 	catalogL2Exists: null,
 	browserTimeoutMs: 500,
 });
-
-/** Collect the JSON body written to a mock ServerResponse. */
-const makeMockResponse = () => {
-	const chunks: string[] = [];
-	return {
-		writtenStatus: 0 as number,
-		body: () => JSON.parse(chunks.join('')),
-		res: {
-			writeHead(status: number) {
-				this.writtenStatus = status;
-			},
-			end(chunk: string) {
-				chunks.push(chunk);
-			},
-		} as unknown as import('node:http').ServerResponse,
-		get writtenStatus() {
-			return (this as { _status: number })._status ?? 0;
-		},
-	};
-};
 
 // We need a response mock that tracks status separately from the object literal
 // so writtenStatus updates are visible after the call.

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -282,6 +282,15 @@ const redisClient: IORedis | null = REDIS_URL
 		})
 	: null;
 
+// Declare which cache tier is active at boot so operators can diagnose silent
+// L1-only degradation (e.g. REDIS_URL accidentally unset in prod) from logs
+// alone, without having to probe the running process.
+logEvent('INFO', 'Cache mode selected', {
+	event: 'cache_mode_selected',
+	mode: redisClient ? 'l1+l2' : 'l1-only',
+	redisConfigured: Boolean(process.env.REDIS_URL),
+});
+
 if (redisClient) {
 	redisClient.on('error', (e) => {
 		logEvent('ERROR', 'Redis L2 client error', {
@@ -291,7 +300,7 @@ if (redisClient) {
 	});
 }
 
-const redisL2Adapter: ServiceCatalogRedisL2 | undefined = redisClient
+const serviceCatalogRedisL2: ServiceCatalogRedisL2 | undefined = redisClient
 	? {
 			getCached: <A>(
 				key: string,
@@ -319,7 +328,7 @@ const serviceCatalog = createAcuityServiceCatalog({
 	staticServices: parseStaticServicesJson(process.env.SERVICES_JSON),
 	scraperConfig,
 	logger: createServiceCatalogLogger(),
-	redisL2: redisL2Adapter,
+	redisL2: serviceCatalogRedisL2,
 });
 
 const isSchedulingError = (error: unknown): error is SchedulingError =>

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -37,6 +37,7 @@ import type { Redis as IORedis } from 'ioredis';
 import type { ScraperConfig } from '../adapters/acuity/scraper.js';
 import {
 	BrowserProcessLive,
+	BrowserProcess,
 	BrowserService,
 	BrowserSessionLive,
 	type BrowserConfig,
@@ -66,6 +67,7 @@ import {
 	readSlotsViaUrl,
 } from '../adapters/acuity/steps/read-via-url.js';
 import { buildHealthPayload } from './health.js';
+import { handleReady as _handleReady } from './ready.js';
 import { ndjsonLog } from '../shared/logger.js';
 import type {
 	Booking,
@@ -353,6 +355,32 @@ const isAcuityAppointmentTypeId = (serviceId: string): boolean => /^\d+$/.test(s
 // =============================================================================
 // ROUTE HANDLERS
 // =============================================================================
+
+/** The L2 Redis key used by the service catalog (must match acuity-service-catalog.ts). */
+const CATALOG_REDIS_KEY = `acuity:services:v1:${ACUITY_BASE_URL}`;
+
+/**
+ * Real-liveness readiness handler wired to the module-level singletons.
+ *
+ * Checks (in parallel, under ~3 s combined budget):
+ *  1. Redis ping
+ *  2. Browser pool `isConnected()` via BrowserProcess Effect service
+ *  3. Catalog has data in L1 (getCachedCount) or L2 (Redis EXISTS)
+ *
+ * Returns HTTP 200 when all pass; 503 otherwise.
+ */
+const handleReady = (res: ServerResponse) =>
+	_handleReady(res, {
+		redisPing: redisClient ? () => redisClient!.ping() : null,
+		browserConnected: () =>
+			browserRuntime.runPromise(
+				BrowserProcess.pipe(Effect.map(({ browser }) => browser.isConnected())),
+			),
+		catalogL1Count: () => serviceCatalog.getCachedCount(),
+		catalogL2Exists: redisClient
+			? () => redisClient!.exists(CATALOG_REDIS_KEY)
+			: null,
+	});
 
 const handleHealth = (_req: IncomingMessage, res: ServerResponse) => {
 	sendSuccess(
@@ -726,19 +754,7 @@ const server = createServer(async (req, res) => {
 		}
 
 		if (path === '/ready' && method === 'GET') {
-			// Redis readiness gate: when a client is configured, a failing ping
-			// flips the pod out of service. When unconfigured (local dev), we
-			// skip the check so the app stays bootable.
-			const redisOk = redisClient
-				? (await redisClient.ping().catch(() => null)) === 'PONG'
-				: true;
-			if (!redisOk) {
-				res.writeHead(503, { 'Content-Type': 'text/plain' });
-				res.end('redis unreachable');
-				return;
-			}
-			// Preserve legacy readiness signal (mirrors `/health` semantics).
-			return handleHealth(req, res);
+			return handleReady(res);
 		}
 
 		// Route matching

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -32,6 +32,8 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { randomUUID } from 'node:crypto';
 import { Effect, Exit, Cause, ManagedRuntime, Scope } from 'effect';
+import { Redis as IORedisImpl } from 'ioredis';
+import type { Redis as IORedis } from 'ioredis';
 import type { ScraperConfig } from '../adapters/acuity/scraper.js';
 import {
 	BrowserProcessLive,
@@ -43,7 +45,10 @@ import {
 import {
 	createAcuityServiceCatalog,
 	parseStaticServicesJson,
+	type ServiceCatalogRedisL2,
 } from '../shared/acuity-service-catalog.js';
+import { getCached as redisL2GetCached, RedisL2 } from '../shared/redis-l2.js';
+import { metrics, renderMetrics } from '../shared/metrics.js';
 import { toSchedulingError, type MiddlewareError } from '../adapters/acuity/errors.js';
 import {
 	navigateToBooking,
@@ -250,12 +255,71 @@ const runEffect = async <A>(
 	return { ok: false, error: { _tag: 'InfrastructureError', code: 'UNKNOWN', message: Cause.pretty(exit.cause) } };
 };
 
+// =============================================================================
+// REDIS L2 CLIENT + ADAPTER SHIM
+// =============================================================================
+//
+// `RedisL2.getCached` (from `shared/redis-l2.ts`) expects `mk: () => Promise<A>`
+// because its Effect.gen generator internally calls `Effect.tryPromise({ try:
+// () => mk(), ... })`. But `ServiceCatalogRedisL2.getCached` (the structural
+// interface the catalog depends on) takes `mk: Effect.Effect<A>` so that
+// non-Node callers and tests stay Effect-native.
+//
+// This shim bridges the two: the catalog hands us an Effect, we wrap it as a
+// Promise via `Effect.runPromise`, pass it into the real `getCached`, and
+// provide the `RedisL2` service via a module-level singleton ioredis client.
+//
+// If REDIS_URL is missing (local dev), `redisL2` stays `undefined` and the
+// catalog falls back to its in-process single-flight path.
+
+const REDIS_URL = process.env.REDIS_URL;
+const REDIS_PASSWORD = process.env.REDIS_PASSWORD;
+
+const redisClient: IORedis | null = REDIS_URL
+	? new IORedisImpl(REDIS_URL, {
+			password: REDIS_PASSWORD,
+			maxRetriesPerRequest: 3,
+		})
+	: null;
+
+if (redisClient) {
+	redisClient.on('error', (e) => {
+		logEvent('ERROR', 'Redis L2 client error', {
+			event: 'redis_client_error',
+			error: describeLogValue(e),
+		});
+	});
+}
+
+const redisL2Adapter: ServiceCatalogRedisL2 | undefined = redisClient
+	? {
+			getCached: <A>(
+				key: string,
+				ttlSeconds: number,
+				mk: Effect.Effect<A>,
+			): Effect.Effect<A> => {
+				const mkPromise = (): Promise<A> => Effect.runPromise(mk);
+				// Provide the RedisL2 service for the real `getCached`, then erase
+				// the `RedisError | CacheTimeoutError` channel so the result fits
+				// the `Effect.Effect<A>` shape expected by the catalog. Defects
+				// propagate as rejections through `Effect.runPromise` in the
+				// catalog, preserving the error-surface contract documented in
+				// `acuity-service-catalog.ts`.
+				return redisL2GetCached(key, ttlSeconds, mkPromise).pipe(
+					Effect.provideService(RedisL2, redisClient),
+					Effect.orDie,
+				);
+			},
+		}
+	: undefined;
+
 const serviceCatalog = createAcuityServiceCatalog({
 	baseUrl: ACUITY_BASE_URL,
 	cacheTtlMs: SERVICE_CACHE_TTL_MS,
 	staticServices: parseStaticServicesJson(process.env.SERVICES_JSON),
 	scraperConfig,
 	logger: createServiceCatalogLogger(),
+	redisL2: redisL2Adapter,
 });
 
 const isSchedulingError = (error: unknown): error is SchedulingError =>
@@ -625,8 +689,9 @@ const server = createServer(async (req, res) => {
 		});
 	});
 
-	// Auth check (skip health endpoint)
-	if (AUTH_TOKEN && path !== '/health') {
+	// Auth check (skip health + observability endpoints)
+	const unauthenticatedPaths = new Set(['/health', '/ready', '/metrics']);
+	if (AUTH_TOKEN && !unauthenticatedPaths.has(path)) {
 		const auth = req.headers.authorization;
 		if (auth !== `Bearer ${AUTH_TOKEN}`) {
 			logRequestEvent('WARN', 'Unauthorized request rejected', context, {
@@ -641,6 +706,32 @@ const server = createServer(async (req, res) => {
 	}
 
 	try {
+		// Observability endpoints are matched BEFORE the main dispatch so the
+		// Prometheus scraper and k8s readiness probe never race with auth or
+		// business-logic errors.
+		if (path === '/metrics' && method === 'GET') {
+			const body = await renderMetrics();
+			res.writeHead(200, { 'Content-Type': metrics.registry.contentType });
+			res.end(body);
+			return;
+		}
+
+		if (path === '/ready' && method === 'GET') {
+			// Redis readiness gate: when a client is configured, a failing ping
+			// flips the pod out of service. When unconfigured (local dev), we
+			// skip the check so the app stays bootable.
+			const redisOk = redisClient
+				? (await redisClient.ping().catch(() => null)) === 'PONG'
+				: true;
+			if (!redisOk) {
+				res.writeHead(503, { 'Content-Type': 'text/plain' });
+				res.end('redis unreachable');
+				return;
+			}
+			// Preserve legacy readiness signal (mirrors `/health` semantics).
+			return handleHealth(req, res);
+		}
+
 		// Route matching
 		if (path === '/health' && method === 'GET') {
 			return handleHealth(req, res);
@@ -704,7 +795,13 @@ const disposeBrowserRuntime = () => {
 	});
 };
 
+const disposeRedisClient = () => {
+	if (!redisClient) return;
+	void redisClient.quit().catch(() => undefined);
+};
+
 server.on('close', disposeBrowserRuntime);
+server.on('close', disposeRedisClient);
 
 // Only start listening when this file is executed directly (not imported)
 if (process.argv[1]?.match(/handler\.(ts|js|mjs)$/)) {

--- a/src/server/ready.ts
+++ b/src/server/ready.ts
@@ -82,6 +82,8 @@ const probeCatalog = async (
 		if (catalogL2Exists) {
 			const exists = await catalogL2Exists().catch(() => null);
 			if (exists === 1) {
+				// size: 0 on L2 hit — EXISTS does not deserialize the payload.
+				// A consumer that needs the real size must GET the key; /ready stays cheap.
 				return { status: 'ok', size: 0, source: 'l2' };
 			}
 		}

--- a/src/server/ready.ts
+++ b/src/server/ready.ts
@@ -1,0 +1,138 @@
+/**
+ * Real-liveness readiness probe for K8s /ready endpoint.
+ *
+ * All dependencies are injected so this module is fully unit-testable without
+ * starting a real browser or Redis connection.
+ */
+
+import type { ServerResponse } from 'node:http';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export type RedisStatus = 'ok' | 'unreachable';
+export type BrowserStatus = 'ok' | 'unavailable' | 'timeout';
+
+export type CatalogResult =
+	| { status: 'ok'; size: number; source: 'l1' | 'l2' }
+	| { status: 'empty' }
+	| { status: 'error'; error: string };
+
+export interface ReadyChecks {
+	redis: RedisStatus;
+	browser: BrowserStatus;
+	catalog: CatalogResult;
+}
+
+export interface ReadyDeps {
+	/** Ping Redis — resolves to 'PONG' on success, rejects on failure. */
+	redisPing: (() => Promise<string>) | null;
+	/** Probe browser liveness — resolves to true if browser is connected. */
+	browserConnected: () => Promise<boolean>;
+	/** Count of services in the L1 in-process cache (synchronous). */
+	catalogL1Count: () => number;
+	/** Check if the catalog key exists in L2 Redis (1 = yes, 0/null = no/error). */
+	catalogL2Exists: (() => Promise<number | null>) | null;
+	/** Timeout in ms for the browser probe (default: 2000). */
+	browserTimeoutMs?: number;
+}
+
+// =============================================================================
+// PROBE HELPERS
+// =============================================================================
+
+const BROWSER_DEFAULT_TIMEOUT_MS = 2000;
+
+const probeRedis = async (redisPing: (() => Promise<string>) | null): Promise<RedisStatus> => {
+	if (!redisPing) return 'ok';
+	try {
+		const result = await redisPing();
+		return result === 'PONG' ? 'ok' : 'unreachable';
+	} catch {
+		return 'unreachable';
+	}
+};
+
+const probeBrowser = async (
+	browserConnected: () => Promise<boolean>,
+	timeoutMs: number,
+): Promise<BrowserStatus> => {
+	const check = browserConnected()
+		.then((connected) => (connected ? ('ok' as const) : ('unavailable' as const)))
+		.catch(() => 'unavailable' as const);
+
+	const timer = new Promise<'timeout'>((resolve) =>
+		setTimeout(() => resolve('timeout'), timeoutMs),
+	);
+
+	return Promise.race([check, timer]);
+};
+
+const probeCatalog = async (
+	catalogL1Count: () => number,
+	catalogL2Exists: (() => Promise<number | null>) | null,
+): Promise<CatalogResult> => {
+	try {
+		const l1Count = catalogL1Count();
+		if (l1Count > 0) {
+			return { status: 'ok', size: l1Count, source: 'l1' };
+		}
+
+		if (catalogL2Exists) {
+			const exists = await catalogL2Exists().catch(() => null);
+			if (exists === 1) {
+				return { status: 'ok', size: 0, source: 'l2' };
+			}
+		}
+
+		return { status: 'empty' };
+	} catch (e) {
+		return { status: 'error', error: e instanceof Error ? e.message : String(e) };
+	}
+};
+
+// =============================================================================
+// READINESS CHECK
+// =============================================================================
+
+/**
+ * Run all liveness sub-checks in parallel and return a structured result.
+ * Never throws — all errors are captured in the returned checks object.
+ */
+export const runReadyChecks = async (deps: ReadyDeps): Promise<ReadyChecks> => {
+	const timeoutMs = deps.browserTimeoutMs ?? BROWSER_DEFAULT_TIMEOUT_MS;
+
+	const [redis, browser, catalog] = await Promise.all([
+		probeRedis(deps.redisPing),
+		probeBrowser(deps.browserConnected, timeoutMs),
+		probeCatalog(deps.catalogL1Count, deps.catalogL2Exists),
+	]);
+
+	return { redis, browser, catalog };
+};
+
+/**
+ * Write a `/ready` HTTP response based on the provided checks result.
+ * HTTP 200 when all checks pass; 503 otherwise.
+ */
+export const sendReadyResponse = (res: ServerResponse, checks: ReadyChecks): void => {
+	const allOk =
+		checks.redis === 'ok' && checks.browser === 'ok' && checks.catalog.status === 'ok';
+
+	res.writeHead(allOk ? 200 : 503, { 'Content-Type': 'application/json' });
+	res.end(
+		JSON.stringify({
+			status: allOk ? 'ready' : 'not_ready',
+			checks,
+		}),
+	);
+};
+
+/**
+ * Full `/ready` handler: run checks then send HTTP response.
+ */
+export const handleReady = async (res: ServerResponse, deps: ReadyDeps): Promise<void> => {
+	const checks = await runReadyChecks(deps);
+	sendReadyResponse(res, checks);
+};

--- a/src/shared/__tests__/acuity-service-catalog.test.ts
+++ b/src/shared/__tests__/acuity-service-catalog.test.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 import {
 	createAcuityServiceCatalog,
@@ -138,5 +139,56 @@ describe('createAcuityServiceCatalog', () => {
 		await expect(catalog.getServices()).resolves.toEqual(services);
 		await expect(catalog.resolveServiceName('svc-2')).resolves.toBe('TMD Tuneup');
 		expect(loadScraperServices).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('AcuityServiceCatalog with Redis L2', () => {
+	it('delegates single-flight to RedisL2.getCached when redisL2 provided', async () => {
+		const mkGetCached = vi.fn(
+			async (_k: string, _ttl: number, mk: Effect.Effect<unknown>) =>
+				await Effect.runPromise(mk),
+		);
+		const mockL2 = {
+			getCached: <A>(key: string, ttl: number, mk: Effect.Effect<A>) =>
+				Effect.promise(() => mkGetCached(key, ttl, mk) as Promise<A>),
+		};
+
+		const fetchBusinessData = vi.fn(async () => null);
+		const loadScraperServices = vi.fn(async () => services);
+
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://x.as.me',
+			staticServices: null,
+			fetchBusinessData,
+			loadScraperServices,
+			redisL2: mockL2,
+			logger: makeLogger(),
+		});
+
+		await catalog.getServices();
+		await catalog.getServices();
+
+		// L2 layer handles dedup; catalog calls it every time.
+		expect(mkGetCached).toHaveBeenCalledTimes(2);
+		// Key should be namespaced with baseUrl.
+		const firstCallKey = mkGetCached.mock.calls[0]?.[0];
+		expect(firstCallKey).toBe('acuity:services:v1:https://x.as.me');
+	});
+
+	it('falls back to in-process cache when redisL2 absent', async () => {
+		const loadSpy = vi.fn(async () => services);
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://x.as.me',
+			staticServices: null,
+			fetchBusinessData: async () => null,
+			loadScraperServices: loadSpy,
+			logger: makeLogger(),
+		});
+
+		await catalog.getServices();
+		await catalog.getServices();
+
+		// in-proc cache hit on second call.
+		expect(loadSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/shared/__tests__/acuity-service-catalog.test.ts
+++ b/src/shared/__tests__/acuity-service-catalog.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import {
 	createAcuityServiceCatalog,
 	parseStaticServicesJson,
+	type AcuityServiceCatalogConfig,
 	type ServiceCatalogLogger,
+	type ServiceCatalogRedisL2,
 } from '../acuity-service-catalog.js';
 import type { Service } from '../../core/types.js';
 import type { AcuityBusinessData } from '../../adapters/acuity/steps/index.js';
@@ -190,5 +192,22 @@ describe('AcuityServiceCatalog with Redis L2', () => {
 
 		// in-proc cache hit on second call.
 		expect(loadSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('surfaces redisL2.getCached errors without falling back to L1', async () => {
+		const boom = new Error('redis-down');
+		const mkGetCached = vi.fn().mockImplementation(
+			() => Effect.fail(boom as never) as Effect.Effect<Service[]>,
+		);
+		const fakeL2 = { getCached: mkGetCached } as ServiceCatalogRedisL2;
+
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://x.as.me',
+			redisL2: fakeL2,
+			staticServices: null,
+		} as unknown as AcuityServiceCatalogConfig);
+
+		await expect(catalog.getServices()).rejects.toThrow();
+		expect(mkGetCached).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/shared/__tests__/acuity-service-catalog.test.ts
+++ b/src/shared/__tests__/acuity-service-catalog.test.ts
@@ -210,4 +210,48 @@ describe('AcuityServiceCatalog with Redis L2', () => {
 		await expect(catalog.getServices()).rejects.toThrow();
 		expect(mkGetCached).toHaveBeenCalledTimes(1);
 	});
+
+	it('increments scrape counter with source=lock_winner when L2 runs mk', async () => {
+		const { metrics } = await import('../metrics.js');
+		const winnerBefore =
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
+				(v) => v.labels.source === 'lock_winner',
+			)?.value ?? 0;
+
+		const mockL2: ServiceCatalogRedisL2 = {
+			getCached: <A>(_k: string, _ttl: number, mk: Effect.Effect<A>) =>
+				Effect.tap(mk, () =>
+					Effect.sync(() =>
+						metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_winner' }),
+					),
+				),
+		};
+
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://x.as.me',
+			staticServices: null,
+			fetchBusinessData: async () => null,
+			loadScraperServices: async () => [
+				{
+					id: '1',
+					name: 's',
+					duration: 60,
+					price: 0,
+					currency: 'USD',
+					category: 'test',
+					active: true,
+				},
+			],
+			redisL2: mockL2,
+			logger: makeLogger(),
+		});
+		await catalog.getServices();
+
+		const winnerAfter =
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
+				(v) => v.labels.source === 'lock_winner',
+			)?.value ?? 0;
+
+		expect(winnerAfter).toBe(winnerBefore + 1);
+	});
 });

--- a/src/shared/__tests__/acuity-service-catalog.test.ts
+++ b/src/shared/__tests__/acuity-service-catalog.test.ts
@@ -7,6 +7,7 @@ import {
 	type ServiceCatalogLogger,
 	type ServiceCatalogRedisL2,
 } from '../acuity-service-catalog.js';
+import { _resetCacheHitRatioForTests, metrics } from '../metrics.js';
 import type { Service } from '../../core/types.js';
 import type { AcuityBusinessData } from '../../adapters/acuity/steps/index.js';
 
@@ -253,5 +254,54 @@ describe('AcuityServiceCatalog with Redis L2', () => {
 			)?.value ?? 0;
 
 		expect(winnerAfter).toBe(winnerBefore + 1);
+	});
+});
+
+describe('AcuityServiceCatalog cache hit ratio wiring', () => {
+	const ratioGauge = async (): Promise<number> => {
+		const snap = await metrics.cacheHitRatio.get();
+		return snap.values[0]?.value ?? NaN;
+	};
+
+	it('records a miss on first load and a hit on subsequent L1 reads', async () => {
+		_resetCacheHitRatioForTests();
+
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://example.com',
+			cacheTtlMs: 60_000,
+			fetchBusinessData: vi.fn(async () => ({} as AcuityBusinessData)),
+			businessToServices: vi.fn(() => services),
+			logger: makeLogger(),
+		});
+
+		// Startup value: no samples, ratio should be the "healthy" 1.0 so the
+		// AcuityCacheHitRatioLow alert does not page an empty pod.
+		expect(await ratioGauge()).toBe(1);
+
+		// First call: cold cache → miss, ratio becomes 0/1 = 0.
+		await catalog.getServices();
+		expect(await ratioGauge()).toBe(0);
+
+		// Second call: inside TTL, served from L1 → hit, ratio = 1/2 = 0.5.
+		await catalog.getServices();
+		expect(await ratioGauge()).toBeCloseTo(0.5, 10);
+
+		// Third call: another L1 hit → ratio = 2/3.
+		await catalog.getServices();
+		expect(await ratioGauge()).toBeCloseTo(2 / 3, 10);
+	});
+
+	it('treats static-service configuration as a cache hit', async () => {
+		_resetCacheHitRatioForTests();
+		const catalog = createAcuityServiceCatalog({
+			baseUrl: 'https://example.com',
+			staticServices: services,
+			logger: makeLogger(),
+		});
+
+		await catalog.getServices();
+		// Static services are a declared configuration surface — they should
+		// never flip the gauge into "unhealthy" territory.
+		expect(await ratioGauge()).toBe(1);
 	});
 });

--- a/src/shared/acuity-service-catalog.ts
+++ b/src/shared/acuity-service-catalog.ts
@@ -28,6 +28,12 @@ export interface AcuityServiceCatalog {
  * the catalog stays usable from non-Effect callers and is trivially mockable
  * in tests. The wiring module (e.g. `src/server/handler.ts`) is responsible
  * for providing the `RedisL2` context that the real `getCached` needs.
+ *
+ * NOTE: this interface intentionally erases Effect error/context channels.
+ * Callers wiring a real `RedisL2` instance must provide a
+ * `(mk: Effect.Effect<A>) => ...` shim that handles `RedisError` /
+ * `CacheTimeoutError` (or turns them into defects). Errors not handled
+ * before `Effect.runPromise` below will reject as unknown defects.
  */
 export interface ServiceCatalogRedisL2 {
 	readonly getCached: <A>(
@@ -193,6 +199,7 @@ export const createAcuityServiceCatalog = (
 			// L2 path: delegate single-flight + TTL to the networked cache.
 			// Coordination across pods is only correct when every refresh goes
 			// through L2, so we skip the in-process `loadInFlight` dedup here.
+			// bump the "v1" suffix when Service shape changes to invalidate stale L2 entries across rolling deploys
 			const cacheKey = `acuity:services:v1:${config.baseUrl}`;
 			const ttlSeconds = Math.max(1, Math.floor(cacheTtlMs / 1000));
 			const services = await Effect.runPromise(

--- a/src/shared/acuity-service-catalog.ts
+++ b/src/shared/acuity-service-catalog.ts
@@ -6,6 +6,7 @@ import {
 	type AcuityBusinessData,
 } from '../adapters/acuity/steps/index.js';
 import { Errors, type SchedulingError, type Service } from '../core/types.js';
+import { metrics } from './metrics.js';
 
 export interface ServiceCatalogLogger {
 	readonly log?: (...args: unknown[]) => void;
@@ -231,10 +232,21 @@ export const createAcuityServiceCatalog = (
 		// When L2 is wired, every call goes through it — L2 is the freshness
 		// authority, not the in-process `cachedServices` buffer. Static
 		// services still short-circuit because they are the declared truth.
+		// Hit/miss accounting for the L2 path is recorded inside
+		// `redis-l2.ts::getCached` so we do not double-count here.
 		if (config.redisL2 && !staticServices) {
 			return runRefresh();
 		}
-		return hasFreshCache() ? cloneServices(cachedServices ?? []) : runRefresh();
+		// L1-only path: a fresh in-process buffer counts as a cache hit, any
+		// path that falls through to `runRefresh()` counts as a miss. Static
+		// services are a declared configuration surface, not a cache, so they
+		// are counted as hits for dashboard continuity.
+		if (hasFreshCache()) {
+			metrics.recordCacheHit();
+			return cloneServices(cachedServices ?? []);
+		}
+		metrics.recordCacheMiss();
+		return runRefresh();
 	};
 
 	return {

--- a/src/shared/acuity-service-catalog.ts
+++ b/src/shared/acuity-service-catalog.ts
@@ -21,6 +21,22 @@ export interface AcuityServiceCatalog {
 	readonly resolveServiceName: (serviceId: string, serviceName?: string) => Promise<string>;
 }
 
+/**
+ * Minimal interface over `RedisL2.getCached` that the catalog depends on.
+ *
+ * Kept as a structural interface (not the concrete Effect service Tag) so that
+ * the catalog stays usable from non-Effect callers and is trivially mockable
+ * in tests. The wiring module (e.g. `src/server/handler.ts`) is responsible
+ * for providing the `RedisL2` context that the real `getCached` needs.
+ */
+export interface ServiceCatalogRedisL2 {
+	readonly getCached: <A>(
+		key: string,
+		ttlSeconds: number,
+		mk: Effect.Effect<A>,
+	) => Effect.Effect<A>;
+}
+
 export interface AcuityServiceCatalogConfig {
 	readonly baseUrl: string;
 	readonly staticServices?: readonly Service[] | null;
@@ -31,6 +47,17 @@ export interface AcuityServiceCatalogConfig {
 	readonly businessToServices?: (business: AcuityBusinessData) => Service[];
 	readonly loadScraperServices?: () => Promise<readonly Service[]>;
 	readonly now?: () => number;
+	/**
+	 * Optional L2 (networked) cache. When provided, every `runRefresh()` call
+	 * is delegated through `getCached`, which is expected to provide
+	 * cross-pod single-flight + TTL semantics. The in-process `loadInFlight`
+	 * dedup path is bypassed because L2 is the coordination boundary.
+	 *
+	 * The local `cachedServices` buffer is still maintained so that the
+	 * synchronous `getCachedService()` accessor and `resolveServiceName()`
+	 * fast path keep working.
+	 */
+	readonly redisL2?: ServiceCatalogRedisL2;
 }
 
 const cloneService = (service: Service): Service => ({ ...service });
@@ -162,6 +189,27 @@ export const createAcuityServiceCatalog = (
 	};
 
 	const runRefresh = async (): Promise<Service[]> => {
+		if (config.redisL2) {
+			// L2 path: delegate single-flight + TTL to the networked cache.
+			// Coordination across pods is only correct when every refresh goes
+			// through L2, so we skip the in-process `loadInFlight` dedup here.
+			const cacheKey = `acuity:services:v1:${config.baseUrl}`;
+			const ttlSeconds = Math.max(1, Math.floor(cacheTtlMs / 1000));
+			const services = await Effect.runPromise(
+				config.redisL2.getCached(
+					cacheKey,
+					ttlSeconds,
+					Effect.promise(refreshServices),
+				),
+			);
+			// Keep L1 buffer warm so `getCachedService()` and the
+			// `resolveServiceName()` fast-path can serve synchronously.
+			setCachedServices(services);
+			return cloneServices(services);
+		}
+
+		// In-process Promise dedup: single-node deployments (or the fallback
+		// path for tests / local dev without Redis).
 		if (!loadInFlight) {
 			loadInFlight = refreshServices().finally(() => {
 				loadInFlight = null;
@@ -170,8 +218,15 @@ export const createAcuityServiceCatalog = (
 		return cloneServices(await loadInFlight);
 	};
 
-	const ensureServices = async (): Promise<Service[]> =>
-		hasFreshCache() ? cloneServices(cachedServices ?? []) : runRefresh();
+	const ensureServices = async (): Promise<Service[]> => {
+		// When L2 is wired, every call goes through it — L2 is the freshness
+		// authority, not the in-process `cachedServices` buffer. Static
+		// services still short-circuit because they are the declared truth.
+		if (config.redisL2 && !staticServices) {
+			return runRefresh();
+		}
+		return hasFreshCache() ? cloneServices(cachedServices ?? []) : runRefresh();
+	};
 
 	return {
 		staticServicesCount: staticServices?.length ?? 0,

--- a/src/shared/acuity-service-catalog.ts
+++ b/src/shared/acuity-service-catalog.ts
@@ -18,6 +18,8 @@ export interface AcuityServiceCatalog {
 	readonly getServices: () => Promise<Service[]>;
 	readonly getService: (serviceId: string) => Promise<Service | null>;
 	readonly getCachedService: (serviceId: string) => Service | undefined;
+	/** Returns the number of services currently held in the L1 in-process cache (0 = not yet populated). */
+	readonly getCachedCount: () => number;
 	readonly resolveServiceName: (serviceId: string, serviceName?: string) => Promise<string>;
 }
 
@@ -246,6 +248,7 @@ export const createAcuityServiceCatalog = (
 			const service = cachedServices?.find((candidate) => candidate.id === serviceId);
 			return service ? cloneService(service) : undefined;
 		},
+		getCachedCount: () => cachedServices?.length ?? 0,
 		resolveServiceName: async (serviceId, serviceName) => {
 			if (isNonNumericServiceName(serviceName)) {
 				return serviceName;

--- a/src/shared/browser-service.ts
+++ b/src/shared/browser-service.ts
@@ -9,6 +9,7 @@
 import { Context, Effect, Layer, Scope } from 'effect';
 import type { Browser, Page } from 'playwright-core';
 import { BrowserError } from '../adapters/acuity/errors.js';
+import { metrics } from './metrics.js';
 
 // =============================================================================
 // CONFIGURATION
@@ -138,16 +139,25 @@ export const BrowserSessionLive = Layer.scoped(
 	Effect.gen(function* () {
 		const { browser, config } = yield* BrowserProcess;
 
+		// Track the active page as a Playwright "session" via acquire/release —
+		// `browserActiveSessions` is incremented when the page is created and
+		// decremented when the scope closes (including on interrupt / failure),
+		// so the gauge reflects the number of live contexts at any instant.
 		const page: Page = yield* Effect.acquireRelease(
 			Effect.tryPromise({
 				try: async () => {
 					const p = await browser.newPage({ userAgent: config.userAgent });
 					p.setDefaultTimeout(config.timeout);
+					metrics.browserActiveSessions.inc();
 					return p;
 				},
 				catch: (e) => new BrowserError({ reason: 'PAGE_FAILED', cause: e }),
 			}),
-			(p) => Effect.promise(() => p.close()).pipe(Effect.ignoreLogged),
+			(p) =>
+				Effect.promise(() => p.close()).pipe(
+					Effect.ensuring(Effect.sync(() => metrics.browserActiveSessions.dec())),
+					Effect.ignoreLogged,
+				),
 		);
 
 		const acquirePage = Effect.acquireRelease(

--- a/src/shared/metrics.test.ts
+++ b/src/shared/metrics.test.ts
@@ -1,5 +1,15 @@
+import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
-import { metrics, renderMetrics } from './metrics.js';
+import {
+	_resetCacheHitRatioForTests,
+	metrics,
+	observePageOp,
+	observePageOpEffect,
+	recordCacheHit,
+	recordCacheMiss,
+	renderMetrics,
+	trackBrowserSession,
+} from './metrics.js';
 
 describe('metrics', () => {
 	it('exposes required SLIs from spec §6.1', () => {
@@ -37,5 +47,149 @@ describe('metrics', () => {
 				(v) => v.labels.source === 'lock_winner',
 			)?.value ?? 0;
 		expect(after).toBe(before + 1);
+	});
+});
+
+describe('cacheHitRatio wiring', () => {
+	const gaugeValue = async (): Promise<number> => {
+		const snap = await metrics.cacheHitRatio.get();
+		return snap.values[0]?.value ?? NaN;
+	};
+
+	it('starts at 1.0 so alerts do not page an idle pod', async () => {
+		_resetCacheHitRatioForTests();
+		// No hits, no misses — the gauge must be a "healthy" 1.0. A raw
+		// computation would divide by zero here; the helper must guard that.
+		expect(await gaugeValue()).toBe(1);
+	});
+
+	it('updates the gauge on hit/miss transitions', async () => {
+		_resetCacheHitRatioForTests();
+
+		recordCacheHit();
+		// 1 hit, 0 misses → ratio = 1
+		expect(await gaugeValue()).toBe(1);
+
+		recordCacheMiss();
+		// 1 hit, 1 miss → ratio = 0.5
+		expect(await gaugeValue()).toBe(0.5);
+
+		recordCacheHit();
+		recordCacheHit();
+		// 3 hits, 1 miss → 0.75
+		expect(await gaugeValue()).toBe(0.75);
+	});
+});
+
+describe('pageOperationsDuration wiring', () => {
+	it('records a sample for each observePageOp invocation', async () => {
+		const bucketCountFor = async (op: string): Promise<number> => {
+			const snap = await metrics.pageOperationsDuration.get();
+			// `_count` lines have `metricName: <name>_count` and the matching operation label.
+			const row = snap.values.find(
+				(v) => v.metricName === 'acuity_page_operations_duration_seconds_count' &&
+					v.labels.operation === op,
+			);
+			return (row?.value as number | undefined) ?? 0;
+		};
+
+		const before = await bucketCountFor('test_op');
+		await observePageOp('test_op', async () => 'value');
+		const after = await bucketCountFor('test_op');
+		expect(after).toBe(before + 1);
+	});
+
+	it('records a sample even when the wrapped function throws', async () => {
+		const bucketCountFor = async (op: string): Promise<number> => {
+			const snap = await metrics.pageOperationsDuration.get();
+			const row = snap.values.find(
+				(v) => v.metricName === 'acuity_page_operations_duration_seconds_count' &&
+					v.labels.operation === op,
+			);
+			return (row?.value as number | undefined) ?? 0;
+		};
+
+		const before = await bucketCountFor('test_op_fail');
+		await expect(
+			observePageOp('test_op_fail', async () => {
+				throw new Error('boom');
+			}),
+		).rejects.toThrow('boom');
+		const after = await bucketCountFor('test_op_fail');
+		expect(after).toBe(before + 1);
+	});
+
+	it('observes samples via the Effect combinator', async () => {
+		const bucketCountFor = async (op: string): Promise<number> => {
+			const snap = await metrics.pageOperationsDuration.get();
+			const row = snap.values.find(
+				(v) => v.metricName === 'acuity_page_operations_duration_seconds_count' &&
+					v.labels.operation === op,
+			);
+			return (row?.value as number | undefined) ?? 0;
+		};
+
+		const before = await bucketCountFor('effect_op');
+		await Effect.runPromise(observePageOpEffect('effect_op', Effect.succeed(42)));
+		const after = await bucketCountFor('effect_op');
+		expect(after).toBe(before + 1);
+	});
+});
+
+describe('browserActiveSessions wiring', () => {
+	const gaugeValue = async (): Promise<number> => {
+		const snap = await metrics.browserActiveSessions.get();
+		return (snap.values[0]?.value as number | undefined) ?? 0;
+	};
+
+	it('increments on acquire and decrements on release via trackBrowserSession', async () => {
+		const baseline = await gaugeValue();
+
+		// The combinator takes an Effect; inside the Effect we assert the
+		// gauge has been incremented. After the Effect resolves, release
+		// must have run even without explicit finalisation.
+		const duringValue = await Effect.runPromise(
+			trackBrowserSession(
+				Effect.sync(() => {
+					// Synchronous peek while the session is "held".
+					const row = (metrics.browserActiveSessions as unknown as {
+						hashMap: Map<string, { value: number }>;
+					}).hashMap;
+					// Fallback to prom-client async snapshot if the internal
+					// structure changes in future versions.
+					void row;
+					return 'inside';
+				}),
+			),
+		);
+		expect(duringValue).toBe('inside');
+
+		// Post-release: gauge must have returned to baseline.
+		expect(await gaugeValue()).toBe(baseline);
+	});
+
+	it('decrements even when the wrapped Effect fails', async () => {
+		const baseline = await gaugeValue();
+		await expect(
+			Effect.runPromise(trackBrowserSession(Effect.fail('nope' as never))),
+		).rejects.toBeDefined();
+		expect(await gaugeValue()).toBe(baseline);
+	});
+
+	it('observes a non-zero gauge while the session is held', async () => {
+		const baseline = await gaugeValue();
+		let observedWhileHeld = baseline;
+
+		await Effect.runPromise(
+			trackBrowserSession(
+				Effect.promise(async () => {
+					const snap = await metrics.browserActiveSessions.get();
+					observedWhileHeld = (snap.values[0]?.value as number | undefined) ?? 0;
+				}),
+			),
+		);
+
+		expect(observedWhileHeld).toBe(baseline + 1);
+		expect(await gaugeValue()).toBe(baseline);
 	});
 });

--- a/src/shared/metrics.test.ts
+++ b/src/shared/metrics.test.ts
@@ -12,14 +12,30 @@ describe('metrics', () => {
 	});
 
 	it('renders Prometheus text format', async () => {
+		// Prime the histogram so the text exposition includes bucket/sum/count
+		// lines (empty histograms render with zero buckets only).
+		metrics.pageOperationsDuration.observe({ operation: 'test' }, 0.5);
 		const text = await renderMetrics();
 		expect(text).toContain('# HELP acuity_browser_active_sessions');
 		expect(text).toContain('# TYPE acuity_browser_active_sessions gauge');
+		// Histogram exposition: per-bucket cumulative, total sum, total count.
+		expect(text).toContain('acuity_page_operations_duration_seconds_bucket{');
+		expect(text).toContain('acuity_page_operations_duration_seconds_sum');
+		expect(text).toContain('acuity_page_operations_duration_seconds_count');
 	});
 
-	it('increments scrape counter with source label', () => {
+	it('increments scrape counter with source label', async () => {
+		// Delta assertion — registry is a module-level singleton so absolute
+		// values accumulate across tests. Pin the +1 rather than trust state.
+		const before =
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
+				(v) => v.labels.source === 'lock_winner',
+			)?.value ?? 0;
 		metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_winner' });
-		const winner = metrics.serviceCatalogScrapeTotal.labels({ source: 'lock_winner' });
-		expect(winner).toBeDefined();
+		const after =
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
+				(v) => v.labels.source === 'lock_winner',
+			)?.value ?? 0;
+		expect(after).toBe(before + 1);
 	});
 });

--- a/src/shared/metrics.test.ts
+++ b/src/shared/metrics.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { metrics, renderMetrics } from './metrics.js';
+
+describe('metrics', () => {
+	it('exposes required SLIs from spec §6.1', () => {
+		const names = metrics.registry.getMetricsAsArray().map((m) => m.name);
+		expect(names).toContain('acuity_browser_active_sessions');
+		expect(names).toContain('acuity_page_operations_duration_seconds');
+		expect(names).toContain('acuity_cache_hit_ratio');
+		expect(names).toContain('acuity_service_catalog_scrape_total');
+		expect(names).toContain('acuity_service_catalog_refresh_duration_seconds');
+	});
+
+	it('renders Prometheus text format', async () => {
+		const text = await renderMetrics();
+		expect(text).toContain('# HELP acuity_browser_active_sessions');
+		expect(text).toContain('# TYPE acuity_browser_active_sessions gauge');
+	});
+
+	it('increments scrape counter with source label', () => {
+		metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_winner' });
+		const winner = metrics.serviceCatalogScrapeTotal.labels({ source: 'lock_winner' });
+		expect(winner).toBeDefined();
+	});
+});

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import {
 	Counter,
 	Gauge,
@@ -54,6 +55,107 @@ const serviceCatalogRefreshDuration = new Histogram({
 	registers: [registry],
 });
 
+// ─── Derived cache hit-ratio ─────────────────────────────────────────────────
+//
+// `cacheHitRatio` is a derived gauge — prom-client cannot compute it for us,
+// so we keep module-scoped hit/miss counters and refresh the gauge on every
+// mutation. A "hit" is either an L1 in-process cache return or an L2 GET
+// that resolved to a cached value; a "miss" is any path that ended up
+// running the scrape / mk closure.
+//
+// Counters are module-scoped by design: they must persist across requests so
+// the gauge reflects steady-state behaviour rather than per-request bursts.
+// Before any traffic has been observed the gauge is set to 1.0 so alerts that
+// fire on `acuity_cache_hit_ratio < 0.8` do not page on a freshly-started pod
+// with no samples.
+
+let cacheHitCount = 0;
+let cacheMissCount = 0;
+
+cacheHitRatio.set(1);
+
+const refreshCacheHitRatio = () => {
+	const total = cacheHitCount + cacheMissCount;
+	if (total === 0) {
+		cacheHitRatio.set(1);
+		return;
+	}
+	cacheHitRatio.set(cacheHitCount / total);
+};
+
+/** Record a cache hit (L1 in-process buffer or L2 networked cache). */
+export const recordCacheHit = (): void => {
+	cacheHitCount += 1;
+	refreshCacheHitRatio();
+};
+
+/** Record a cache miss (fell through to scrape / mk closure). */
+export const recordCacheMiss = (): void => {
+	cacheMissCount += 1;
+	refreshCacheHitRatio();
+};
+
+/**
+ * Test-only helper to reset the hit/miss accumulators so assertions can pin
+ * the initial ratio. Module-level singletons accumulate across vitest files,
+ * so production code must never rely on this function.
+ */
+export const _resetCacheHitRatioForTests = (): void => {
+	cacheHitCount = 0;
+	cacheMissCount = 0;
+	cacheHitRatio.set(1);
+};
+
+// ─── Page-operation timer helper ─────────────────────────────────────────────
+//
+// Keep label cardinality low: `operation` should be a small enum of
+// high-level step names (e.g. `availability_dates`, `availability_slots`,
+// `scrape_catalog`, `wizard_navigate`). Never label per-service_id or per-url.
+
+/** Observe a Playwright/page operation's wall time. Handles Promise success + failure. */
+export const observePageOp = async <A>(
+	operation: string,
+	fn: () => Promise<A>,
+): Promise<A> => {
+	const end = pageOperationsDuration.startTimer({ operation });
+	try {
+		return await fn();
+	} finally {
+		end();
+	}
+};
+
+/**
+ * Effect combinator variant of `observePageOp` — times an Effect program and
+ * observes its wall time into `pageOperationsDuration`. Uses `Effect.acquireUseRelease`
+ * so that interruption still records a sample.
+ */
+export const observePageOpEffect = <A, E, R>(
+	operation: string,
+	effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+	Effect.acquireUseRelease(
+		Effect.sync(() => pageOperationsDuration.startTimer({ operation })),
+		() => effect,
+		(end) => Effect.sync(() => end()),
+	);
+
+// ─── Browser session lifecycle helper ────────────────────────────────────────
+//
+// Tracks the number of currently-active Playwright pages / contexts by
+// wrapping a scoped Effect with acquireUseRelease. Callers must use this
+// combinator instead of calling `.inc()` / `.dec()` directly so the
+// release path runs even on interrupt.
+
+export const trackBrowserSession = <A, E, R>(
+	effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+	Effect.acquireUseRelease(
+		Effect.sync(() => browserActiveSessions.inc()),
+		() => effect,
+		() => Effect.sync(() => browserActiveSessions.dec()),
+	);
+
 export const metrics = {
 	registry,
 	browserActiveSessions,
@@ -61,6 +163,11 @@ export const metrics = {
 	cacheHitRatio,
 	serviceCatalogScrapeTotal,
 	serviceCatalogRefreshDuration,
+	recordCacheHit,
+	recordCacheMiss,
+	observePageOp,
+	observePageOpEffect,
+	trackBrowserSession,
 };
 
 export const renderMetrics = (): Promise<string> => registry.metrics();

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -1,0 +1,66 @@
+import {
+	Counter,
+	Gauge,
+	Histogram,
+	Registry,
+	collectDefaultMetrics,
+} from 'prom-client';
+
+/**
+ * Prometheus metrics registry for the acuity-middleware bridge.
+ *
+ * Scope: Kubernetes phase 1.0 observability. SLIs are the canonical set
+ * enumerated in spec §6.1 — do not extend this list without a spec update.
+ *
+ * The `Registry` is a module-level singleton. In tests, a shared registry
+ * means counters accumulate across files — assertions should be written as
+ * deltas (e.g. `after - before === 1`) rather than absolute values.
+ */
+
+const registry = new Registry();
+collectDefaultMetrics({ register: registry, prefix: 'acuity_' });
+
+const browserActiveSessions = new Gauge({
+	name: 'acuity_browser_active_sessions',
+	help: 'Current number of open Playwright browser contexts',
+	registers: [registry],
+});
+
+const pageOperationsDuration = new Histogram({
+	name: 'acuity_page_operations_duration_seconds',
+	help: 'Duration of Playwright page operations',
+	labelNames: ['operation'],
+	buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+	registers: [registry],
+});
+
+const cacheHitRatio = new Gauge({
+	name: 'acuity_cache_hit_ratio',
+	help: 'Derived: l1_hits / (l1_hits + l2_hits + misses)',
+	registers: [registry],
+});
+
+const serviceCatalogScrapeTotal = new Counter({
+	name: 'acuity_service_catalog_scrape_total',
+	help: 'Service catalog scrapes, labelled by whether this pod was the lock winner',
+	labelNames: ['source'],
+	registers: [registry],
+});
+
+const serviceCatalogRefreshDuration = new Histogram({
+	name: 'acuity_service_catalog_refresh_duration_seconds',
+	help: 'Wall time to scrape Acuity service catalog',
+	buckets: [0.5, 1, 2, 5, 10, 30, 60],
+	registers: [registry],
+});
+
+export const metrics = {
+	registry,
+	browserActiveSessions,
+	pageOperationsDuration,
+	cacheHitRatio,
+	serviceCatalogScrapeTotal,
+	serviceCatalogRefreshDuration,
+};
+
+export const renderMetrics = (): Promise<string> => registry.metrics();

--- a/src/shared/redis-l2.test.ts
+++ b/src/shared/redis-l2.test.ts
@@ -29,8 +29,11 @@ const run = <A>(
 describe('RedisL2.getCached', () => {
 	let mock: IORedisMock;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		mock = new IORedisMock();
+		// ioredis-mock shares state across instances (module-scoped Redis data),
+		// so we must flushall between tests to guarantee isolation.
+		await mock.flushall();
 	});
 
 	it('returns cached value on hit without calling mk', async () => {
@@ -105,6 +108,7 @@ describe('RedisL2.getCached', () => {
 
 	it(
 		'loser times out at 10s and falls through to run mk independently',
+		{ timeout: 15_000 },
 		async () => {
 			// Pre-seat the lock with a long TTL and never write the cache.
 			await mock.set('lock:stuck', 'ghost-token', 'PX', 60_000, 'NX');
@@ -122,7 +126,6 @@ describe('RedisL2.getCached', () => {
 			expect(elapsed).toBeGreaterThanOrEqual(9_500);
 			expect(elapsed).toBeLessThan(12_000);
 		},
-		{ timeout: 15_000 },
 	);
 
 	it('lock TTL expires after its window; second caller acquires new lock', async () => {

--- a/src/shared/redis-l2.test.ts
+++ b/src/shared/redis-l2.test.ts
@@ -1,0 +1,190 @@
+import { Effect, Layer } from 'effect';
+import IORedisMock from 'ioredis-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Redis as IORedis } from 'ioredis';
+import { getCached, RedisL2 } from './redis-l2.js';
+
+/**
+ * JSON round-trip contract: values pass through `JSON.stringify`/`JSON.parse`.
+ * Date objects are NOT revived — callers that need Date semantics should parse
+ * ISO strings on read. Plain objects, arrays, primitives, nested structures all
+ * survive the round-trip.
+ */
+
+// Helper: inject a pre-instantiated ioredis-mock as the RedisL2 service.
+// We cast through `unknown` — ioredis-mock is structurally compatible with
+// the subset of ioredis (`get`/`set`/`eval`) used by redis-l2.
+const mockLayer = (mock: IORedisMock) =>
+	Layer.succeed(RedisL2, mock as unknown as IORedis);
+
+const run = <A>(
+	mock: IORedisMock,
+	eff: Effect.Effect<A, unknown, RedisL2>,
+): Promise<A> =>
+	Effect.runPromise(
+		eff.pipe(Effect.provide(mockLayer(mock))) as Effect.Effect<A, unknown, never>,
+	);
+
+describe('RedisL2.getCached', () => {
+	let mock: IORedisMock;
+
+	beforeEach(() => {
+		mock = new IORedisMock();
+	});
+
+	it('returns cached value on hit without calling mk', async () => {
+		await mock.set('k', JSON.stringify({ hello: 'world' }));
+		const mk = vi.fn(async () => ({ hello: 'fresh' }));
+
+		const out = await run(mock, getCached('k', 60, mk));
+		expect(out).toEqual({ hello: 'world' });
+		expect(mk).not.toHaveBeenCalled();
+	});
+
+	it('miss -> winner: mk called exactly once, cache written with ~ttl, lock released', async () => {
+		const mk = vi.fn(async () => ({ computed: 42 }));
+
+		const out = await run(mock, getCached('k', 90, mk));
+		expect(out).toEqual({ computed: 42 });
+		expect(mk).toHaveBeenCalledTimes(1);
+
+		// Cache populated
+		const cached = await mock.get('k');
+		expect(JSON.parse(cached!)).toEqual({ computed: 42 });
+
+		// TTL ~90s (wide tolerance — ioredis-mock uses real timers)
+		const ttlMs = await mock.pttl('k');
+		expect(ttlMs).toBeGreaterThan(80_000);
+		expect(ttlMs).toBeLessThanOrEqual(90_000);
+
+		// Lock released
+		const lock = await mock.get('lock:k');
+		expect(lock).toBeNull();
+	});
+
+	it('single-flight: only one of N concurrent callers runs mk; others read cache', async () => {
+		let calls = 0;
+		const mk = async () => {
+			calls += 1;
+			// simulate modest work so concurrent callers race into loser path
+			await new Promise((r) => setTimeout(r, 120));
+			return { id: calls };
+		};
+
+		const results = await Promise.all(
+			Array.from({ length: 5 }, () => run(mock, getCached('shared', 60, mk))),
+		);
+
+		expect(calls).toBe(1);
+		for (const r of results) expect(r).toEqual({ id: 1 });
+	});
+
+	it('loser polls at ~50ms cadence and resolves when winner writes', async () => {
+		// Pre-seat the lock so the next caller becomes a loser.
+		await mock.set('lock:late', 'winner-token', 'PX', 30_000, 'NX');
+
+		// After 200ms, "winner" writes the cache value.
+		setTimeout(() => {
+			void mock.set('late', JSON.stringify({ ok: true }), 'EX', 60);
+		}, 200);
+
+		const mk = vi.fn(async () => ({ wrong: true }));
+
+		const start = Date.now();
+		const out = await run(mock, getCached('late', 60, mk));
+		const elapsed = Date.now() - start;
+
+		expect(out).toEqual({ ok: true });
+		expect(mk).not.toHaveBeenCalled();
+		// Poll cadence is 50ms; should observe within ~300ms of winner writing.
+		expect(elapsed).toBeLessThan(1000);
+		// Must have actually polled (waited for winner) — > poll interval.
+		expect(elapsed).toBeGreaterThanOrEqual(150);
+	});
+
+	it(
+		'loser times out at 10s and falls through to run mk independently',
+		async () => {
+			// Pre-seat the lock with a long TTL and never write the cache.
+			await mock.set('lock:stuck', 'ghost-token', 'PX', 60_000, 'NX');
+
+			const mk = vi.fn(async () => ({ fallback: true }));
+
+			const start = Date.now();
+			const out = await run(mock, getCached('stuck', 60, mk));
+			const elapsed = Date.now() - start;
+
+			// Degraded single-flight: loser falls through and runs mk itself.
+			expect(out).toEqual({ fallback: true });
+			expect(mk).toHaveBeenCalledTimes(1);
+			// Must have waited roughly MAX_WAIT_MS (10s) before falling through.
+			expect(elapsed).toBeGreaterThanOrEqual(9_500);
+			expect(elapsed).toBeLessThan(12_000);
+		},
+		{ timeout: 15_000 },
+	);
+
+	it('lock TTL expires after its window; second caller acquires new lock', async () => {
+		// Simulate a "stuck winner": another process is holding the lock but
+		// will never finish. Use a short artificial lock TTL to avoid making
+		// the test run 30s — we set the lock manually with a 200ms TTL.
+		await mock.set('lock:slow', 'dead-winner', 'PX', 200, 'NX');
+
+		// Sanity: another caller cannot re-acquire while the lock is live.
+		const blocked = await mock.set('lock:slow', 'me', 'PX', 200, 'NX');
+		expect(blocked).toBeNull();
+
+		// Wait past the lock TTL.
+		await new Promise((r) => setTimeout(r, 250));
+
+		// A fresh getCached should become the NEW winner and populate cache.
+		const mk = vi.fn(async () => ({ second: true }));
+		const out = await run(mock, getCached('slow', 60, mk));
+
+		expect(out).toEqual({ second: true });
+		expect(mk).toHaveBeenCalledTimes(1);
+
+		// Cache populated by the second caller.
+		expect(JSON.parse((await mock.get('slow'))!)).toEqual({ second: true });
+	});
+
+	it("Lua CAS release does not delete a successor's lock", async () => {
+		// Simulate: winner A held lock with tokenA but its lock expired.
+		// Successor B acquired a fresh lock with tokenB. If A later attempts
+		// to release using tokenA, the Lua CAS must NOT delete B's lock.
+		await mock.set('lock:cas', 'tokenB', 'PX', 60_000, 'NX');
+
+		// A's Lua release attempt with its stale tokenA (identical to redis-l2.ts).
+		const LUA_CAS_DEL = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end`;
+		const result = await mock.eval(LUA_CAS_DEL, 1, 'lock:cas', 'tokenA');
+		expect(result).toBe(0);
+
+		// B's lock is still there.
+		expect(await mock.get('lock:cas')).toBe('tokenB');
+	});
+
+	it('round-trips JSON values (objects, arrays, ISO strings)', async () => {
+		const value = {
+			list: [1, 2, 3],
+			nested: { a: { b: 'c' } },
+			iso: '2026-04-17T12:00:00.000Z',
+			nullable: null,
+			bool: true,
+		};
+		const mk = vi.fn(async () => value);
+
+		const out = await run(mock, getCached('json', 60, mk));
+		expect(out).toEqual(value);
+
+		// Second call is a cache hit — mk not called again.
+		const out2 = await run(mock, getCached('json', 60, mk));
+		expect(out2).toEqual(value);
+		expect(mk).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/shared/redis-l2.test.ts
+++ b/src/shared/redis-l2.test.ts
@@ -3,6 +3,7 @@ import IORedisMock from 'ioredis-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Redis as IORedis } from 'ioredis';
+import { metrics } from './metrics.js';
 import { getCached, RedisL2 } from './redis-l2.js';
 
 /**
@@ -48,6 +49,14 @@ describe('RedisL2.getCached', () => {
 	it('miss -> winner: mk called exactly once, cache written with ~ttl, lock released', async () => {
 		const mk = vi.fn(async () => ({ computed: 42 }));
 
+		// Pin real instrumentation: winner path must inc serviceCatalogScrapeTotal
+		// with source=lock_winner. Delta assertion (not absolute) because the
+		// registry is a module-level singleton and accumulates across tests.
+		const winnerBefore =
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
+				(v) => v.labels.source === 'lock_winner',
+			)?.value ?? 0;
+
 		const out = await run(mock, getCached('k', 90, mk));
 		expect(out).toEqual({ computed: 42 });
 		expect(mk).toHaveBeenCalledTimes(1);
@@ -64,6 +73,12 @@ describe('RedisL2.getCached', () => {
 		// Lock released
 		const lock = await mock.get('lock:k');
 		expect(lock).toBeNull();
+
+		const winnerAfter =
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
+				(v) => v.labels.source === 'lock_winner',
+			)?.value ?? 0;
+		expect(winnerAfter).toBe(winnerBefore + 1);
 	});
 
 	it('single-flight: only one of N concurrent callers runs mk; others read cache', async () => {
@@ -94,6 +109,13 @@ describe('RedisL2.getCached', () => {
 
 		const mk = vi.fn(async () => ({ wrong: true }));
 
+		// Pin real instrumentation: loser-polls-then-hits path must inc
+		// serviceCatalogScrapeTotal with source=lock_loser.
+		const loserBefore =
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
+				(v) => v.labels.source === 'lock_loser',
+			)?.value ?? 0;
+
 		const start = Date.now();
 		const out = await run(mock, getCached('late', 60, mk));
 		const elapsed = Date.now() - start;
@@ -104,6 +126,12 @@ describe('RedisL2.getCached', () => {
 		expect(elapsed).toBeLessThan(1000);
 		// Must have actually polled (waited for winner) — > poll interval.
 		expect(elapsed).toBeGreaterThanOrEqual(150);
+
+		const loserAfter =
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
+				(v) => v.labels.source === 'lock_loser',
+			)?.value ?? 0;
+		expect(loserAfter).toBe(loserBefore + 1);
 	});
 
 	it(

--- a/src/shared/redis-l2.ts
+++ b/src/shared/redis-l2.ts
@@ -1,0 +1,172 @@
+import { randomBytes } from 'node:crypto';
+
+import { Context, Data, Effect, Layer } from 'effect';
+import type { Redis as IORedis, RedisOptions } from 'ioredis';
+import { Redis as IORedisImpl } from 'ioredis';
+
+/**
+ * RedisL2 — Effect-wrapped ioredis client with SETNX single-flight `getCached`.
+ *
+ * Scope: this module is the L2 (networked) cache layer for the acuity-middleware
+ * bridge. Paper-critical: correctness over brevity.
+ *
+ * Contract:
+ *   - Values are JSON-serialized with `JSON.stringify` / `JSON.parse`.
+ *     Dates are NOT revived — callers must parse ISO strings themselves.
+ *   - Single-flight semantics are "degraded": after a 10s wait, a loser falls
+ *     through to run `mk` itself rather than hang. Correctness > perfection.
+ *   - Lock release uses a Lua CAS (GET-then-DEL if token matches) so expired
+ *     holders cannot delete a successor's lock.
+ */
+
+// ─── Tagged errors ───────────────────────────────────────────────────────────
+// Typed errors let retry schedules target RedisError specifically (instead of
+// swallowing UnknownException from tryPromise with no catch).
+
+export class RedisError extends Data.TaggedError('RedisError')<{
+	readonly cause: unknown;
+}> {}
+
+export class CacheTimeoutError extends Data.TaggedError('CacheTimeoutError')<{
+	readonly key: string;
+}> {}
+
+// ─── Service tag ─────────────────────────────────────────────────────────────
+
+export class RedisL2 extends Context.Tag('acuity-mw/RedisL2')<RedisL2, IORedis>() {}
+
+// ─── Layer ───────────────────────────────────────────────────────────────────
+// `Layer.scoped` + `Effect.acquireRelease` ensures the ioredis connection's
+// `quit()` runs when the scope closes. `Layer.effect` would leak the socket.
+//
+// Pitfalls avoided:
+//   - `lazyConnect: true` → hides connection failures until first command.
+//     Leave default so startup fails fast.
+//   - Default `maxRetriesPerRequest` (20) amplifies Effect-schedule retries.
+//     Cap to 3.
+
+export const RedisL2Live = (url: string, opts?: RedisOptions) =>
+	Layer.scoped(
+		RedisL2,
+		Effect.acquireRelease(
+			Effect.sync(() => {
+				const c = new IORedisImpl(url, { maxRetriesPerRequest: 3, ...opts });
+				c.on('error', (e) => {
+					// Forward client-level errors to stderr. Callers that want
+					// structured logging should wrap RedisL2Live with their own
+					// layer observer.
+					console.error('[redis-l2] client error', e);
+				});
+				return c;
+			}),
+			(c) =>
+				Effect.promise(() =>
+					c.quit().then(
+						() => undefined,
+						() => undefined,
+					),
+				),
+		),
+	);
+
+// ─── Lua CAS release ─────────────────────────────────────────────────────────
+// Standard Redis single-flight release idiom. The Lua script runs server-side
+// inside Redis (not JS eval). Compares token, deletes only if still owned —
+// prevents expired holders from stomping on a successor's lock.
+
+const LUA_CAS_DEL = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end`;
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const LOCK_TTL_MS = 30_000;
+const POLL_INTERVAL_MS = 50;
+const MAX_WAIT_MS = 10_000;
+const lockKey = (k: string) => `lock:${k}`;
+
+// ─── getCached — SETNX single-flight ─────────────────────────────────────────
+
+/**
+ * Cache-aside with single-flight coordination via Redis SETNX.
+ *
+ * Flow:
+ *   1. Fast path: GET key. If hit, JSON.parse and return.
+ *   2. Miss: try `SET lock:k <token> PX 30000 NX`.
+ *      - "OK" → winner: run mk, write cache with `EX ttlSeconds`, release
+ *        lock via server-side Lua CAS script.
+ *      - null → loser: poll cache every 50ms for up to 10s.
+ *   3. Loser timeout: fall through and run mk ourselves (degraded mode —
+ *      logged so operators can see it).
+ *
+ * Release uses `Effect.ensuring` rather than try/finally so interrupts still
+ * trigger the Lua CAS release.
+ */
+export const getCached = <A>(
+	key: string,
+	ttlSeconds: number,
+	mk: () => Promise<A>,
+): Effect.Effect<A, RedisError | CacheTimeoutError, RedisL2> =>
+	Effect.gen(function* () {
+		const client = yield* RedisL2;
+
+		// ── Fast path: cache hit ──
+		const hit = yield* Effect.tryPromise({
+			try: () => client.get(key),
+			catch: (e) => new RedisError({ cause: e }),
+		});
+		if (hit !== null) return JSON.parse(hit) as A;
+
+		// ── Try to acquire single-flight lock ──
+		const token = randomBytes(16).toString('hex');
+		const acquired = yield* Effect.tryPromise({
+			try: () => client.set(lockKey(key), token, 'PX', LOCK_TTL_MS, 'NX'),
+			catch: (e) => new RedisError({ cause: e }),
+		});
+
+		if (acquired === 'OK') {
+			// Winner path. Use Effect.ensuring so interrupts still release.
+			const releaseLock = Effect.tryPromise({
+				try: () => client.eval(LUA_CAS_DEL, 1, lockKey(key), token),
+				catch: (e) => new RedisError({ cause: e }),
+			}).pipe(Effect.ignore);
+
+			return yield* Effect.gen(function* () {
+				const value = yield* Effect.tryPromise({
+					try: () => mk(),
+					catch: (e) => new RedisError({ cause: e }),
+				});
+				yield* Effect.tryPromise({
+					try: () => client.set(key, JSON.stringify(value), 'EX', ttlSeconds),
+					catch: (e) => new RedisError({ cause: e }),
+				});
+				return value;
+			}).pipe(Effect.ensuring(releaseLock));
+		}
+
+		// ── Loser path: poll for cache ──
+		const deadline = Date.now() + MAX_WAIT_MS;
+		while (Date.now() < deadline) {
+			yield* Effect.sleep(`${POLL_INTERVAL_MS} millis`);
+			const v = yield* Effect.tryPromise({
+				try: () => client.get(key),
+				catch: (e) => new RedisError({ cause: e }),
+			});
+			if (v !== null) return JSON.parse(v) as A;
+		}
+
+		// ── Degraded single-flight: loser timed out, run mk itself ──
+		// We log the path so operators can detect it in production. We do not
+		// attempt to write the cache here — another winner may be about to.
+		console.warn(
+			`[redis-l2] loser timeout ${MAX_WAIT_MS}ms on key=${key}, falling through`,
+		);
+		const fallback = yield* Effect.tryPromise({
+			try: () => mk(),
+			catch: (e) => new RedisError({ cause: e }),
+		});
+		return fallback;
+	});

--- a/src/shared/redis-l2.ts
+++ b/src/shared/redis-l2.ts
@@ -4,6 +4,8 @@ import { Context, Data, Effect, Layer } from 'effect';
 import type { Redis as IORedis, RedisOptions } from 'ioredis';
 import { Redis as IORedisImpl } from 'ioredis';
 
+import { metrics } from './metrics.js';
+
 /**
  * RedisL2 — Effect-wrapped ioredis client with SETNX single-flight `getCached`.
  *
@@ -134,6 +136,15 @@ export const getCached = <A>(
 				catch: (e) => new RedisError({ cause: e }),
 			}).pipe(Effect.ignore);
 
+			// Record that this pod won the lock and is about to run mk.
+			// prom-client's Histogram.startTimer returns `endTimer()` — we
+			// invoke it once mk settles (success or failure) so duration
+			// observations match wall-time cost of the scrape.
+			yield* Effect.sync(() =>
+				metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_winner' }),
+			);
+			const endTimer = metrics.serviceCatalogRefreshDuration.startTimer();
+
 			return yield* Effect.gen(function* () {
 				const value = yield* Effect.tryPromise({
 					try: () => mk(),
@@ -144,7 +155,10 @@ export const getCached = <A>(
 					catch: (e) => new RedisError({ cause: e }),
 				});
 				return value;
-			}).pipe(Effect.ensuring(releaseLock));
+			}).pipe(
+				Effect.ensuring(Effect.sync(() => endTimer())),
+				Effect.ensuring(releaseLock),
+			);
 		}
 
 		// ── Loser path: poll for cache ──
@@ -155,7 +169,15 @@ export const getCached = <A>(
 				try: () => client.get(key),
 				catch: (e) => new RedisError({ cause: e }),
 			});
-			if (v !== null) return JSON.parse(v) as A;
+			if (v !== null) {
+				// Cache became fresh while we polled — the winner in some other
+				// pod ran mk on our behalf. Count this as a lock_loser scrape
+				// so the SLI can distinguish "we scraped" vs "somebody else did".
+				yield* Effect.sync(() =>
+					metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_loser' }),
+				);
+				return JSON.parse(v) as A;
+			}
 		}
 
 		// ── Degraded single-flight: loser timed out, run mk itself ──

--- a/src/shared/redis-l2.ts
+++ b/src/shared/redis-l2.ts
@@ -120,7 +120,13 @@ export const getCached = <A>(
 			try: () => client.get(key),
 			catch: (e) => new RedisError({ cause: e }),
 		});
-		if (hit !== null) return JSON.parse(hit) as A;
+		if (hit !== null) {
+			// L2 hit: cached value served without running mk. Record as a cache
+			// hit so the derived `acuity_cache_hit_ratio` gauge reflects actual
+			// networked-cache effectiveness.
+			metrics.recordCacheHit();
+			return JSON.parse(hit) as A;
+		}
 
 		// ── Try to acquire single-flight lock ──
 		const token = randomBytes(16).toString('hex');
@@ -140,9 +146,12 @@ export const getCached = <A>(
 			// prom-client's Histogram.startTimer returns `endTimer()` — we
 			// invoke it once mk settles (success or failure) so duration
 			// observations match wall-time cost of the scrape.
-			yield* Effect.sync(() =>
-				metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_winner' }),
-			);
+			yield* Effect.sync(() => {
+				metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_winner' });
+				// Winner path runs mk against the origin — this is a cache miss
+				// from the ratio's perspective.
+				metrics.recordCacheMiss();
+			});
 			const endTimer = metrics.serviceCatalogRefreshDuration.startTimer();
 
 			return yield* Effect.gen(function* () {
@@ -173,9 +182,12 @@ export const getCached = <A>(
 				// Cache became fresh while we polled — the winner in some other
 				// pod ran mk on our behalf. Count this as a lock_loser scrape
 				// so the SLI can distinguish "we scraped" vs "somebody else did".
-				yield* Effect.sync(() =>
-					metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_loser' }),
-				);
+				yield* Effect.sync(() => {
+					metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_loser' });
+					// From this pod's perspective, another pod served us a
+					// cached value — count as a cache hit.
+					metrics.recordCacheHit();
+				});
 				return JSON.parse(v) as A;
 			}
 		}
@@ -186,6 +198,7 @@ export const getCached = <A>(
 		console.warn(
 			`[redis-l2] loser timeout ${MAX_WAIT_MS}ms on key=${key}, falling through`,
 		);
+		yield* Effect.sync(() => metrics.recordCacheMiss());
 		const fallback = yield* Effect.tryPromise({
 			try: () => mk(),
 			catch: (e) => new RedisError({ cause: e }),


### PR DESCRIPTION
## Summary

Implements Tasks 7–12 of the [acuity-middleware K8s phase 1.0 migration plan](https://github.com/Jesssullivan/MassageIthaca/blob/sprint-y-ui-sweep/.claude/worktrees/acuity-middleware-k8s/docs/superpowers/plans/2026-04-17-acuity-middleware-k8s-migration-plan.md). Introduces an Effect-native Redis L2 layer that preserves the O(1/T) upstream-scrape cost across N replicas, wires it into the existing `acuity-service-catalog.ts`, and exposes a prom-client `/metrics` endpoint alongside a Redis-gated `/ready` probe.

Backward-compatible: the L2 path is only active when `REDIS_URL` is set. Local dev / single-node deploys fall back to the existing in-proc cache; an INFO boot log declares the active mode so silent degradation is operator-visible.

## What landed

- **Deps**: `ioredis@^5` + `prom-client@^15` runtime; `ioredis-mock@^8.13.1` dev.
- **`src/shared/redis-l2.ts`** (new): Effect `Layer.scoped` `RedisL2` service with `getCached(key, ttlSec, mk)` single-flight. SETNX with 128-bit token, Lua CAS release via `Effect.ensuring`, loser-polls-then-timeout-fallthrough at 10s. Typed errors (`RedisError`, `CacheTimeoutError`).
- **`src/shared/acuity-service-catalog.ts`**: optional `redisL2: ServiceCatalogRedisL2` field. L2-on path bypasses L1 freshness gate (L2 is the authority). L1 retained for the public sync `getCachedService()` accessor.
- **`src/shared/metrics.ts`** (new): 5 SLIs from spec §6.1 — `acuity_browser_active_sessions`, `acuity_page_operations_duration_seconds`, `acuity_cache_hit_ratio`, `acuity_service_catalog_scrape_total{source}`, `acuity_service_catalog_refresh_duration_seconds` + `acuity_`-prefixed default metrics.
- **`src/server/handler.ts`**: `/metrics` (Prometheus text) + `/ready` (Redis ping gate) on the unauth allowlist for Tailscale-only deployment. Inline `serviceCatalogRedisL2` adapter conforms the real `RedisL2` service to the catalog's structural interface via `Effect.provideService + Effect.orDie`. Graceful shutdown disposes the Redis client.
- **Instrumentation in `redis-l2.ts`**: lock-winner branch increments `scrape_total{source=lock_winner}` and wraps `mk` with `refresh_duration_seconds` timer (Effect.ensuring guarantees both fire through success/failure/interrupt). Lock-loser polling increments `scrape_total{source=lock_loser}`.

## Tests

- 107/107 passing across 10 files. Coverage: RedisL2 SETNX + CAS + loser-polls + 10s timeout; real counter increments pinned against `ioredis-mock`; metrics registry renders Prometheus text with histograms; catalog failure surfaces errors rather than silently falling back to L1.
- `pnpm typecheck`: clean.

## Known gaps (tracked, non-blocking for shadow)

1. **`/ready` static config dump below Redis ping** — no browser/catalog liveness. Acceptable for shadow traffic (non-user-visible). MUST land real-liveness probe before non-shadow promotion (tracked).
2. **Task 12 catalog-side counter test** is self-fulfilling by design. Real instrumentation coverage lives in `redis-l2.test.ts` counter-delta assertions.

## Review trail

- Each task went through spec-compliance + code-quality review. All APPROVED with cheap follow-ups landed inline:
  - `d851c65` RedisL2 error-channel JSDoc + L2 failure-path test.
  - `cc41e07` real-generator counter-delta assertions + cache-mode boot log + adapter rename + stronger metrics.test.ts.

## Test plan

- [ ] CI green on `main`-base PR (build + test + typecheck).
- [ ] Manual smoke: `pnpm test` → 107/107, `pnpm typecheck` → clean.
- [ ] Post-merge: cut `feat/k8s-phase1-tofu-stack` branch on blahaj for T15 apply.