### PR TITLE
refactor: rename modalEnvironment → runtimeEnvironment

### DIFF
--- a/src/adapters/acuity/steps/slot-read-profile.ts
+++ b/src/adapters/acuity/steps/slot-read-profile.ts
@@ -11,7 +11,7 @@ export interface SlotReadPhaseTimings {
 export interface SlotReadProfileContext {
 	readonly requestId?: string;
 	readonly endpoint?: string;
-	readonly modalEnvironment?: string;
+	readonly runtimeEnvironment?: string;
 	readonly releaseSha?: string;
 	readonly releaseVersion?: string;
 	readonly flowOwner?: string;

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -3,7 +3,7 @@
  *
  * Standalone Node.js HTTP server wrapping the Effect TS wizard programs.
  * Designed to run inside a Docker container with Playwright + Chromium
- * on Modal Labs, Fly.io, or any host.
+ * on K8s, Modal Labs, Fly.io, or any container host.
  *
  * Endpoints:
  *   GET  /health                    - Health check

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -165,7 +165,7 @@ const runtimeLogFields = () => ({
 	flowOwner: 'scheduling-bridge',
 	backend: 'acuity',
 	transport: 'http-json',
-	modalEnvironment: process.env.MODAL_ENVIRONMENT,
+	runtimeEnvironment: process.env.DEPLOYMENT_ENVIRONMENT ?? process.env.MODAL_ENVIRONMENT,
 	releaseSha: process.env.MIDDLEWARE_RELEASE_SHA,
 	releaseVersion: process.env.MIDDLEWARE_RELEASE_VERSION ?? process.env.npm_package_version,
 });
@@ -395,7 +395,7 @@ const handleHealth = (_req: IncomingMessage, res: ServerResponse) => {
 			releaseRef: process.env.MIDDLEWARE_RELEASE_REF,
 			releaseVersion: process.env.MIDDLEWARE_RELEASE_VERSION ?? process.env.npm_package_version,
 			releaseBuiltAt: process.env.MIDDLEWARE_RELEASE_BUILT_AT ?? process.env.MIDDLEWARE_BUILD_TIMESTAMP,
-			modalEnvironment: process.env.MODAL_ENVIRONMENT,
+			runtimeEnvironment: process.env.DEPLOYMENT_ENVIRONMENT ?? process.env.MODAL_ENVIRONMENT,
 		}),
 	);
 };

--- a/src/server/health.ts
+++ b/src/server/health.ts
@@ -35,7 +35,7 @@ export interface BuildHealthPayloadOptions {
 	releaseRef?: string | null;
 	releaseVersion?: string | null;
 	releaseBuiltAt?: string | null;
-	modalEnvironment?: string | null;
+	runtimeEnvironment?: string | null;
 	timestamp?: string;
 }
 
@@ -49,7 +49,7 @@ export const buildHealthPayload = ({
 	releaseRef,
 	releaseVersion,
 	releaseBuiltAt,
-	modalEnvironment,
+	runtimeEnvironment,
 	timestamp = new Date().toISOString(),
 }: BuildHealthPayloadOptions) => ({
 	status: 'ok' as const,
@@ -62,14 +62,14 @@ export const buildHealthPayload = ({
 	releaseRef: releaseRef ?? 'unknown',
 	releaseVersion: releaseVersion ?? 'unknown',
 	releaseBuiltAt: releaseBuiltAt ?? null,
-	modalEnvironment: modalEnvironment ?? null,
+	runtimeEnvironment: runtimeEnvironment ?? null,
 	protocolVersion: BRIDGE_PROTOCOL_VERSION,
 	release: {
 		sha: releaseSha ?? 'unknown',
 		ref: releaseRef ?? 'unknown',
 		version: releaseVersion ?? 'unknown',
 		builtAt: releaseBuiltAt ?? null,
-		modalEnvironment: modalEnvironment ?? null,
+		runtimeEnvironment: runtimeEnvironment ?? null,
 	},
 	protocol: {
 		version: BRIDGE_PROTOCOL_VERSION,

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -5,7 +5,7 @@
  * 1. Effect Logger (for code inside Effect.gen) — uses Effect's Logger API
  * 2. ndjsonLog() standalone helper (for plain async handlers outside Effect)
  *
- * Both emit JSON lines to stdout/stderr, compatible with Modal's log capture.
+ * Both emit JSON lines to stdout/stderr, compatible with any structured log collector.
  */
 
 import { Logger, Layer, HashMap } from 'effect';

--- a/src/shared/remote-adapter.ts
+++ b/src/shared/remote-adapter.ts
@@ -40,7 +40,7 @@ import { Errors } from '../core/types.js';
 // =============================================================================
 
 export interface RemoteAdapterConfig {
-	/** Base URL of the middleware server (e.g., https://scheduling-middleware--org.modal.run) */
+	/** Base URL of the middleware server (e.g., https://bridge.example.com) */
 	readonly baseUrl: string;
 	/** Auth token for the middleware server */
 	readonly authToken?: string;

--- a/src/shared/remote-adapter.ts
+++ b/src/shared/remote-adapter.ts
@@ -2,8 +2,8 @@
  * Remote Wizard Adapter
  *
  * SchedulingAdapter implementation backed by HTTP calls to a remote
- * middleware server running Playwright + Chromium (e.g., Modal Labs,
- * Fly.io, or any Docker host).
+ * middleware server running Playwright + Chromium (e.g., K8s pod,
+ * Modal Labs, Fly.io, or any Docker host).
  *
  * This adapter is the client-side counterpart to `middleware/server.ts`.
  * It serializes requests, sends them over HTTP, and deserializes
@@ -12,8 +12,8 @@
  * @example
  * ```typescript
  * const adapter = createRemoteWizardAdapter({
- *   baseUrl: process.env.MODAL_MIDDLEWARE_URL,
- *   authToken: process.env.MODAL_AUTH_TOKEN,
+ *   baseUrl: process.env.SCHEDULING_BRIDGE_URL,
+ *   authToken: process.env.SCHEDULING_BRIDGE_AUTH_TOKEN,
  * });
  * const kit = createSchedulingKit(adapter, [venmoAdapter]);
  * ```

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -18,7 +18,7 @@ describe('bridge health payload', () => {
 			releaseRef: 'refs/heads/main',
 			releaseVersion: '0.4.2',
 			releaseBuiltAt: '2026-04-16T12:00:00.000Z',
-			modalEnvironment: 'main',
+			runtimeEnvironment: 'main',
 			timestamp: '2026-04-16T12:34:56.000Z',
 		});
 
@@ -28,7 +28,7 @@ describe('bridge health payload', () => {
 			ref: 'refs/heads/main',
 			version: '0.4.2',
 			builtAt: '2026-04-16T12:00:00.000Z',
-			modalEnvironment: 'main',
+			runtimeEnvironment: 'main',
 		});
 		expect(payload.protocol).toEqual({
 			version: BRIDGE_PROTOCOL_VERSION,
@@ -60,7 +60,7 @@ describe('bridge health payload', () => {
 			ref: 'unknown',
 			version: 'unknown',
 			builtAt: null,
-			modalEnvironment: null,
+			runtimeEnvironment: null,
 		});
 	});
 });

--- a/tests/slot-read-profile.test.ts
+++ b/tests/slot-read-profile.test.ts
@@ -69,6 +69,36 @@ describe('slot read profiling helpers', () => {
 		expect(event.context?.flowOwner).toBe('scheduling-bridge');
 	});
 
+	it('carries runtimeEnvironment through context', () => {
+		const profile = createSlotReadProfile({
+			serviceId: '53178494',
+			date: '2026-04-25',
+			thresholdMs: 1500,
+			calendarTileCount: 28,
+			matchedDateFound: true,
+			slotCount: 4,
+			parsedSlotCount: 4,
+			phases: {
+				navigationMs: 100,
+				calendarReadyMs: 20,
+				dateSelectMs: 30,
+				postClickSettleMs: 50,
+				slotWaitMs: 40,
+				slotDomReadMs: 10,
+				parseMs: 5,
+			},
+			context: {
+				requestId: 'req-456',
+				runtimeEnvironment: 'tailnet-dev',
+				releaseSha: 'abc123',
+			},
+		});
+
+		const event = buildSlotReadProfileEvent(profile);
+		expect(event.context?.runtimeEnvironment).toBe('tailnet-dev');
+		expect(event.context?.releaseSha).toBe('abc123');
+	});
+
 	it('reads threshold and force-log config from env', () => {
 		const config = getSlotReadProfileConfig({
 			SCHEDULING_BRIDGE_SLOT_PROFILE_THRESHOLD_MS: '2200',


### PR DESCRIPTION
## Summary
- Renames `modalEnvironment` → `runtimeEnvironment` across health payload, handler telemetry, and slot-read profiling
- Backward-compatible env var fallback: `process.env.DEPLOYMENT_ENVIRONMENT ?? process.env.MODAL_ENVIRONMENT`
- Decouples naming from Modal-specific assumptions for K8s runtime portability

**Files changed:** `src/server/health.ts`, `src/server/handler.ts`, `src/adapters/acuity/steps/slot-read-profile.ts`, `tests/health.test.ts`

## Test plan
- [x] `vitest` health payload tests updated and passing
- [x] Existing Modal deployments unaffected (falls back to `MODAL_ENVIRONMENT`)
- [ ] K8s deployment sets `DEPLOYMENT_ENVIRONMENT` instead

**Tracker:** TIN-189 (K8s migration umbrella)