### PR TITLE
docs: codify bridge payment boundary

### DIFF
--- a/.claude/plans/2026-04-17-codex-bridge-capability-boundary.md
+++ b/.claude/plans/2026-04-17-codex-bridge-capability-boundary.md
@@ -1,0 +1,56 @@
+# Codex Bridge Capability Boundary
+
+Date: 2026-04-17
+Worktree: `.claude/worktrees/codex-bridge-capability-boundary`
+Branch: `codex-bridge-capability-boundary`
+
+## Current Truth
+
+- `src/capabilities.ts` currently exports `extractCapabilities`.
+- The helper already emits public Stripe as `card`, so the immediate bug is not
+  the value shape.
+- The architectural problem is ownership: this repo is a remote automation
+  bridge, but it still publishes a booking-surface payment capability contract.
+- `MassageIthaca` and `scheduling-kit` are now converging on package-owned
+  public payment ids, which makes the bridge-owned capability helper transition
+  debt instead of a valid long-term authority.
+
+## Authority Decision
+
+- `acuity-middleware` / `@tummycrypt/scheduling-bridge` should own:
+  - Acuity wizard steps
+  - remote protocol and HTTP surfaces
+  - runtime, browser, and deployment semantics
+- It should not own:
+  - booking-surface payment capability extraction
+  - canonical public payment method ids
+  - site policy for which rails should be exposed
+
+## Transition Plan
+
+1. Short term
+- Keep `extractCapabilities` readable for downstream compatibility.
+- Mark the helper as transition debt in repo-local docs and AGENTS guidance.
+- Do not expand the helper or move more site-policy logic into this repo.
+
+2. Mid term
+- Move public payment capability extraction to the repo that owns the booking
+  surface contract.
+- Prefer `scheduling-kit` for reusable capability normalization helpers.
+- Keep application repos responsible for combining practitioner settings with
+  site policy and deployment/runtime context.
+
+3. Cleanup
+- Deprecate and later remove `extractCapabilities` from the bridge public API
+  after downstream consumers stop importing it.
+- Update tests so protocol and transport truth remain here, while payment
+  capability truth moves upstream.
+
+## Execution Notes
+
+- The first upstream `scheduling-kit` lane is draft PR
+  `Jesssullivan/scheduling-kit#63`.
+- This bridge lane should stay non-breaking until the app and package adoption
+  path is explicit.
+- If a bridge PR is opened from this branch, it should be docs/authority only
+  unless a consumer-safe deprecation marker is added.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ It does **not** own:
 - application-specific environment switching
 - site-specific admin UI
 - reusable, backend-agnostic UI components
+- payment capability extraction or booking-surface payment policy
+- canonical public payment method identifiers
 
 ## Strategic Goal
 
@@ -98,6 +100,19 @@ Key architectural lessons already established:
 - URL-based direct reads are preferable when Acuity ids allow them
 - shared service catalog logic should not be duplicated across local and remote paths
 
+Authority boundary rules:
+
+- `@tummycrypt/scheduling-bridge` owns Acuity protocol truth, wizard-step
+  semantics, and remote transport behavior.
+- `@tummycrypt/scheduling-kit` owns reusable booking-controller semantics and
+  canonical public payment identifiers.
+- application repos such as `MassageIthaca` own site policy, environment
+  selection, and which payment capabilities should be exposed on a given
+  surface.
+- if this repo still exports helper contracts like `extractCapabilities`, treat
+  them as transition debt to be removed or deprecated once downstream consumers
+  adopt the package-owned authority.
+
 ## Effect Guidance
 
 Effect is useful here because this repo truly has resource lifecycle problems:
@@ -168,3 +183,5 @@ rather than by implication.
 - Do not confuse this repo with the reusable UI/package layer.
 - Do not let the bridge package declare stale `scheduling-kit` dependencies
   while downstream apps have already moved on.
+- Do not let this repo become the long-term owner of booking-surface payment
+  policy just because it can currently see practitioner settings.


### PR DESCRIPTION
## What changed
- codify in `AGENTS.md` that `@tummycrypt/scheduling-bridge` should not be the long-term owner of booking-surface payment capability policy
- add a repo-local plan describing the transition of `extractCapabilities` out of the bridge authority layer
- keep this lane docs-only and non-breaking while downstream adoption is still in flight

## Why
The bridge repo currently exports `extractCapabilities`, which means a remote automation package still owns part of the booking-surface payment contract. Even when the helper emits the correct `card` id, that ownership is still wrong for long-term module boundaries.

## Impact
This PR makes the bridge repo’s local operating contract explicit before any breaking code move happens. It keeps the bridge focused on Acuity protocol truth, remote transport, and runtime semantics while the reusable payment capability contract converges upstream.

## Validation
- docs-only review
- no runtime or package tests changed in this slice

## Root cause
Cross-repo authority blurred because the bridge could see practitioner settings and started publishing booking-surface capability helpers. That created a silent contract leak between remote automation and reusable booking-surface policy.
