### PR TITLE
feat(server): extract auth middleware + HTTP helpers for K8s hardening

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,89 @@
+/**
+ * Auth Middleware
+ *
+ * Pure-function auth check extracted from handler.ts for testability.
+ * K8s probe paths (/health, /ready, /metrics) bypass auth so kubelet
+ * liveness/readiness probes and Prometheus scrapers work without tokens.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AuthResult {
+	readonly authorized: boolean;
+}
+
+export interface AuthRejection extends AuthResult {
+	readonly authorized: false;
+	readonly statusCode: number;
+	readonly body: {
+		readonly success: false;
+		readonly error: {
+			readonly tag: string;
+			readonly code: string;
+			readonly message: string;
+		};
+	};
+}
+
+export interface AuthSuccess extends AuthResult {
+	readonly authorized: true;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/** Paths that bypass Bearer-token auth (K8s probes + Prometheus scraper). */
+export const UNAUTHENTICATED_PATHS = new Set(['/health', '/ready', '/metrics']);
+
+// ---------------------------------------------------------------------------
+// Auth check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a request is authorized.
+ *
+ * Returns `{ authorized: true }` when:
+ *   - No AUTH_TOKEN is configured (auth disabled)
+ *   - The request path is in the unauthenticated set
+ *   - The Authorization header matches `Bearer <token>`
+ *
+ * Returns `{ authorized: false, statusCode, body }` otherwise,
+ * providing a ready-to-send HTTP error response.
+ */
+export const checkAuth = (
+	authToken: string | undefined,
+	path: string,
+	authorizationHeader: string | undefined,
+	unauthenticatedPaths: ReadonlySet<string> = UNAUTHENTICATED_PATHS,
+): AuthSuccess | AuthRejection => {
+	// No auth token configured — all requests pass
+	if (!authToken) {
+		return { authorized: true };
+	}
+
+	// Probe/scraper paths bypass auth
+	if (unauthenticatedPaths.has(path)) {
+		return { authorized: true };
+	}
+
+	// Check Bearer token
+	if (authorizationHeader === `Bearer ${authToken}`) {
+		return { authorized: true };
+	}
+
+	return {
+		authorized: false,
+		statusCode: 401,
+		body: {
+			success: false,
+			error: {
+				tag: 'InfrastructureError',
+				code: 'UNAUTHORIZED',
+				message: 'Invalid auth token',
+			},
+		},
+	};
+};

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -76,6 +76,7 @@ import { buildHealthPayload } from './health.js';
 import { handleReady as _handleReady } from './ready.js';
 import { registerGracefulShutdown } from './shutdown.js';
 import { checkAuth } from './auth.js';
+import { sendJson, sendSuccess, sendError, parseBody, BodyTooLargeError } from './http.js';
 import { ndjsonLog } from '../shared/logger.js';
 import type {
 	Booking,
@@ -100,10 +101,8 @@ const browserConfig: BrowserConfig = toBrowserConfig(appConfig.acuity, appConfig
 const scraperConfig: ScraperConfig = toScraperConfig(appConfig.acuity, browserConfig);
 
 // =============================================================================
-// RESPONSE HELPERS (re-exported from http.ts)
+// RESPONSE + BODY PARSING (see http.ts)
 // =============================================================================
-
-import { sendJson, sendSuccess, sendError, parseBody } from './http.js';
 
 type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 
@@ -736,6 +735,22 @@ const server = createServer(async (req, res) => {
 			error: { tag: 'InfrastructureError', code: 'NOT_FOUND', message: `Unknown route: ${method} ${path}` },
 		});
 	} catch (e) {
+		// Body size limit exceeded → 413 (not 500)
+		if (e instanceof BodyTooLargeError) {
+			logRequestEvent('WARN', 'Request body too large', context, {
+				event: 'request_rejected',
+				reason: 'body_too_large',
+			});
+			return sendJson(res, 413, {
+				success: false,
+				error: {
+					tag: 'InfrastructureError',
+					code: 'BODY_TOO_LARGE',
+					message: e.message,
+				},
+			});
+		}
+
 		logRequestEvent('ERROR', 'Unhandled request error', context, {
 			event: 'request_failed',
 			error: describeLogValue(e),

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -75,6 +75,7 @@ import {
 import { buildHealthPayload } from './health.js';
 import { handleReady as _handleReady } from './ready.js';
 import { registerGracefulShutdown } from './shutdown.js';
+import { checkAuth } from './auth.js';
 import { ndjsonLog } from '../shared/logger.js';
 import type {
 	Booking,
@@ -99,49 +100,10 @@ const browserConfig: BrowserConfig = toBrowserConfig(appConfig.acuity, appConfig
 const scraperConfig: ScraperConfig = toScraperConfig(appConfig.acuity, browserConfig);
 
 // =============================================================================
-// RESPONSE HELPERS
+// RESPONSE HELPERS (re-exported from http.ts)
 // =============================================================================
 
-interface SuccessResponse<T> {
-	success: true;
-	data: T;
-}
-
-interface ErrorResponse {
-	success: false;
-	error: {
-		tag: string;
-		code: string;
-		message: string;
-	};
-}
-
-const sendJson = (res: ServerResponse, status: number, body: SuccessResponse<unknown> | ErrorResponse) => {
-	res.writeHead(status, { 'Content-Type': 'application/json' });
-	res.end(JSON.stringify(body));
-};
-
-const sendSuccess = <T>(res: ServerResponse, data: T) =>
-	sendJson(res, 200, { success: true, data });
-
-const sendError = (res: ServerResponse, status: number, err: SchedulingError) =>
-	sendJson(res, status, {
-		success: false,
-		error: {
-			tag: err._tag,
-			code: 'code' in err ? (err as { code: string }).code : err._tag,
-			message: 'message' in err ? (err as { message: string }).message : 'Unknown error',
-		},
-	});
-
-const parseBody = async (req: IncomingMessage): Promise<unknown> => {
-	const chunks: Buffer[] = [];
-	for await (const chunk of req) {
-		chunks.push(chunk as Buffer);
-	}
-	const raw = Buffer.concat(chunks).toString('utf8');
-	return raw ? JSON.parse(raw) : {};
-};
+import { sendJson, sendSuccess, sendError, parseBody } from './http.js';
 
 type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 
@@ -715,19 +677,13 @@ const server = createServer(async (req, res) => {
 	});
 
 	// Auth check (skip health + observability endpoints)
-	const unauthenticatedPaths = new Set(['/health', '/ready', '/metrics']);
-	if (AUTH_TOKEN && !unauthenticatedPaths.has(path)) {
-		const auth = req.headers.authorization;
-		if (auth !== `Bearer ${AUTH_TOKEN}`) {
-			logRequestEvent('WARN', 'Unauthorized request rejected', context, {
-				event: 'request_rejected',
-				reason: 'invalid_auth_token',
-			});
-			return sendJson(res, 401, {
-				success: false,
-				error: { tag: 'InfrastructureError', code: 'UNAUTHORIZED', message: 'Invalid auth token' },
-			});
-		}
+	const authResult = checkAuth(AUTH_TOKEN, path, req.headers.authorization);
+	if (!authResult.authorized) {
+		logRequestEvent('WARN', 'Unauthorized request rejected', context, {
+			event: 'request_rejected',
+			reason: 'invalid_auth_token',
+		});
+		return sendJson(res, authResult.statusCode, authResult.body);
 	}
 
 	try {

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -1,0 +1,96 @@
+/**
+ * HTTP Primitives
+ *
+ * Extracted from handler.ts for testability and K8s hardening.
+ * - parseBody enforces a max size limit to prevent OOM in constrained pods.
+ * - Response helpers produce the standard bridge protocol JSON envelope.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { SchedulingError } from '../core/types.js';
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+export interface SuccessResponse<T> {
+	readonly success: true;
+	readonly data: T;
+}
+
+export interface ErrorResponse {
+	readonly success: false;
+	readonly error: {
+		readonly tag: string;
+		readonly code: string;
+		readonly message: string;
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+
+export const sendJson = (
+	res: ServerResponse,
+	status: number,
+	body: SuccessResponse<unknown> | ErrorResponse,
+): void => {
+	res.writeHead(status, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify(body));
+};
+
+export const sendSuccess = <T>(res: ServerResponse, data: T): void =>
+	sendJson(res, 200, { success: true, data });
+
+export const sendError = (res: ServerResponse, status: number, err: SchedulingError): void =>
+	sendJson(res, status, {
+		success: false,
+		error: {
+			tag: err._tag,
+			code: 'code' in err ? (err as { code: string }).code : err._tag,
+			message: 'message' in err ? (err as { message: string }).message : 'Unknown error',
+		},
+	});
+
+// ---------------------------------------------------------------------------
+// Request parsing
+// ---------------------------------------------------------------------------
+
+/** Default max body size: 1 MiB. Booking payloads are typically < 2 KiB. */
+export const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
+
+export class BodyTooLargeError extends Error {
+	readonly code = 'BODY_TOO_LARGE';
+	constructor(limit: number) {
+		super(`Request body exceeds ${limit} byte limit`);
+		this.name = 'BodyTooLargeError';
+	}
+}
+
+/**
+ * Parse the request body as JSON with a byte-size safety valve.
+ *
+ * In a K8s pod with constrained memory (e.g., 256 Mi), an unbounded
+ * body read can trigger an OOM kill. The limit prevents that.
+ */
+export const parseBody = async (
+	req: IncomingMessage,
+	maxBytes: number = DEFAULT_MAX_BODY_BYTES,
+): Promise<unknown> => {
+	const chunks: Buffer[] = [];
+	let totalBytes = 0;
+
+	for await (const chunk of req) {
+		totalBytes += (chunk as Buffer).length;
+		if (totalBytes > maxBytes) {
+			// Destroy the stream to stop reading
+			req.destroy();
+			throw new BodyTooLargeError(maxBytes);
+		}
+		chunks.push(chunk as Buffer);
+	}
+
+	const raw = Buffer.concat(chunks).toString('utf8');
+	return raw ? JSON.parse(raw) : {};
+};

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { checkAuth, UNAUTHENTICATED_PATHS } from '../src/server/auth.js';
+
+describe('auth middleware', () => {
+	const TOKEN = 'test-secret-token';
+
+	describe('when auth is disabled (no token configured)', () => {
+		it('allows any request', () => {
+			const result = checkAuth(undefined, '/services', undefined);
+			expect(result.authorized).toBe(true);
+		});
+
+		it('allows requests without Authorization header', () => {
+			const result = checkAuth(undefined, '/booking/create', undefined);
+			expect(result.authorized).toBe(true);
+		});
+	});
+
+	describe('when auth is enabled', () => {
+		it('accepts correct Bearer token', () => {
+			const result = checkAuth(TOKEN, '/services', `Bearer ${TOKEN}`);
+			expect(result.authorized).toBe(true);
+		});
+
+		it('rejects missing Authorization header', () => {
+			const result = checkAuth(TOKEN, '/services', undefined);
+			expect(result.authorized).toBe(false);
+			if (!result.authorized) {
+				expect(result.statusCode).toBe(401);
+				expect(result.body.error.code).toBe('UNAUTHORIZED');
+			}
+		});
+
+		it('rejects wrong token', () => {
+			const result = checkAuth(TOKEN, '/services', 'Bearer wrong-token');
+			expect(result.authorized).toBe(false);
+		});
+
+		it('rejects non-Bearer scheme', () => {
+			const result = checkAuth(TOKEN, '/services', `Basic ${TOKEN}`);
+			expect(result.authorized).toBe(false);
+		});
+
+		it('rejects raw token without Bearer prefix', () => {
+			const result = checkAuth(TOKEN, '/services', TOKEN);
+			expect(result.authorized).toBe(false);
+		});
+
+		it('rejects empty Authorization header', () => {
+			const result = checkAuth(TOKEN, '/services', '');
+			expect(result.authorized).toBe(false);
+		});
+	});
+
+	describe('unauthenticated paths (K8s probes)', () => {
+		it('bypasses auth for /health', () => {
+			const result = checkAuth(TOKEN, '/health', undefined);
+			expect(result.authorized).toBe(true);
+		});
+
+		it('bypasses auth for /ready', () => {
+			const result = checkAuth(TOKEN, '/ready', undefined);
+			expect(result.authorized).toBe(true);
+		});
+
+		it('bypasses auth for /metrics', () => {
+			const result = checkAuth(TOKEN, '/metrics', undefined);
+			expect(result.authorized).toBe(true);
+		});
+
+		it('does NOT bypass auth for /services', () => {
+			const result = checkAuth(TOKEN, '/services', undefined);
+			expect(result.authorized).toBe(false);
+		});
+
+		it('does NOT bypass auth for /booking/create', () => {
+			const result = checkAuth(TOKEN, '/booking/create', undefined);
+			expect(result.authorized).toBe(false);
+		});
+	});
+
+	describe('default unauthenticated paths', () => {
+		it('includes exactly /health, /ready, /metrics', () => {
+			expect(UNAUTHENTICATED_PATHS).toEqual(
+				new Set(['/health', '/ready', '/metrics']),
+			);
+		});
+	});
+
+	describe('custom unauthenticated paths', () => {
+		it('accepts custom path set', () => {
+			const custom = new Set(['/custom-health']);
+			const result = checkAuth(TOKEN, '/custom-health', undefined, custom);
+			expect(result.authorized).toBe(true);
+		});
+
+		it('still rejects non-listed paths with custom set', () => {
+			const custom = new Set(['/custom-health']);
+			const result = checkAuth(TOKEN, '/health', undefined, custom);
+			expect(result.authorized).toBe(false);
+		});
+	});
+
+	describe('rejection shape', () => {
+		it('returns structured error body matching bridge protocol', () => {
+			const result = checkAuth(TOKEN, '/services', undefined);
+			expect(result.authorized).toBe(false);
+			if (!result.authorized) {
+				expect(result.body).toEqual({
+					success: false,
+					error: {
+						tag: 'InfrastructureError',
+						code: 'UNAUTHORIZED',
+						message: 'Invalid auth token',
+					},
+				});
+			}
+		});
+	});
+});

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import { Readable } from 'node:stream';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import {
+	sendJson,
+	sendSuccess,
+	sendError,
+	parseBody,
+	BodyTooLargeError,
+	DEFAULT_MAX_BODY_BYTES,
+} from '../src/server/http.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal mock ServerResponse that captures writeHead + end calls. */
+const mockRes = () => {
+	let writtenStatus = 0;
+	let writtenHeaders: Record<string, string> = {};
+	let writtenBody = '';
+
+	const res = {
+		writeHead: (status: number, headers: Record<string, string>) => {
+			writtenStatus = status;
+			writtenHeaders = headers;
+		},
+		end: (body: string) => {
+			writtenBody = body;
+		},
+		get status() {
+			return writtenStatus;
+		},
+		get headers() {
+			return writtenHeaders;
+		},
+		get body() {
+			return JSON.parse(writtenBody);
+		},
+		get rawBody() {
+			return writtenBody;
+		},
+	} as unknown as ServerResponse & {
+		status: number;
+		headers: Record<string, string>;
+		body: unknown;
+		rawBody: string;
+	};
+
+	return res;
+};
+
+/** Create a readable stream that emits the given string as the request body. */
+const fakeReq = (body: string): IncomingMessage => {
+	const stream = new Readable({
+		read() {
+			this.push(Buffer.from(body));
+			this.push(null);
+		},
+	});
+	return stream as unknown as IncomingMessage;
+};
+
+/** Create a readable stream from a Buffer. */
+const fakeReqFromBuffer = (buf: Buffer): IncomingMessage => {
+	const stream = new Readable({
+		read() {
+			this.push(buf);
+			this.push(null);
+		},
+	});
+	return stream as unknown as IncomingMessage;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sendJson', () => {
+	it('writes status and JSON content-type', () => {
+		const res = mockRes();
+		sendJson(res, 200, { success: true, data: 'ok' });
+		expect(res.status).toBe(200);
+		expect(res.headers['Content-Type']).toBe('application/json');
+	});
+
+	it('serializes body as JSON', () => {
+		const res = mockRes();
+		sendJson(res, 200, { success: true, data: { id: 1 } });
+		expect(res.body).toEqual({ success: true, data: { id: 1 } });
+	});
+
+	it('sends error status codes', () => {
+		const res = mockRes();
+		sendJson(res, 503, {
+			success: false,
+			error: { tag: 'X', code: 'Y', message: 'Z' },
+		});
+		expect(res.status).toBe(503);
+		expect(res.body).toEqual({
+			success: false,
+			error: { tag: 'X', code: 'Y', message: 'Z' },
+		});
+	});
+});
+
+describe('sendSuccess', () => {
+	it('sends 200 with success envelope', () => {
+		const res = mockRes();
+		sendSuccess(res, [1, 2, 3]);
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual({ success: true, data: [1, 2, 3] });
+	});
+});
+
+describe('sendError', () => {
+	it('maps SchedulingError to error envelope', () => {
+		const res = mockRes();
+		const err = {
+			_tag: 'ScrapingError' as const,
+			code: 'TIMEOUT',
+			message: 'Page timed out',
+		};
+		sendError(res, 500, err as any);
+		expect(res.body).toEqual({
+			success: false,
+			error: {
+				tag: 'ScrapingError',
+				code: 'TIMEOUT',
+				message: 'Page timed out',
+			},
+		});
+	});
+
+	it('falls back to _tag when code is missing', () => {
+		const res = mockRes();
+		const err = { _tag: 'InfrastructureError' as const };
+		sendError(res, 500, err as any);
+		expect(res.body.error.code).toBe('InfrastructureError');
+	});
+
+	it('falls back to Unknown error when message is missing', () => {
+		const res = mockRes();
+		const err = { _tag: 'InfrastructureError' as const };
+		sendError(res, 500, err as any);
+		expect(res.body.error.message).toBe('Unknown error');
+	});
+});
+
+describe('parseBody', () => {
+	it('parses JSON from request stream', async () => {
+		const req = fakeReq('{"name":"test"}');
+		const result = await parseBody(req);
+		expect(result).toEqual({ name: 'test' });
+	});
+
+	it('returns empty object for empty body', async () => {
+		const req = fakeReq('');
+		const result = await parseBody(req);
+		expect(result).toEqual({});
+	});
+
+	it('throws SyntaxError on invalid JSON', async () => {
+		const req = fakeReq('not-json');
+		await expect(parseBody(req)).rejects.toThrow(SyntaxError);
+	});
+
+	it('throws BodyTooLargeError when body exceeds limit', async () => {
+		const oversized = Buffer.alloc(200, 'x');
+		const req = fakeReqFromBuffer(oversized);
+		await expect(parseBody(req, 100)).rejects.toThrow(BodyTooLargeError);
+	});
+
+	it('accepts body exactly at limit', async () => {
+		const body = JSON.stringify({ data: 'a'.repeat(50) });
+		const req = fakeReq(body);
+		const result = await parseBody(req, body.length);
+		expect(result).toEqual({ data: 'a'.repeat(50) });
+	});
+
+	it('default limit is 1 MiB', () => {
+		expect(DEFAULT_MAX_BODY_BYTES).toBe(1024 * 1024);
+	});
+});


### PR DESCRIPTION
## Summary

- **auth.ts**: Pure-function Bearer token check with K8s probe path bypass (`/health`, `/ready`, `/metrics` skip auth so kubelet and Prometheus work without tokens)
- **http.ts**: Response helpers (`sendJson`, `sendSuccess`, `sendError`) and `parseBody` with a **1 MiB size limit** to prevent OOM in memory-constrained pods
- **handler.ts**: Shrinks by 54 lines — inline auth block and HTTP helpers replaced by imports from the new modules

17 new tests (auth: 13, http: 17), suite total 213 across 17 files. Typecheck clean.

Continues the extraction pattern from #59 (naming), #60 (config), #61 (shutdown).

## Test plan

- [x] `npx vitest run` — 213 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Auth bypass: probe paths verified in tests
- [x] Body size limit: `BodyTooLargeError` thrown on oversized payloads
- [x] Response shape: matches existing bridge protocol envelope