### PR TITLE
fix(ci): update ci-templates SHA (permissions fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@7dddffb9969ccd3e0f2d9105e95cd834d3050685
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@f2e12c10580f17d54ac48434e2577fbcfe502a05
     with:
       runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}


### PR DESCRIPTION
## Summary
- Updates `js-bazel-package.yml` SHA from `@7dddffb` to `@f2e12c1`
- ci-templates PR #11 removed per-job `permissions` blocks that caused `startup_failure`

## Root cause
Reusable workflows cannot expand GITHUB_TOKEN permissions beyond what the caller grants. The repo's default is `read`, but publish jobs requested `id-token: write` and `packages: write`. GitHub rejected the entire workflow at planning time.

## Test plan
- [ ] CI creates jobs (no `startup_failure`)
- [ ] Unit tests pass on self-hosted runner