### PR TITLE
[codex] Make package lane repo-owned and isolated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,15 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@dde8c378815e47aa027c163278430c0d98ae007b
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
     with:
-      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
+      runner_mode: repo_owned
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      workspace_mode: isolated
+      publish_mode: same_runner
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"
-      cleanup_paths: "dist node_modules pkg pkg-github bazel-bin bazel-out bazel-testlogs .pnpm-store bazel-pkg.tgz MODULE.bazel.lock"
       metadata_check_command: pnpm check:release-metadata
       typecheck_command: pnpm typecheck
       unit_test_command: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0e13cc4e50b191f48191f08b3db081307d3447ce
     with:
       runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0e13cc4e50b191f48191f08b3db081307d3447ce
     with:
       runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,15 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@dde8c378815e47aa027c163278430c0d98ae007b
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
     with:
-      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
+      runner_mode: repo_owned
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      workspace_mode: isolated
+      publish_mode: same_runner
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"
-      cleanup_paths: "dist node_modules pkg pkg-github bazel-bin bazel-out bazel-testlogs .pnpm-store bazel-pkg.tgz MODULE.bazel.lock"
       metadata_check_command: pnpm check:release-metadata
       typecheck_command: pnpm typecheck
       unit_test_command: pnpm test


### PR DESCRIPTION
## What changed
- switched the shared package workflow call to the V2 branch in `ci-templates`
- declared `runner_mode: repo_owned`
- declared `workspace_mode: isolated`
- declared `publish_mode: same_runner`
- removed the legacy cleanup-path dependency from the package lane

## Why
`acuity-middleware` already has a real repo-owned self-hosted package path, but the workflow still expressed it as a hosted-compatible fallback. This patch makes the package contract honest without touching the separate hosted Modal deploy boundary.

## Impact
- package CI and publish now declare repo-owned self-hosted intent directly
- workspace isolation becomes part of the package contract
- the hosted deploy exception stays explicit and outside this PR

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/publish.yml")'`

## Notes
- this depends on the companion `ci-templates` V2 branch being merged or kept available while testing
