### PR TITLE
feat(deploy): SOPS-age encrypted secret + roundtrip verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage/
 out/
 MODULE.bazel.lock
 bazel-*
+
+# Plaintext secrets — only *.enc.yaml (SOPS-encrypted) should be committed
+deploy/k8s/secret.yaml

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,16 @@
+# SOPS configuration for acuity-middleware secrets.
+#
+# Uses the same age key as the blahaj infrastructure repo.
+# Private key: ~/.config/sops/age/keys.txt (never committed)
+#
+# Usage:
+#   sops -e deploy/k8s/secret.yaml > deploy/k8s/secret.enc.yaml   # encrypt
+#   sops -d deploy/k8s/secret.enc.yaml                             # decrypt
+#   sops -d deploy/k8s/secret.enc.yaml | kubectl apply -f -        # deploy
+creation_rules:
+  - path_regex: deploy/k8s/secret\.enc\.yaml$
+    encrypted_regex: ^(data|stringData)$
+    age: age1wc2s9pfju7haufdw0at0pm2cxx9rs9qmj80nf0nzy82w0fr0gp3skzfgds
+  - path_regex: .*\.enc\.yaml$
+    encrypted_regex: ^(data|stringData)$
+    age: age1wc2s9pfju7haufdw0at0pm2cxx9rs9qmj80nf0nzy82w0fr0gp3skzfgds

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -8,9 +8,6 @@
 #   sops -d deploy/k8s/secret.enc.yaml                             # decrypt
 #   sops -d deploy/k8s/secret.enc.yaml | kubectl apply -f -        # deploy
 creation_rules:
-  - path_regex: deploy/k8s/secret\.enc\.yaml$
-    encrypted_regex: ^(data|stringData)$
-    age: age1wc2s9pfju7haufdw0at0pm2cxx9rs9qmj80nf0nzy82w0fr0gp3skzfgds
   - path_regex: .*\.enc\.yaml$
     encrypted_regex: ^(data|stringData)$
     age: age1wc2s9pfju7haufdw0at0pm2cxx9rs9qmj80nf0nzy82w0fr0gp3skzfgds

--- a/deploy/k8s/secret.enc.yaml
+++ b/deploy/k8s/secret.enc.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: scheduling-bridge-secrets
+    namespace: scheduling-bridge
+    labels:
+        app.kubernetes.io/name: scheduling-bridge
+        app.kubernetes.io/component: middleware
+        app.kubernetes.io/part-of: tinyland
+type: Opaque
+stringData:
+    AUTH_TOKEN: ENC[AES256_GCM,data:IcUzgU2dm39uZ3arVr586z7Qj1NyiD7dX5bm+3C9eN+K2UmWHUQmggQ+,iv:sY+drKNpga7Z66JGWAtDedIVau3jYHHz4+Z2nb94X0s=,tag:jxUUiwvnuPoQcJEcKZN79Q==,type:str]
+    ACUITY_BYPASS_COUPON: ENC[AES256_GCM,data:R2DZPLUR7lh4T+4K17f50d3Hj8QP5ljbP7cNYJ1WlxLo64pNu7QfxUigfA==,iv:C7sRmnuqOLkXdLX43aKMlDNdXuH7uqymPxCrV4U0RgI=,tag:ermtvDZfWFHl8VihNl/ghA==,type:str]
+    REDIS_URL: ENC[AES256_GCM,data:XGQXd/9Nqkc/0LRESiHwGZpLrMqfxV1Z+OhO98taO0PdcXfFx2AmIp8rqOLGgdZq4F1Y3WyX6/9YRh+gqour1R6g8BOFlh0xS5L4TWZuZ4yBzIUQVgDZEqSlalHera8gIps=,iv:6sCII9/WEG+cv2SgD5/VunEHp0jVn++qSAASpVaIkko=,tag:NQaXrbKq0ktMlZY0njHGbw==,type:str]
+    REDIS_PASSWORD: ENC[AES256_GCM,data:bNxca7iYto/5fEcqmjnYvfnbHC1p/Qq+57LC7MPkri85yC9Mk87fq41vuy3T,iv:znjJYv/iIxgOtX0ZsYASQTqGDtOOuhMdv+EuIoGc5hs=,tag:YUIwwe4+DkTWgxBDobFJaA==,type:str]
+sops:
+    age:
+        - recipient: age1wc2s9pfju7haufdw0at0pm2cxx9rs9qmj80nf0nzy82w0fr0gp3skzfgds
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2SlJ2ckRrREhnNjNDV2Qr
+            a1RINVlXRG1SZlIveDB3VE1LWE93cWJRMUhBCnM1dmNKd3llbzVZOHRoN0d0RndH
+            TlY3Sk95aklBNVg4cUIzNHJjeDBLYUEKLS0tIGtlY1N5YmVCMWVrWTNCVlBNQURR
+            ZHZidG1vKzdCdFRBZ3YwbXQ1d1RtVWMKBWZrr7BaCdS1pgH3r+kex4d1nF378vc+
+            dHk/fijnbUnf08qMQ2GL8paUhNV0yxAoC5gNLjXNzeEi1tPwKuw+SA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-19T03:31:19Z"
+    mac: ENC[AES256_GCM,data:aMioTI0nM9Pvs0cEE802rQJlqC749m7+ziG7EaY92715guxNrwYgh2chw8QjBvu4kLJCb9PDgUINps2LCSidyJmO8uVjQ20jw2hQ8H+OaYse7LJ+YyoIo6UibNQwVUqkW23DXGbQCNqOedr5Y8WtC70WfFm4kGKqsssL5YqJi3M=,iv:1yPaMHGqj84KKjAORw0i2eA6RdPGuFav1RgDEi42czM=,tag:9SOzebroiStMpz3OMdwS7g==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0


### PR DESCRIPTION
## Summary
- `.sops.yaml` config with blahaj age public key + `encrypted_regex: ^(data|stringData)$`
- `deploy/k8s/secret.enc.yaml` — encrypted K8s Secret with test placeholders
- Metadata stays plaintext (reviewable), only `stringData` values encrypted
- Roundtrip verified: encrypt → decrypt → semantic equality confirmed

## Deploy workflow
```bash
sops -d deploy/k8s/secret.enc.yaml | kubectl apply -f -
```

## Before first real deploy
Replace test placeholder values with real credentials via:
```bash
sops deploy/k8s/secret.enc.yaml  # opens editor with decrypted values
```

## Test plan
- [x] `sops -e -i` encrypts successfully
- [x] `sops -d` decrypts with all 4 values intact
- [x] Metadata fields remain plaintext
- [x] Semantic roundtrip equality verified (JSON parse + compare)

**Tracker:** TIN-189, GitHub #47