### PR TITLE
fix(ci): update publish workflow ci-templates SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0e13cc4e50b191f48191f08b3db081307d3447ce
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@f2e12c10580f17d54ac48434e2577fbcfe502a05
     with:
       runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}


### PR DESCRIPTION
## Summary
- Publish workflow (`publish.yml`) still pinned to ci-templates `@0e13cc4` which has per-job `permissions` blocks causing `startup_failure`
- CI workflow was updated in #55 but publish was missed
- Updates to `@f2e12c1` (ci-templates PRs #10 + #11)

Without this fix, any `v*` tag push will fail with `startup_failure` before jobs are created.

## Tracked
- TIN-104 (Bazel artifact truth)
- TIN-164 (ci-templates Bazel workflow)