### PR TITLE
feat(parity): Modal vs K8s harness + daily rollup (phase 1.1)

### DIFF
--- a/parity/README.md
+++ b/parity/README.md
@@ -19,13 +19,30 @@ can be surfaced via Loki alerts long before any cutover.
 
 ## Environment variables
 
-| Variable        | Required | Default | Purpose                                                          |
-| --------------- | -------- | ------- | ---------------------------------------------------------------- |
-| `MODAL_URL`     | yes      | —       | Base URL of the Modal deployment (tailnet-reachable).            |
-| `K8S_URL`       | yes      | —       | Base URL of the K8s shadow deployment (tailnet-reachable).       |
-| `HMAC_SECRET`   | yes      | —       | Shared secret used by the middleware for request signing.        |
-| `SERVICE_IDS`   | yes      | —       | Comma-separated Acuity service IDs to probe.                     |
-| `DATE_HORIZON`  | no       | `14`    | Probe days 0..N into the future (inclusive), per service.        |
+| Variable                 | Required | Default | Purpose                                                                          |
+| ------------------------ | -------- | ------- | -------------------------------------------------------------------------------- |
+| `MODAL_URL`              | yes      | —       | Base URL of the Modal deployment (tailnet-reachable).                            |
+| `K8S_URL`                | yes      | —       | Base URL of the K8s shadow deployment (tailnet-reachable).                       |
+| `ACUITY_MW_AUTH_TOKEN`   | yes      | —       | Bearer token the middleware server requires (`AUTH_TOKEN` on the server side).   |
+| `ACUITY_MW_HMAC_SECRET`  | yes      | —       | Shared HMAC secret for replay-protection signing (`HMAC_SECRET` legacy alias).   |
+| `SERVICE_IDS`            | yes      | —       | Comma-separated Acuity service IDs to probe.                                     |
+| `DATE_HORIZON`           | no       | `14`    | Probe days 0..N into the future (inclusive), per service.                        |
+
+### Auth model
+
+Every request to both backends sends **two** auth mechanisms:
+
+1. **Bearer token** (`Authorization: Bearer <ACUITY_MW_AUTH_TOKEN>`) — the
+   mechanism the middleware server actually enforces. Requests without a valid
+   `AUTH_TOKEN` header are rejected 401.
+2. **HMAC headers** (`X-Timestamp` + `X-Signature`) — replay-protection
+   signing for future tightening. The server currently logs these but does not
+   enforce them; they are included now so the infrastructure is in place before
+   enforcement is added.
+
+The HMAC signature is `HMAC-SHA256(secret, timestamp + path)` where `timestamp`
+is the Unix epoch in milliseconds and `path` is the request path including query
+string (e.g., `/availability/slots?service=12345&date=2026-05-01`).
 
 Both `MODAL_URL` and `K8S_URL` must be tailnet-reachable from the harness host.
 The harness never punches out to the public internet — it relies on the same
@@ -94,19 +111,23 @@ Run directly from a tailnet host with environment variables set:
 ```bash
 export MODAL_URL='https://modal.example-tailnet.internal'
 export K8S_URL='https://k8s.example-tailnet.internal'
-export HMAC_SECRET='...'
+export ACUITY_MW_AUTH_TOKEN='...'
+export ACUITY_MW_HMAC_SECRET='...'
 export SERVICE_IDS='12345,67890'
 export DATE_HORIZON=14
 
 tsx parity/check.ts
 ```
 
-Each probe emits one NDJSON line to stdout:
+Each probe emits one NDJSON line to stdout with structured fields:
 
 ```json
-{"ts":"2026-04-17T06:30:00.000Z","level":"OK","detail":"drift=0"}
-{"ts":"2026-04-17T06:30:00.100Z","level":"WARN","detail":"drift=3, onlyModal=2, onlyK8s=1"}
+{"ts":"2026-04-17T06:30:00.000Z","service":"12345","date":"2026-05-01","modalCount":4,"k8sCount":4,"level":"OK","detail":"drift=0"}
+{"ts":"2026-04-17T06:30:00.100Z","service":"12345","date":"2026-05-02","modalCount":5,"k8sCount":8,"level":"WARN","detail":"drift=3, onlyModal=2, onlyK8s=1"}
 ```
+
+The `service` and `date` fields allow T22 rollup queries to aggregate by service
+or date window without needing to parse the `detail` string.
 
 ## Structure
 

--- a/parity/README.md
+++ b/parity/README.md
@@ -1,0 +1,127 @@
+# Modal ↔ K8s Parity Harness
+
+Shadow-traffic parity check for the Modal → K8s migration (phase 1.1 bake).
+Compares `/availability/slots` responses between the Modal (production) backend
+and the K8s (shadow) backend, classifies divergence into `OK` / `WARN` /
+`CRITICAL` buckets, and emits one NDJSON record per (service, date) probe.
+
+The harness is intended to run from a tailnet-reachable host (cron or Ansible
+managed). It never exposes either backend publicly and requires the same HMAC
+shared secret the middleware uses for upstream auth.
+
+## Purpose
+
+During phase 1.1 of the Modal → K8s migration, the K8s cluster serves *shadow*
+traffic only: real reads are replayed against it for correctness comparison
+while Modal stays authoritative. This harness drives that comparison on a
+fixed cadence (nightly or every 10 minutes during active bake) so divergence
+can be surfaced via Loki alerts long before any cutover.
+
+## Environment variables
+
+| Variable        | Required | Default | Purpose                                                          |
+| --------------- | -------- | ------- | ---------------------------------------------------------------- |
+| `MODAL_URL`     | yes      | —       | Base URL of the Modal deployment (tailnet-reachable).            |
+| `K8S_URL`       | yes      | —       | Base URL of the K8s shadow deployment (tailnet-reachable).       |
+| `HMAC_SECRET`   | yes      | —       | Shared secret used by the middleware for request signing.        |
+| `SERVICE_IDS`   | yes      | —       | Comma-separated Acuity service IDs to probe.                     |
+| `DATE_HORIZON`  | no       | `14`    | Probe days 0..N into the future (inclusive), per service.        |
+
+Both `MODAL_URL` and `K8S_URL` must be tailnet-reachable from the harness host.
+The harness never punches out to the public internet — it relies on the same
+private routing the middleware itself uses.
+
+## Exit codes
+
+| Code | Meaning                                                            |
+| ---- | ------------------------------------------------------------------ |
+| `0`  | All probes returned `OK` or `WARN`. Nothing to alert on.           |
+| `2`  | At least one probe returned `CRITICAL`. Cron should alert.         |
+| `1`  | Unexpected runtime error (missing env var, TypeScript crash, …).   |
+
+Cron should treat `exit != 0` as page-worthy; `exit == 2` specifically is the
+signal that Modal/K8s have meaningfully diverged for at least one slot probe.
+
+## Suggested cadence
+
+During phase 1.1 bake, run every **10 minutes** via cron from a tailnet host.
+Pipe stdout to a journal file and forward to Loki so `level=CRITICAL` lines
+can drive an alert.
+
+Example crontab line:
+
+```
+*/10 * * * *  cd /opt/parity && tsx parity/check.ts >> /var/log/parity.ndjson 2>&1
+```
+
+Once bake is complete (≥ 7 consecutive days with zero `CRITICAL`), drop the
+cadence to hourly or nightly before promoting K8s to receive real traffic.
+
+## Diff thresholds
+
+The classifier bins the symmetric-difference count of `start_iso` timestamps:
+
+| Drift (slots) | Level      | Action                                                    |
+| ------------- | ---------- | --------------------------------------------------------- |
+| `≤ 2`         | `OK`       | Normal TTL skew — no action.                              |
+| `3..5`        | `WARN`     | Log but do not page; investigate if persistent.           |
+| `> 5`         | `CRITICAL` | Page on-call; Modal ↔ K8s have meaningfully diverged.     |
+
+### Why `2` for OK
+
+The middleware caches slot reads with a **5-minute TTL**. At any TTL boundary
+one backend may observe the next refresh a few seconds before the other, so a
+single slot can legitimately appear in one response and not the other without
+indicating a real divergence. Empirically two slots is a safe ceiling for
+that natural edge — one can plausibly appear and another plausibly disappear
+in the same boundary window. We chose `2` (rather than `1`) to absorb that
+without generating false `WARN` noise.
+
+If you tighten the TTL (e.g., to 60 s) you may be able to lower this to `1`
+and still avoid false positives. If you loosen it, raise the threshold.
+
+### Why `5` for WARN → CRITICAL
+
+Beyond 5 slots of drift, the most common cause we have seen in manual testing
+is a stale catalog or a dropped Acuity session on one side — i.e., exactly
+the classes of bug this harness exists to surface. Keeping `CRITICAL` at
+`> 5` keeps the alert quiet until the signal is unambiguous.
+
+## Usage
+
+Run directly from a tailnet host with environment variables set:
+
+```bash
+export MODAL_URL='https://modal.example-tailnet.internal'
+export K8S_URL='https://k8s.example-tailnet.internal'
+export HMAC_SECRET='...'
+export SERVICE_IDS='12345,67890'
+export DATE_HORIZON=14
+
+tsx parity/check.ts
+```
+
+Each probe emits one NDJSON line to stdout:
+
+```json
+{"ts":"2026-04-17T06:30:00.000Z","level":"OK","detail":"drift=0"}
+{"ts":"2026-04-17T06:30:00.100Z","level":"WARN","detail":"drift=3, onlyModal=2, onlyK8s=1"}
+```
+
+## Structure
+
+- `parity/check.ts` — library + CLI. Exports `classifyDiff`, `runParityCheck`,
+  and the supporting types (`Slot`, `SlotsResponse`, `DiffLevel`, `DiffResult`,
+  `ParityConfig`).
+- `parity/check.test.ts` — Vitest suite covering the four classifier bands.
+- CLI entry point is guarded with `import.meta.url === file://$0` so it is
+  inert under `vitest` / library imports and active only when invoked directly
+  via `tsx parity/check.ts` or `node parity/check.js`.
+
+## Non-goals
+
+- This harness does **not** probe booking, intake, or any write endpoint.
+  Writes must never be shadowed to both backends concurrently.
+- It does **not** own alerting. Loki / Alertmanager rules live in the Ansible
+  deployment (see T21).
+- It does **not** own the long-term paper dataset rollup — that is T22.

--- a/parity/check.test.ts
+++ b/parity/check.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { classifyDiff, type SlotsResponse } from './check.js';
+
+describe('classifyDiff for /availability/slots', () => {
+  const modal: SlotsResponse = {
+    service_id: 's1',
+    slots: [
+      { start_iso: '2026-05-01T10:00:00Z' },
+      { start_iso: '2026-05-01T11:00:00Z' },
+    ],
+  };
+
+  it('OK when identical', () => {
+    expect(classifyDiff(modal, modal).level).toBe('OK');
+  });
+
+  it('OK for ≤ 2 slot drift', () => {
+    const k8s: SlotsResponse = {
+      ...modal,
+      slots: [...modal.slots, { start_iso: '2026-05-01T12:00:00Z' }],
+    };
+    expect(classifyDiff(modal, k8s).level).toBe('OK');
+  });
+
+  it('WARN for 3–5 slot drift', () => {
+    const k8s: SlotsResponse = {
+      service_id: 's1',
+      slots: ['10', '11', '12', '13', '14'].map(h => ({
+        start_iso: `2026-05-01T${h}:00:00Z`,
+      })),
+    };
+    expect(classifyDiff(modal, k8s).level).toBe('WARN');
+  });
+
+  it('CRITICAL for > 5 slot drift', () => {
+    const k8s: SlotsResponse = {
+      service_id: 's1',
+      slots: Array.from({ length: 10 }, (_, i) => ({
+        start_iso: `2026-05-01T${String(i + 10).padStart(2, '0')}:00:00Z`,
+      })),
+    };
+    expect(classifyDiff(modal, k8s).level).toBe('CRITICAL');
+  });
+});

--- a/parity/check.test.ts
+++ b/parity/check.test.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   classifyDiff,
@@ -91,8 +91,11 @@ describe('fetchWithHmac signature shape', () => {
     expect(sig).not.toBeNull();
     expect(auth).toBe(`Bearer ${BEARER}`);
 
-    // Independently recompute expected HMAC
-    const expected = createHmac('sha256', SECRET).update(`${ts}${PATH}`).digest('hex');
+    // Independently recompute expected HMAC: bodyHash = sha256('') for bodyless GET.
+    const emptyBodyHash = createHash('sha256').update('').digest('hex');
+    const expected = createHmac('sha256', SECRET)
+      .update(`${ts}${PATH}${emptyBodyHash}`)
+      .digest('hex');
     expect(sig).toBe(expected);
   });
 
@@ -101,6 +104,60 @@ describe('fetchWithHmac signature shape', () => {
 
     expect(capturedRequest!.headers.get('Authorization')).toBeNull();
     expect(capturedRequest!.headers.get('X-Signature')).not.toBeNull();
+  });
+
+  it('sends POST with Content-Type JSON and stringified body when body provided', async () => {
+    const body = { service_id: '99', date: '2026-05-01' };
+    await fetchWithHmac(BASE, '/availability/slots', SECRET, undefined, body);
+
+    expect(capturedRequest!.method).toBe('POST');
+    expect(capturedRequest!.headers.get('Content-Type')).toBe('application/json');
+
+    // Verify body was serialized and sent
+    const sent = await capturedRequest!.text();
+    expect(sent).toBe(JSON.stringify(body));
+  });
+
+  it('canonical string includes body hash: signatures differ with/without body', async () => {
+    // Freeze time so timestamps match between the two calls
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T12:00:00Z'));
+
+    try {
+      let sigNoBody: string | null = null;
+      let sigWithBody: string | null = null;
+      let sigEmptyBodyObj: string | null = null;
+
+      globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const req = new Request(input, init);
+        const s = req.headers.get('X-Signature');
+        // Order of capture matches order of calls below
+        if (sigNoBody === null) sigNoBody = s;
+        else if (sigWithBody === null) sigWithBody = s;
+        else sigEmptyBodyObj = s;
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+      });
+
+      // Call 1: no body (GET)
+      await fetchWithHmac(BASE, '/availability/slots', SECRET);
+      // Call 2: with body (POST)
+      await fetchWithHmac(BASE, '/availability/slots', SECRET, undefined, { service_id: '99', date: '2026-05-01' });
+      // Call 3: with explicit empty-string-equivalent body — JSON.stringify('') === '""', so this MUST differ from Call 1.
+      // To verify the "empty body vs no body" equivalence, we pass an empty object and compare against no body separately.
+
+      expect(sigNoBody).not.toBeNull();
+      expect(sigWithBody).not.toBeNull();
+      // Different bodies → different signatures
+      expect(sigWithBody).not.toBe(sigNoBody);
+
+      // And: "no body at all" vs "body = undefined" should produce the same canonical string
+      // (both take the bodyHash of ''). Re-run the no-body path a second time to confirm stable output.
+      sigEmptyBodyObj = null;
+      await fetchWithHmac(BASE, '/availability/slots', SECRET);
+      expect(sigEmptyBodyObj).toBe(sigNoBody);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/parity/check.test.ts
+++ b/parity/check.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { classifyDiff, type SlotsResponse } from './check.js';
+import { createHmac } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  classifyDiff,
+  fetchWithHmac,
+  runParityCheck,
+  type SlotsResponse,
+} from './check.js';
 
+// ---------------------------------------------------------------------------
+// classifyDiff — four classifier bands
+// ---------------------------------------------------------------------------
 describe('classifyDiff for /availability/slots', () => {
   const modal: SlotsResponse = {
     service_id: 's1',
@@ -40,5 +49,140 @@ describe('classifyDiff for /availability/slots', () => {
       })),
     };
     expect(classifyDiff(modal, k8s).level).toBe('CRITICAL');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchWithHmac — signature shape + Bearer header
+// ---------------------------------------------------------------------------
+describe('fetchWithHmac signature shape', () => {
+  const SECRET = 'test-secret-abc';
+  const BASE = 'https://modal.example.internal';
+  const PATH = '/availability/slots?service=99&date=2026-05-01';
+  const BEARER = 'my-bearer-token';
+
+  let capturedRequest: Request | undefined;
+  let restoreFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    restoreFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedRequest = new Request(input, init);
+      return new Response(JSON.stringify({ service_id: '99', slots: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = restoreFetch;
+  });
+
+  it('sends X-Timestamp, X-Signature, and Authorization: Bearer headers', async () => {
+    await fetchWithHmac(BASE, PATH, SECRET, BEARER);
+
+    expect(capturedRequest).toBeDefined();
+    const ts = capturedRequest!.headers.get('X-Timestamp');
+    const sig = capturedRequest!.headers.get('X-Signature');
+    const auth = capturedRequest!.headers.get('Authorization');
+
+    expect(ts).not.toBeNull();
+    expect(sig).not.toBeNull();
+    expect(auth).toBe(`Bearer ${BEARER}`);
+
+    // Independently recompute expected HMAC
+    const expected = createHmac('sha256', SECRET).update(`${ts}${PATH}`).digest('hex');
+    expect(sig).toBe(expected);
+  });
+
+  it('omits Authorization header when no bearerToken supplied', async () => {
+    await fetchWithHmac(BASE, PATH, SECRET);
+
+    expect(capturedRequest!.headers.get('Authorization')).toBeNull();
+    expect(capturedRequest!.headers.get('X-Signature')).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runParityCheck — happy path and error path
+// ---------------------------------------------------------------------------
+describe('runParityCheck', () => {
+  const makeSlotPayload = (slots: string[]): SlotsResponse => ({
+    service_id: 'svc1',
+    slots: slots.map(s => ({ start_iso: s })),
+  });
+
+  const happyPayload = makeSlotPayload([
+    '2026-05-01T10:00:00Z',
+    '2026-05-01T11:00:00Z',
+  ]);
+
+  let restoreFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    restoreFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = restoreFetch;
+  });
+
+  it('happy path: identical payloads → classification OK with all structured fields', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify(happyPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const results = await runParityCheck({
+      modalUrl: 'https://modal.internal',
+      k8sUrl: 'https://k8s.internal',
+      hmacSecret: 'secret',
+      serviceIds: ['svc1'],
+      dateHorizonDays: 0,
+    });
+
+    expect(results).toHaveLength(1);
+    const r = results[0];
+    expect(r.level).toBe('OK');
+    expect(r.service).toBe('svc1');
+    expect(r.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(r.modalCount).toBe(2);
+    expect(r.k8sCount).toBe(2);
+    expect(typeof r.detail).toBe('string');
+  });
+
+  it('error path: K8s fetch throws → emits CRITICAL rather than crashing', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      callCount++;
+      if (url.startsWith('https://k8s.internal')) {
+        throw new Error('connection refused');
+      }
+      return new Response(JSON.stringify(happyPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const results = await runParityCheck({
+      modalUrl: 'https://modal.internal',
+      k8sUrl: 'https://k8s.internal',
+      hmacSecret: 'secret',
+      serviceIds: ['svc1'],
+      dateHorizonDays: 0,
+    });
+
+    expect(results).toHaveLength(1);
+    const r = results[0];
+    expect(r.level).toBe('CRITICAL');
+    expect(r.detail).toMatch(/fetch error/);
+    expect(r.service).toBe('svc1');
+    // modalCount / k8sCount are sentinel -1 on error
+    expect(r.modalCount).toBe(-1);
+    expect(r.k8sCount).toBe(-1);
   });
 });

--- a/parity/check.ts
+++ b/parity/check.ts
@@ -1,0 +1,85 @@
+// parity/check.ts
+import { createHmac } from 'node:crypto';
+
+export interface Slot { start_iso: string }
+export interface SlotsResponse { service_id: string; slots: Slot[] }
+export type DiffLevel = 'OK' | 'WARN' | 'CRITICAL';
+export interface DiffResult { level: DiffLevel; detail: string }
+
+const sign = (secret: string, path: string, ts: string): string =>
+  createHmac('sha256', secret).update(`${ts}${path}`).digest('hex');
+
+export const classifyDiff = (modal: SlotsResponse, k8s: SlotsResponse): DiffResult => {
+  const modalSet = new Set(modal.slots.map(s => s.start_iso));
+  const k8sSet = new Set(k8s.slots.map(s => s.start_iso));
+  const onlyModal = [...modalSet].filter(s => !k8sSet.has(s));
+  const onlyK8s = [...k8sSet].filter(s => !modalSet.has(s));
+  const drift = onlyModal.length + onlyK8s.length;
+
+  if (drift <= 2) return { level: 'OK', detail: `drift=${drift}` };
+  if (drift <= 5) return { level: 'WARN', detail: `drift=${drift}, onlyModal=${onlyModal.length}, onlyK8s=${onlyK8s.length}` };
+  return { level: 'CRITICAL', detail: `drift=${drift}, onlyModal=${onlyModal.length}, onlyK8s=${onlyK8s.length}` };
+};
+
+const fetchWithHmac = async (base: string, path: string, secret: string): Promise<unknown> => {
+  const ts = Date.now().toString();
+  const res = await fetch(`${base}${path}`, {
+    headers: {
+      'X-Timestamp': ts,
+      'X-Signature': sign(secret, path, ts),
+    },
+  });
+  if (!res.ok) throw new Error(`${base}${path} → ${res.status}`);
+  return res.json();
+};
+
+export interface ParityConfig {
+  modalUrl: string;
+  k8sUrl: string;
+  hmacSecret: string;
+  serviceIds: string[];
+  dateHorizonDays: number;
+}
+
+export const runParityCheck = async (cfg: ParityConfig): Promise<DiffResult[]> => {
+  const results: DiffResult[] = [];
+  const today = new Date();
+  for (const sid of cfg.serviceIds) {
+    for (let d = 0; d <= cfg.dateHorizonDays; d++) {
+      const date = new Date(today);
+      date.setDate(date.getDate() + d);
+      const iso = date.toISOString().slice(0, 10);
+      const path = `/availability/slots?service=${sid}&date=${iso}`;
+      try {
+        const modal = (await fetchWithHmac(cfg.modalUrl, path, cfg.hmacSecret)) as SlotsResponse;
+        const k8s = (await fetchWithHmac(cfg.k8sUrl, path, cfg.hmacSecret)) as SlotsResponse;
+        results.push(classifyDiff(modal, k8s));
+      } catch (e) {
+        results.push({ level: 'CRITICAL', detail: `fetch error: ${String(e)}` });
+      }
+    }
+  }
+  return results;
+};
+
+// CLI entry point (skip in tests)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  (async (): Promise<void> => {
+    const results = await runParityCheck({
+      modalUrl: process.env.MODAL_URL!,
+      k8sUrl: process.env.K8S_URL!,
+      hmacSecret: process.env.HMAC_SECRET!,
+      serviceIds: (process.env.SERVICE_IDS ?? '').split(',').filter(Boolean),
+      dateHorizonDays: Number(process.env.DATE_HORIZON ?? 14),
+    });
+
+    for (const r of results) {
+      console.log(JSON.stringify({ ts: new Date().toISOString(), ...r }));
+    }
+    const critical = results.filter(r => r.level === 'CRITICAL').length;
+    process.exit(critical > 0 ? 2 : 0);
+  })().catch((e: unknown) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/parity/check.ts
+++ b/parity/check.ts
@@ -14,6 +14,11 @@ export interface DiffResult {
   detail: string;
 }
 
+// Canonical HMAC input is `${ts}${path}` only. Method and host are intentionally
+// omitted: the harness runs over Tailscale (single known host) and exclusively
+// issues GETs, so both would be constants that add no replay-prevention value.
+// If the deployment ever exposes writes or fan-outs to multiple hosts, extend
+// this to SigV4-style (METHOD + HOST + PATH + BODY_HASH + TS).
 const sign = (secret: string, path: string, ts: string): string =>
   createHmac('sha256', secret).update(`${ts}${path}`).digest('hex');
 

--- a/parity/check.ts
+++ b/parity/check.ts
@@ -4,12 +4,20 @@ import { createHmac } from 'node:crypto';
 export interface Slot { start_iso: string }
 export interface SlotsResponse { service_id: string; slots: Slot[] }
 export type DiffLevel = 'OK' | 'WARN' | 'CRITICAL';
-export interface DiffResult { level: DiffLevel; detail: string }
+
+export interface DiffResult {
+  service: string;
+  date: string;
+  modalCount: number;
+  k8sCount: number;
+  level: DiffLevel;
+  detail: string;
+}
 
 const sign = (secret: string, path: string, ts: string): string =>
   createHmac('sha256', secret).update(`${ts}${path}`).digest('hex');
 
-export const classifyDiff = (modal: SlotsResponse, k8s: SlotsResponse): DiffResult => {
+export const classifyDiff = (modal: SlotsResponse, k8s: SlotsResponse): { level: DiffLevel; detail: string } => {
   const modalSet = new Set(modal.slots.map(s => s.start_iso));
   const k8sSet = new Set(k8s.slots.map(s => s.start_iso));
   const onlyModal = [...modalSet].filter(s => !k8sSet.has(s));
@@ -21,14 +29,21 @@ export const classifyDiff = (modal: SlotsResponse, k8s: SlotsResponse): DiffResu
   return { level: 'CRITICAL', detail: `drift=${drift}, onlyModal=${onlyModal.length}, onlyK8s=${onlyK8s.length}` };
 };
 
-const fetchWithHmac = async (base: string, path: string, secret: string): Promise<unknown> => {
+export const fetchWithHmac = async (
+  base: string,
+  path: string,
+  secret: string,
+  bearerToken?: string,
+): Promise<unknown> => {
   const ts = Date.now().toString();
-  const res = await fetch(`${base}${path}`, {
-    headers: {
-      'X-Timestamp': ts,
-      'X-Signature': sign(secret, path, ts),
-    },
-  });
+  const headers: Record<string, string> = {
+    'X-Timestamp': ts,
+    'X-Signature': sign(secret, path, ts),
+  };
+  if (bearerToken) {
+    headers['Authorization'] = `Bearer ${bearerToken}`;
+  }
+  const res = await fetch(`${base}${path}`, { headers });
   if (!res.ok) throw new Error(`${base}${path} → ${res.status}`);
   return res.json();
 };
@@ -37,6 +52,7 @@ export interface ParityConfig {
   modalUrl: string;
   k8sUrl: string;
   hmacSecret: string;
+  bearerToken?: string;
   serviceIds: string[];
   dateHorizonDays: number;
 }
@@ -51,11 +67,26 @@ export const runParityCheck = async (cfg: ParityConfig): Promise<DiffResult[]> =
       const iso = date.toISOString().slice(0, 10);
       const path = `/availability/slots?service=${sid}&date=${iso}`;
       try {
-        const modal = (await fetchWithHmac(cfg.modalUrl, path, cfg.hmacSecret)) as SlotsResponse;
-        const k8s = (await fetchWithHmac(cfg.k8sUrl, path, cfg.hmacSecret)) as SlotsResponse;
-        results.push(classifyDiff(modal, k8s));
+        const modal = (await fetchWithHmac(cfg.modalUrl, path, cfg.hmacSecret, cfg.bearerToken)) as SlotsResponse;
+        const k8s = (await fetchWithHmac(cfg.k8sUrl, path, cfg.hmacSecret, cfg.bearerToken)) as SlotsResponse;
+        const { level, detail } = classifyDiff(modal, k8s);
+        results.push({
+          service: sid,
+          date: iso,
+          modalCount: modal.slots.length,
+          k8sCount: k8s.slots.length,
+          level,
+          detail,
+        });
       } catch (e) {
-        results.push({ level: 'CRITICAL', detail: `fetch error: ${String(e)}` });
+        results.push({
+          service: sid,
+          date: iso,
+          modalCount: -1,
+          k8sCount: -1,
+          level: 'CRITICAL',
+          detail: `fetch error: ${String(e)}`,
+        });
       }
     }
   }
@@ -68,7 +99,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     const results = await runParityCheck({
       modalUrl: process.env.MODAL_URL!,
       k8sUrl: process.env.K8S_URL!,
-      hmacSecret: process.env.HMAC_SECRET!,
+      hmacSecret: process.env.ACUITY_MW_HMAC_SECRET ?? process.env.HMAC_SECRET!,
+      bearerToken: process.env.ACUITY_MW_AUTH_TOKEN,
       serviceIds: (process.env.SERVICE_IDS ?? '').split(',').filter(Boolean),
       dateHorizonDays: Number(process.env.DATE_HORIZON ?? 14),
     });

--- a/parity/check.ts
+++ b/parity/check.ts
@@ -1,5 +1,5 @@
 // parity/check.ts
-import { createHmac } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 
 export interface Slot { start_iso: string }
 export interface SlotsResponse { service_id: string; slots: Slot[] }
@@ -14,13 +14,19 @@ export interface DiffResult {
   detail: string;
 }
 
-// Canonical HMAC input is `${ts}${path}` only. Method and host are intentionally
-// omitted: the harness runs over Tailscale (single known host) and exclusively
-// issues GETs, so both would be constants that add no replay-prevention value.
-// If the deployment ever exposes writes or fan-outs to multiple hosts, extend
-// this to SigV4-style (METHOD + HOST + PATH + BODY_HASH + TS).
-const sign = (secret: string, path: string, ts: string): string =>
-  createHmac('sha256', secret).update(`${ts}${path}`).digest('hex');
+// Canonical HMAC input is `${ts}${path}${bodyHash}` where bodyHash is the
+// sha256 hex digest of the raw request body (or the sha256 of the empty string
+// for bodyless GETs). Method and host are intentionally omitted: the harness
+// runs over Tailscale (single known host). Including the body hash binds the
+// signature to the exact JSON payload so that POST /availability/slots cannot
+// be replayed with a mutated body. For GETs, bodyHash is the sha256 of `''`,
+// which keeps pre-body signatures stable on read-only endpoints.
+// If the deployment ever fan-outs to multiple hosts, extend this to SigV4-
+// style (METHOD + HOST + PATH + BODY_HASH + TS).
+const sign = (secret: string, path: string, ts: string, body?: string): string => {
+  const bodyHash = createHash('sha256').update(body ?? '').digest('hex');
+  return createHmac('sha256', secret).update(`${ts}${path}${bodyHash}`).digest('hex');
+};
 
 export const classifyDiff = (modal: SlotsResponse, k8s: SlotsResponse): { level: DiffLevel; detail: string } => {
   const modalSet = new Set(modal.slots.map(s => s.start_iso));
@@ -39,16 +45,25 @@ export const fetchWithHmac = async (
   path: string,
   secret: string,
   bearerToken?: string,
+  body?: unknown,
 ): Promise<unknown> => {
   const ts = Date.now().toString();
+  const serialized = body === undefined ? undefined : JSON.stringify(body);
   const headers: Record<string, string> = {
     'X-Timestamp': ts,
-    'X-Signature': sign(secret, path, ts),
+    'X-Signature': sign(secret, path, ts, serialized),
   };
   if (bearerToken) {
     headers['Authorization'] = `Bearer ${bearerToken}`;
   }
-  const res = await fetch(`${base}${path}`, { headers });
+  const init: RequestInit = body === undefined
+    ? { headers }
+    : {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: serialized,
+      };
+  const res = await fetch(`${base}${path}`, init);
   if (!res.ok) throw new Error(`${base}${path} → ${res.status}`);
   return res.json();
 };
@@ -70,10 +85,11 @@ export const runParityCheck = async (cfg: ParityConfig): Promise<DiffResult[]> =
       const date = new Date(today);
       date.setDate(date.getDate() + d);
       const iso = date.toISOString().slice(0, 10);
-      const path = `/availability/slots?service=${sid}&date=${iso}`;
+      const path = `/availability/slots`;
+      const body = { service_id: sid, date: iso };
       try {
-        const modal = (await fetchWithHmac(cfg.modalUrl, path, cfg.hmacSecret, cfg.bearerToken)) as SlotsResponse;
-        const k8s = (await fetchWithHmac(cfg.k8sUrl, path, cfg.hmacSecret, cfg.bearerToken)) as SlotsResponse;
+        const modal = (await fetchWithHmac(cfg.modalUrl, path, cfg.hmacSecret, cfg.bearerToken, body)) as SlotsResponse;
+        const k8s = (await fetchWithHmac(cfg.k8sUrl, path, cfg.hmacSecret, cfg.bearerToken, body)) as SlotsResponse;
         const { level, detail } = classifyDiff(modal, k8s);
         results.push({
           service: sid,
@@ -102,12 +118,12 @@ export const runParityCheck = async (cfg: ParityConfig): Promise<DiffResult[]> =
 if (import.meta.url === `file://${process.argv[1]}`) {
   (async (): Promise<void> => {
     const results = await runParityCheck({
-      modalUrl: process.env.MODAL_URL!,
-      k8sUrl: process.env.K8S_URL!,
+      modalUrl: process.env.ACUITY_MW_MODAL_URL ?? process.env.MODAL_URL!,
+      k8sUrl: process.env.ACUITY_MW_K8S_URL ?? process.env.K8S_URL!,
       hmacSecret: process.env.ACUITY_MW_HMAC_SECRET ?? process.env.HMAC_SECRET!,
       bearerToken: process.env.ACUITY_MW_AUTH_TOKEN,
-      serviceIds: (process.env.SERVICE_IDS ?? '').split(',').filter(Boolean),
-      dateHorizonDays: Number(process.env.DATE_HORIZON ?? 14),
+      serviceIds: (process.env.ACUITY_MW_SERVICE_IDS ?? process.env.SERVICE_IDS ?? '').split(',').filter(Boolean),
+      dateHorizonDays: Number(process.env.ACUITY_MW_DATE_HORIZON ?? process.env.DATE_HORIZON ?? 14),
     });
 
     for (const r of results) {

--- a/parity/daily-rollup.test.ts
+++ b/parity/daily-rollup.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { rollupJournalLines } from './daily-rollup.js';
+
+describe('rollupJournalLines', () => {
+  it('counts diff levels + extracts scrape counts', () => {
+    const lines = [
+      JSON.stringify({ ts: '2026-05-01T10:00:00Z', level: 'OK',       detail: 'drift=0' }),
+      JSON.stringify({ ts: '2026-05-01T10:10:00Z', level: 'OK',       detail: 'drift=1' }),
+      JSON.stringify({ ts: '2026-05-01T10:20:00Z', level: 'WARN',     detail: 'drift=4' }),
+      JSON.stringify({ ts: '2026-05-01T10:30:00Z', level: 'CRITICAL', detail: 'drift=7' }),
+    ];
+    const result = rollupJournalLines(lines, '2026-05-01');
+    expect(result).toEqual({
+      date: '2026-05-01',
+      runs: 4,
+      ok: 2,
+      warn: 1,
+      critical: 1,
+    });
+  });
+
+  it('skips malformed JSON silently', () => {
+    const lines = [
+      JSON.stringify({ ts: '2026-05-01T09:00:00Z', level: 'OK', detail: 'drift=0' }),
+      'not-valid-json',
+      '{broken:',
+    ];
+    const result = rollupJournalLines(lines, '2026-05-01');
+    expect(result).toEqual({
+      date: '2026-05-01',
+      runs: 1,
+      ok: 1,
+      warn: 0,
+      critical: 0,
+    });
+  });
+
+  it('returns zero counts for empty input', () => {
+    const result = rollupJournalLines([], '2026-05-02');
+    expect(result).toEqual({
+      date: '2026-05-02',
+      runs: 0,
+      ok: 0,
+      warn: 0,
+      critical: 0,
+    });
+  });
+
+  it('skips lines missing a recognized level field', () => {
+    const lines = [
+      JSON.stringify({ ts: '2026-05-01T10:00:00Z', level: 'OK',      detail: 'drift=0' }),
+      JSON.stringify({ ts: '2026-05-01T10:05:00Z', detail: 'drift=0' }),   // no level
+      JSON.stringify({ ts: '2026-05-01T10:10:00Z', level: 'UNKNOWN', detail: 'x' }), // unrecognized
+    ];
+    const result = rollupJournalLines(lines, '2026-05-01');
+    expect(result).toEqual({
+      date: '2026-05-01',
+      runs: 1,
+      ok: 1,
+      warn: 0,
+      critical: 0,
+    });
+  });
+});

--- a/parity/daily-rollup.ts
+++ b/parity/daily-rollup.ts
@@ -1,0 +1,88 @@
+// parity/daily-rollup.ts
+// Note: T20's NDJSON carries `service`, `date`, `modalCount`, `k8sCount` as structured fields.
+// A future `rollupByService(lines, date)` can aggregate per-service without schema migration.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+
+export interface DailyRollup {
+  date: string;
+  runs: number;
+  ok: number;
+  warn: number;
+  critical: number;
+}
+
+/**
+ * Aggregate NDJSON journal lines for a single date into a DailyRollup.
+ * Malformed JSON and lines with unrecognized/missing `level` fields are skipped silently.
+ */
+export const rollupJournalLines = (lines: string[], date: string): DailyRollup => {
+  let runs = 0;
+  let ok = 0;
+  let warn = 0;
+  let critical = 0;
+
+  for (const raw of lines) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue; // malformed JSON — skip silently
+    }
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('level' in parsed)
+    ) {
+      continue;
+    }
+
+    const level = (parsed as Record<string, unknown>)['level'];
+    if (level === 'OK') {
+      runs++;
+      ok++;
+    } else if (level === 'WARN') {
+      runs++;
+      warn++;
+    } else if (level === 'CRITICAL') {
+      runs++;
+      critical++;
+    }
+    // Unrecognized level values are skipped silently
+  }
+
+  return { date, runs, ok, warn, critical };
+};
+
+// CLI entry point (skip in tests / library import)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  (async (): Promise<void> => {
+    const date = process.argv[2] ?? new Date().toISOString().slice(0, 10);
+
+    const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+    const lines: string[] = [];
+    for await (const line of rl) {
+      lines.push(line);
+    }
+
+    const rollup = rollupJournalLines(lines, date);
+
+    // Write to paper/data/phase1/<date>.json relative to CWD
+    const outDir = join(process.cwd(), 'paper', 'data', 'phase1');
+    mkdirSync(outDir, { recursive: true });
+    const outPath = join(outDir, `${date}.json`);
+    writeFileSync(outPath, JSON.stringify(rollup, null, 2) + '\n');
+
+    console.log(`Wrote ${outPath}`);
+    console.log(JSON.stringify(rollup));
+  })().catch((e: unknown) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['src/**/*.test.ts', 'src/**/__tests__/**/*.test.ts', 'tests/**/*.test.ts'],
+		include: [
+			'src/**/*.test.ts',
+			'src/**/__tests__/**/*.test.ts',
+			'tests/**/*.test.ts',
+			'parity/**/*.test.ts',
+		],
 		environment: 'node',
 		globals: true,
 		testTimeout: 10000,


### PR DESCRIPTION
## Summary
- Modal vs K8s parity harness (`parity/check.ts`) emitting NDJSON per (service, date) with drift classification OK / WARN / CRITICAL
- HMAC (ts+path canonical string, tailnet-only) + Bearer token auth for calls into both backends
- Daily rollup (`parity/daily-rollup.ts`) folds NDJSON journal into `paper/data/phase1/${date}.json` for thesis dataset consumption
- Tracks T20 + T22 of docs/superpowers/plans/2026-04-17-acuity-middleware-k8s-migration-plan.md

## Scope
- Phase 1.1 shadow-bake tooling only. No runtime wiring changes.
- Consumed by Ansible role in tinyland-inc/blahaj#82 (systemd timer, 10-min cadence).

## Test plan
- [x] `pnpm vitest run parity/` — classifyDiff + fetchWithHmac + runParityCheck + rollupJournalLines
- [ ] Manual smoke on tailnet host after tinyland-inc/blahaj#82 merges
- [ ] First rollup lands in `paper/data/phase1/` after 24h bake