### PR TITLE
fix(deps): tighten scheduling-kit pin to ^0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "paper:dev": "node docs/paper/watch.mjs"
   },
   "dependencies": {
-    "@tummycrypt/scheduling-kit": "^0.7.1",
+    "@tummycrypt/scheduling-kit": "^0.7.2",
     "effect": "^3.19.14",
     "ioredis": "^5",
     "playwright-core": "1.58.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@tummycrypt/scheduling-kit':
-        specifier: ^0.7.1
-        version: 0.7.1(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
+        specifier: ^0.7.2
+        version: 0.7.2(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
       effect:
         specifier: ^3.19.14
         version: 3.21.0
@@ -373,8 +373,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@tummycrypt/scheduling-kit@0.7.1':
-    resolution: {integrity: sha512-kG8dBfVYOwngICtCiKzI7M95xJ5hxhLK1Kdoftboz0aSS5dDlwogaFXZvKaWzodL472GPRV968sQa19IpI/QNA==}
+  '@tummycrypt/scheduling-kit@0.7.2':
+    resolution: {integrity: sha512-AO2kju5cvM7jiBGM2MMw0YAOZxh3qxh2VcRN3q1TSdo6lt9ne6BtbN1ynf+WybavkIx6D8kQ/+c3LPCmlBKY8w==}
     engines: {node: '>=20 <25'}
     peerDependencies:
       '@skeletonlabs/skeleton': ^4.0.0
@@ -1367,7 +1367,7 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tummycrypt/scheduling-kit@0.7.1(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
+  '@tummycrypt/scheduling-kit@0.7.2(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
     dependencies:
       '@tummycrypt/tinyland-auth-pg': 0.1.1(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)
       drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)


### PR DESCRIPTION
## Summary
- Bridge dependency on `@tummycrypt/scheduling-kit` was `^0.7.1`, now `^0.7.2`
- Kit is at 0.7.2; MassageIthaca already pins `^0.7.2`
- Eliminates drift risk where a clean install could resolve to 0.7.1

Surfaced by TIN-101 cross-repo version audit: "no hidden dependency drift like bridge → kit ^0.6.1"

## Tracked
- TIN-101 (toolchain convergence)
- TIN-94 (ownership map — dependency alignment)