### PR TITLE
ci(docker): GHCR build + push workflow (T14)

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,60 @@
+name: docker-ghcr
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*', 'phase-*']
+  pull_request:
+    # Build-only (no push) on PRs touching the Dockerfile or this workflow
+    # so we catch build breakage before merge.
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-ghcr.yml'
+      - '.dockerignore'
+  workflow_dispatch:
+
+concurrency:
+  group: docker-ghcr-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      # Login only on push events; PR builds are validation-only (push=false below).
+      - if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/acuity-middleware
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          # Push on branch/tag events; build-only on PRs (validation).
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,13 @@
 #     -e ACUITY_BYPASS_COUPON=... \
 #     acuity-middleware
 #
-# Modal Labs:
-#   modal deploy modal-app.py
-
 FROM mcr.microsoft.com/playwright:v1.58.2-noble
+
+LABEL org.opencontainers.image.source="https://github.com/Jesssullivan/acuity-middleware"
+LABEL org.opencontainers.image.description="Acuity Scheduling middleware with Playwright browser automation"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.title="acuity-middleware"
+LABEL org.opencontainers.image.vendor="tummycrypt"
 
 # Install Node.js 22 LTS + pnpm
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
@@ -47,7 +50,7 @@ ENV PORT=3001
 ENV PLAYWRIGHT_HEADLESS=true
 ENV PLAYWRIGHT_TIMEOUT=30000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3001/health', (r) => r.statusCode === 200 ? process.exit(0) : process.exit(1))"
+HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
+  CMD wget -qO- --tries=1 http://localhost:3001/health
 
 CMD ["node", "dist/server/handler.js"]


### PR DESCRIPTION
## Summary
- Cherry-picks the GHCR Docker workflow from `dev/k8s` (PR #51) onto `main`
- GitHub Actions only discovers workflows on the default branch — this file must be on `main` to trigger
- Adds `docker-ghcr.yml`: builds and pushes `ghcr.io/jesssullivan/acuity-middleware` on push to main, tags (`v*`, `phase-*`), and workflow_dispatch
- PR builds are validation-only (no push) for Dockerfile/workflow path changes
- All 5 actions SHA-pinned (Greptile P2 addressed in original PR)
- Dockerfile OCI metadata labels + HEALTHCHECK improvements included

## Why this is CI infra, not K8s application promotion
Same category as `ci.yml`, `publish.yml`, and `deploy-modal.yml` which already live on main. The workflow produces container artifacts — it doesn't change application behavior or deploy anything.

## Phase 1.0 critical path (TIN-189)
This unblocks the first GHCR image (`sha-<short>` tag), which is required before:
1. blahaj `variables.tf` can pin to an immutable image tag
2. `tofu apply` from tailnet (T15)
3. Pods can pull a real image (currently would `ImagePullBackOff`)

## Test plan
- [ ] CI passes (workflow file is valid YAML, Dockerfile builds)
- [ ] After merge: first push to main triggers `docker-ghcr` workflow
- [ ] GHCR image appears at `ghcr.io/jesssullivan/acuity-middleware`

Tracked: TIN-189, TIN-104.