### PR TITLE
feat(deploy): NetworkPolicy for scheduling-bridge namespace

### DIFF
--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   #   sops -d deploy/k8s/secret.enc.yaml | kubectl apply -f -
   - deployment.yaml
   - service.yaml
+  - networkpolicy.yaml
 
 labels:
   - pairs:

--- a/deploy/k8s/networkpolicy.yaml
+++ b/deploy/k8s/networkpolicy.yaml
@@ -1,0 +1,63 @@
+# Default-deny ingress for the scheduling-bridge namespace.
+# All ingress is blocked unless explicitly allowed by the companion policy below.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: scheduling-bridge
+  labels:
+    app.kubernetes.io/part-of: tinyland
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  podSelector: {}  # matches all pods in namespace
+  policyTypes:
+    - Ingress
+---
+# Allow ingress to scheduling-bridge pods from:
+#   1. Same-namespace pods (N=2 replicas + Redis StatefulSet)
+#   2. Prometheus (tinyland-dev-production) for /metrics scraping
+#   3. Tailscale proxy (blahaj-ops) for tailnet-exposed service
+#
+# Egress is unrestricted — middleware must reach Acuity (HTTPS),
+# Redis (same namespace), and DNS.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-scheduling-bridge-ingress
+  namespace: scheduling-bridge
+  labels:
+    app.kubernetes.io/part-of: tinyland
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: scheduling-bridge
+  policyTypes:
+    - Ingress
+  ingress:
+    # Same-namespace pod-to-pod (N=2 replicas, Redis StatefulSet)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scheduling-bridge
+      ports:
+        - protocol: TCP
+          port: 3001
+
+    # Prometheus scraping from monitoring namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tinyland-dev-production
+      ports:
+        - protocol: TCP
+          port: 3001
+
+    # Tailscale proxy for tailnet access
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: blahaj-ops
+      ports:
+        - protocol: TCP
+          port: 3001

--- a/deploy/k8s/networkpolicy.yaml
+++ b/deploy/k8s/networkpolicy.yaml
@@ -13,8 +13,8 @@ spec:
   policyTypes:
     - Ingress
 ---
-# Allow ingress to scheduling-bridge pods from:
-#   1. Same-namespace pods (N=2 replicas + Redis StatefulSet)
+# Allow ingress to scheduling-bridge middleware pods from:
+#   1. Same-namespace pods (N=2 replicas)
 #   2. Prometheus (tinyland-dev-production) for /metrics scraping
 #   3. Tailscale proxy (blahaj-ops) for tailnet-exposed service
 #
@@ -35,7 +35,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # Same-namespace pod-to-pod (N=2 replicas, Redis StatefulSet)
+    # Same-namespace pod-to-pod (N=2 replicas)
     - from:
         - namespaceSelector:
             matchLabels:
@@ -44,11 +44,14 @@ spec:
         - protocol: TCP
           port: 3001
 
-    # Prometheus scraping from monitoring namespace
+    # Prometheus scraping from monitoring namespace (pod-scoped)
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: tinyland-dev-production
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
       ports:
         - protocol: TCP
           port: 3001
@@ -61,3 +64,30 @@ spec:
       ports:
         - protocol: TCP
           port: 3001
+---
+# Allow ingress to Redis StatefulSet from middleware pods.
+# Without this, default-deny-ingress blocks middleware → Redis traffic.
+# (Greptile P1: Redis pods need their own allow rule)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-redis-ingress
+  namespace: scheduling-bridge
+  labels:
+    app.kubernetes.io/part-of: tinyland
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis-scheduling-bridge
+  policyTypes:
+    - Ingress
+  ingress:
+    # Only middleware pods can reach Redis
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: scheduling-bridge
+      ports:
+        - protocol: TCP
+          port: 6379


### PR DESCRIPTION
## Summary
- Default-deny ingress policy for the `scheduling-bridge` namespace
- Explicit allow rules: same-namespace pods, Prometheus (`tinyland-dev-production`), Tailscale proxy (`blahaj-ops`)
- Egress unrestricted (middleware needs Acuity HTTPS, Redis, DNS)
- Added to kustomization.yaml resources; both base and overlay render cleanly

## Context
Closes the NetworkPolicy gap flagged in TIN-189 exit criteria and GitHub #47. Reference pattern from blahaj `tofu/stacks/mail/network-policies.tf`.

## Test plan
- [x] `kubectl kustomize deploy/k8s/` renders both policies
- [x] `kubectl kustomize deploy/overlays/tailnet-dev/` renders both policies
- [ ] `--dry-run=server` against blahaj (Task #19, after merge)

**Tracker:** TIN-189, GitHub #47