### PR TITLE
ci(docker): GHCR build + push workflow (T14 — Phase 1.0 exit unblocker)

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -6,6 +6,10 @@ on:
     tags: ['v*', 'phase-*']
   workflow_dispatch:
 
+concurrency:
+  group: docker-ghcr-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-push:
     runs-on: ubuntu-latest
@@ -26,7 +30,7 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/jesssullivan/acuity-middleware
+          images: ghcr.io/${{ github.repository_owner }}/acuity-middleware
           tags: |
             type=ref,event=branch
             type=ref,event=tag

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main]
     tags: ['v*', 'phase-*']
+  pull_request:
+    # Build-only (no push) on PRs touching the Dockerfile or this workflow
+    # so we catch build breakage before merge.
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-ghcr.yml'
+      - '.dockerignore'
   workflow_dispatch:
 
 concurrency:
@@ -17,30 +25,34 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      # Login only on push events; PR builds are validation-only (push=false below).
+      - if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/acuity-middleware
           tags: |
             type=ref,event=branch
             type=ref,event=tag
+            type=ref,event=pr
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
-          push: true
+          # Push on branch/tag events; build-only on PRs (validation).
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,44 @@
+name: docker-ghcr
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*', 'phase-*']
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/jesssullivan/acuity-middleware
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,13 @@
 #     -e ACUITY_BYPASS_COUPON=... \
 #     acuity-middleware
 #
-# Modal Labs:
-#   modal deploy modal-app.py
-
 FROM mcr.microsoft.com/playwright:v1.58.2-noble
+
+LABEL org.opencontainers.image.source="https://github.com/Jesssullivan/acuity-middleware"
+LABEL org.opencontainers.image.description="Acuity Scheduling middleware with Playwright browser automation"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.title="acuity-middleware"
+LABEL org.opencontainers.image.vendor="tummycrypt"
 
 # Install Node.js 22 LTS + pnpm
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
@@ -47,7 +50,7 @@ ENV PORT=3001
 ENV PLAYWRIGHT_HEADLESS=true
 ENV PLAYWRIGHT_TIMEOUT=30000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3001/health', (r) => r.statusCode === 200 ? process.exit(0) : process.exit(1))"
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget -qO- --tries=1 http://localhost:3001/health || exit 1
 
 CMD ["node", "dist/server/handler.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,6 @@ ENV PLAYWRIGHT_HEADLESS=true
 ENV PLAYWRIGHT_TIMEOUT=30000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
-  CMD wget -qO- --tries=1 http://localhost:3001/health || exit 1
+  CMD wget -qO- --tries=1 http://localhost:3001/health
 
 CMD ["node", "dist/server/handler.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV PORT=3001
 ENV PLAYWRIGHT_HEADLESS=true
 ENV PLAYWRIGHT_TIMEOUT=30000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
   CMD wget -qO- --tries=1 http://localhost:3001/health || exit 1
 
 CMD ["node", "dist/server/handler.js"]


### PR DESCRIPTION
## Summary

- Publishes the production container image via GitHub Actions → GHCR on every push to `main`, tag, or manual dispatch.
- Emits semantic tag set (`type=ref,event=branch`, `type=ref,event=tag`, `type=sha,format=short`, `latest` on default branch) via `docker/metadata-action@v5`.
- Adds OCI metadata labels + switches the `HEALTHCHECK` to `wget` with a 45s start-period to survive Playwright browser cold-start.

## Why

**This is the blocker for Phase 1.0 exit** (see [Issue #47 — Phase 1.0 Exit Checklist](https://github.com/Jesssullivan/acuity-middleware/issues/47)). The blahaj Tofu stack ([tinyland-inc/blahaj#80](https://github.com/tinyland-inc/blahaj/pull/80)) is merged and references `ghcr.io/jesssullivan/acuity-middleware:<tag>`, but no image exists in GHCR because this workflow never landed. Any `tofu apply` today would `ImagePullBackOff`. Once this PR merges and the first workflow run succeeds, the next step is opening a blahaj PR that flips `tofu/stacks/acuity-middleware/variables.tf` `image_tag` default from the rolling `"main"` to the emitted immutable `sha-<short>` or `v0.4.x` tag.

## Coverage (plan task)

- **T14** — Build + push acuity-middleware image to GHCR (plan line 1529).

## Test plan

- [ ] CI matrix passes on this branch
- [ ] First `docker-ghcr` workflow run on merge-to-main emits `ghcr.io/jesssullivan/acuity-middleware:main`, `:sha-<short>`, `:latest`
- [ ] Manifest includes the OCI labels (`org.opencontainers.image.source=...`, etc.)
- [ ] HEALTHCHECK passes on a Playwright cold-start container (45s start-period covers browser warm-up)
- [ ] GHCR package visibility is public (follow-up setting, not in this PR)

## Out of scope

- Multi-arch (`linux/arm64`) — kept single-arch `linux/amd64` for speed; add later if blahaj grows arm workers.
- Vulnerability scanning — can wire Trivy in a follow-up.
