### PR TITLE
feat(deploy): tailnet-dev Kustomize overlay + deploy script

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# deploy.sh — Apply the scheduling bridge to a K8s cluster.
+#
+# Usage:
+#   deploy/deploy.sh tailnet-dev              # apply tailnet-dev overlay
+#   deploy/deploy.sh tailnet-dev --dry-run     # preview without applying
+#   IMAGE_TAG=sha-abc1234 deploy/deploy.sh tailnet-dev
+#
+# Prerequisites:
+#   - kubectl configured for the target cluster
+#   - SOPS + age key available for secret decryption
+#   - GHCR image already pushed (PR #57 → main)
+set -euo pipefail
+
+OVERLAY="${1:?Usage: deploy.sh <overlay> [--dry-run]}"
+DRY_RUN="${2:-}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OVERLAY_DIR="${SCRIPT_DIR}/overlays/${OVERLAY}"
+
+if [[ ! -d "${OVERLAY_DIR}" ]]; then
+  echo "Error: overlay '${OVERLAY}' not found at ${OVERLAY_DIR}" >&2
+  echo "Available overlays:" >&2
+  ls "${SCRIPT_DIR}/overlays/" 2>/dev/null || echo "  (none)" >&2
+  exit 1
+fi
+
+# Override image tag if IMAGE_TAG is set
+if [[ -n "${IMAGE_TAG:-}" ]]; then
+  echo "Using image tag: ${IMAGE_TAG}"
+  cd "${OVERLAY_DIR}"
+  kustomize edit set image "ghcr.io/jesssullivan/acuity-middleware:${IMAGE_TAG}"
+  cd - > /dev/null
+fi
+
+echo "Rendering overlay: ${OVERLAY}"
+echo "---"
+
+if [[ "${DRY_RUN}" == "--dry-run" ]]; then
+  kubectl kustomize "${OVERLAY_DIR}"
+  echo "---"
+  echo "(dry-run — no changes applied)"
+else
+  kubectl apply -k "${OVERLAY_DIR}"
+  echo "---"
+  echo "Waiting for rollout..."
+  kubectl -n scheduling-bridge rollout status deployment/scheduling-bridge --timeout=120s
+  echo "Deploy complete."
+fi

--- a/deploy/overlays/tailnet-dev/configmap-patch.yaml
+++ b/deploy/overlays/tailnet-dev/configmap-patch.yaml
@@ -1,0 +1,10 @@
+# Patch: tailnet-dev environment identity
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scheduling-bridge-config
+  namespace: scheduling-bridge
+data:
+  DEPLOYMENT_ENVIRONMENT: "tailnet-dev"
+  # Lower cache TTL for faster iteration during dev
+  ACUITY_SERVICE_CACHE_TTL_MS: "60000"

--- a/deploy/overlays/tailnet-dev/deployment-patch.yaml
+++ b/deploy/overlays/tailnet-dev/deployment-patch.yaml
@@ -1,0 +1,23 @@
+# Patch: tailnet-dev resource tuning
+#
+# Single replica, lower resource limits for dev cluster.
+# The blahaj cluster has limited capacity — save headroom
+# for other workloads.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scheduling-bridge
+  namespace: scheduling-bridge
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: middleware
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi

--- a/deploy/overlays/tailnet-dev/kustomization.yaml
+++ b/deploy/overlays/tailnet-dev/kustomization.yaml
@@ -1,0 +1,20 @@
+# Tailnet-dev overlay — single-replica, relaxed resources, dev identity.
+#
+# Usage:
+#   kubectl apply -k deploy/overlays/tailnet-dev/
+#
+# This overlay targets the blahaj on-prem cluster's scheduling-bridge
+# namespace, accessible only via Tailscale.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../k8s  # base
+
+patches:
+  - path: deployment-patch.yaml
+  - path: configmap-patch.yaml
+
+images:
+  - name: ghcr.io/jesssullivan/acuity-middleware
+    newTag: latest  # CI replaces with sha-<short> on deploy


### PR DESCRIPTION
## Summary

- **tailnet-dev overlay** in `deploy/overlays/tailnet-dev/` — patches for the blahaj on-prem cluster:
  - Resource limits: 500m/768Mi (vs base 1/1Gi) — saves headroom on limited cluster
  - Cache TTL: 60s (vs base 300s) — faster iteration during dev
  - `DEPLOYMENT_ENVIRONMENT=tailnet-dev` identity
- **`deploy/deploy.sh`** — wraps `kubectl apply -k` with:
  - `IMAGE_TAG` env var for CI-injected image tags
  - `--dry-run` mode for preview
  - `kubectl rollout status` wait after apply
  - Overlay existence validation

Layout: `deploy/k8s/` (base), `deploy/overlays/<env>/` (patches), `deploy/deploy.sh` (entrypoint). Overlays are siblings of the base to avoid kustomize cycle detection.

## Test plan

- [x] `kubectl kustomize deploy/overlays/tailnet-dev/` renders cleanly
- [x] ConfigMap patched: `ACUITY_SERVICE_CACHE_TTL_MS=60000`
- [x] Deployment patched: `cpu: 500m`, `memory: 768Mi` limits
- [x] No kustomize cycle errors
- [x] `deploy/deploy.sh --dry-run` validates (requires kubectl context)