### PR TITLE
feat(deploy): K8s manifest scaffold with Kustomize base

### DIFF
--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,27 @@
+# Non-secret configuration for the scheduling bridge.
+# Secrets (AUTH_TOKEN, REDIS_PASSWORD, ACUITY_BYPASS_COUPON) are
+# managed via SOPS-encrypted Secret manifests — see secret.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scheduling-bridge-config
+  namespace: scheduling-bridge
+  labels:
+    app.kubernetes.io/name: scheduling-bridge
+    app.kubernetes.io/component: middleware
+    app.kubernetes.io/part-of: tinyland
+data:
+  # Server
+  PORT: "3001"
+  NODE_ENV: "production"
+
+  # Acuity
+  ACUITY_BASE_URL: "https://MassageIthaca.as.me"
+  ACUITY_SERVICE_CACHE_TTL_MS: "300000"
+
+  # Browser / Playwright
+  PLAYWRIGHT_HEADLESS: "true"
+  PLAYWRIGHT_TIMEOUT: "30000"
+
+  # Runtime identity (injected by CI — overridden per-deploy)
+  DEPLOYMENT_ENVIRONMENT: "tailnet-dev"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -74,6 +74,7 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
+            timeoutSeconds: 5  # Chromium cold-start can be slow
             failureThreshold: 12  # 5 + 12*5 = 65s max startup
 
           # Liveness: is the Node process alive?

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,113 @@
+# Scheduling bridge Deployment.
+#
+# Wires up:
+#   - Liveness probe  → GET /health  (is the process alive?)
+#   - Readiness probe  → GET /ready   (are Redis + browser + catalog healthy?)
+#   - Startup probe   → GET /health  (allow slow Chromium launch)
+#   - Graceful shutdown via SIGTERM + terminationGracePeriodSeconds
+#   - Non-root securityContext (matches Dockerfile USER middleware)
+#   - Resource limits sized for Playwright + Chromium headless
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scheduling-bridge
+  namespace: scheduling-bridge
+  labels:
+    app.kubernetes.io/name: scheduling-bridge
+    app.kubernetes.io/component: middleware
+    app.kubernetes.io/part-of: tinyland
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: scheduling-bridge
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: scheduling-bridge
+        app.kubernetes.io/component: middleware
+        app.kubernetes.io/part-of: tinyland
+      annotations:
+        # Prometheus scrape config — /metrics endpoint (prom-client)
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3001"
+        prometheus.io/path: "/metrics"
+    spec:
+      # Match the Dockerfile's 15s drain timeout + a 5s buffer
+      terminationGracePeriodSeconds: 20
+
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+        - name: middleware
+          image: ghcr.io/jesssullivan/acuity-middleware:latest
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+
+          envFrom:
+            - configMapRef:
+                name: scheduling-bridge-config
+            - secretRef:
+                name: scheduling-bridge-secrets
+
+          # Release metadata — injected by CI at deploy time
+          env:
+            - name: MIDDLEWARE_RELEASE_SHA
+              value: ""  # overridden by kustomize or CI
+            - name: MIDDLEWARE_RELEASE_VERSION
+              value: ""
+            - name: MIDDLEWARE_RELEASE_REF
+              value: ""
+            - name: MIDDLEWARE_RELEASE_BUILT_AT
+              value: ""
+
+          # --- Probes ---
+          # Startup: generous timeout for Chromium cold-start
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12  # 5 + 12*5 = 65s max startup
+
+          # Liveness: is the Node process alive?
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+
+          # Readiness: are dependencies (Redis, browser, catalog) healthy?
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 2
+
+          # --- Resources ---
+          # Chromium headless needs ~300-500 Mi per page.
+          # One concurrent browser session at a time.
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false  # Chromium needs /tmp writes
+            capabilities:
+              drop:
+                - ALL

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -14,7 +14,9 @@ namespace: scheduling-bridge
 resources:
   - namespace.yaml
   - configmap.yaml
-  - sealed-secret-template.yaml
+  # sealed-secret-template.yaml is NOT a resource — it documents the
+  # expected Secret shape. Apply real secrets via:
+  #   sops -d deploy/k8s/secret.enc.yaml | kubectl apply -f -
   - deployment.yaml
   - service.yaml
 

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,29 @@
+# Kustomize base for the scheduling bridge.
+#
+# Usage:
+#   kubectl apply -k deploy/k8s/
+#
+# For environment-specific overlays (e.g., tailnet-dev vs prod), create
+# deploy/k8s/overlays/<env>/kustomization.yaml that patches image tags,
+# replica counts, and resource limits.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: scheduling-bridge
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - sealed-secret-template.yaml
+  - deployment.yaml
+  - service.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: tinyland
+      app.kubernetes.io/managed-by: kustomize
+    includeSelectors: false
+
+images:
+  - name: ghcr.io/jesssullivan/acuity-middleware
+    newTag: latest  # overridden per-deploy by CI

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scheduling-bridge
+  labels:
+    app.kubernetes.io/part-of: tinyland
+    app.kubernetes.io/managed-by: kubectl

--- a/deploy/k8s/sealed-secret-template.yaml
+++ b/deploy/k8s/sealed-secret-template.yaml
@@ -1,0 +1,21 @@
+# SOPS-encrypted secret placeholder.
+#
+# Actual values are injected via:
+#   sops -d deploy/k8s/secret.enc.yaml | kubectl apply -f -
+#
+# This file documents the expected shape. Never commit plaintext values.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scheduling-bridge-secrets
+  namespace: scheduling-bridge
+  labels:
+    app.kubernetes.io/name: scheduling-bridge
+    app.kubernetes.io/component: middleware
+    app.kubernetes.io/part-of: tinyland
+type: Opaque
+stringData:
+  AUTH_TOKEN: "PLACEHOLDER — replace via sops"
+  ACUITY_BYPASS_COUPON: "PLACEHOLDER — replace via sops"
+  REDIS_URL: "PLACEHOLDER — replace via sops"
+  REDIS_PASSWORD: "PLACEHOLDER — replace via sops"

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,20 @@
+# ClusterIP service for tailnet-internal traffic.
+# External access is via Tailscale Ingress or tailnet-only DNS.
+apiVersion: v1
+kind: Service
+metadata:
+  name: scheduling-bridge
+  namespace: scheduling-bridge
+  labels:
+    app.kubernetes.io/name: scheduling-bridge
+    app.kubernetes.io/component: middleware
+    app.kubernetes.io/part-of: tinyland
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: scheduling-bridge
+  ports:
+    - name: http
+      port: 3001
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
## Summary

- **Kustomize base** in `deploy/k8s/` — first deployable K8s target for the scheduling bridge
- **Deployment** with three-probe strategy: startup (Chromium cold-start), liveness (`/health`), readiness (`/ready` — checks Redis, browser, catalog)
- **Prometheus annotations** on pod template for automatic `/metrics` scraping
- **terminationGracePeriodSeconds: 20** matched to the 15s drain timeout from #61
- **Resource limits** sized for Playwright + Chromium headless (512Mi request, 1Gi limit)
- **ConfigMap** with non-secret env vars matching the centralized config.ts readers from #60
- **Secret template** (SOPS placeholder) for AUTH_TOKEN, Redis credentials, coupon code
- **ClusterIP Service** for tailnet-internal traffic

Wires together all K8s readiness work: #59 (runtime naming), #60 (config), #61 (shutdown), #62 (auth/probes).

## Test plan

- [x] `kubectl kustomize deploy/k8s/` renders cleanly (no warnings)
- [x] Probe paths match actual endpoints (`/health`, `/ready`, `/metrics`)
- [x] terminationGracePeriodSeconds > shutdown drainTimeoutMs
- [x] Resource limits account for Chromium headless memory usage
- [ ] Dry-run apply against dev cluster (future — requires GHCR image from #57)