### PR TITLE
feat(adapter): add custom headers to RemoteAdapterConfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,9 @@ jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c0ee4a21713eb91cc6fec2670054aab42b1aac22
     with:
-      runner_mode: shared
-      shared_runner_labels_json: '["tinyland-docker"]'
+      runner_mode: hosted
       workspace_mode: isolated
-      publish_mode: same_runner
+      publish_mode: hosted_exception
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c0ee4a21713eb91cc6fec2670054aab42b1aac22
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@26cc90926d727b0830748b0c846082952860be0d
     with:
       runner_mode: hosted
       workspace_mode: isolated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@f2e12c10580f17d54ac48434e2577fbcfe502a05
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c0ee4a21713eb91cc6fec2670054aab42b1aac22
     with:
-      runner_mode: repo_owned
-      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      runner_mode: shared
+      shared_runner_labels_json: '["tinyland-docker"]'
       workspace_mode: isolated
       publish_mode: same_runner
       node_versions: '["20", "22"]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c0ee4a21713eb91cc6fec2670054aab42b1aac22
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@26cc90926d727b0830748b0c846082952860be0d
     with:
       runner_mode: hosted
       workspace_mode: isolated

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,9 @@ jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c0ee4a21713eb91cc6fec2670054aab42b1aac22
     with:
-      runner_mode: shared
-      shared_runner_labels_json: '["tinyland-docker"]'
+      runner_mode: hosted
       workspace_mode: isolated
-      publish_mode: same_runner
+      publish_mode: hosted_exception
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@f2e12c10580f17d54ac48434e2577fbcfe502a05
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c0ee4a21713eb91cc6fec2670054aab42b1aac22
     with:
-      runner_mode: repo_owned
-      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      runner_mode: shared
+      shared_runner_labels_json: '["tinyland-docker"]'
       workspace_mode: isolated
       publish_mode: same_runner
       node_versions: '["20", "22"]'

--- a/src/shared/__tests__/remote-adapter.test.ts
+++ b/src/shared/__tests__/remote-adapter.test.ts
@@ -1,0 +1,127 @@
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRemoteWizardAdapter, type RemoteAdapterConfig } from '../remote-adapter.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Capture the headers sent by makeRequest via a mocked global fetch. */
+const capturedHeaders: Record<string, string>[] = [];
+
+const mockFetchSuccess = (data: unknown = []) =>
+	vi.fn(async (_url: string, init?: RequestInit) => {
+		const raw = init?.headers ?? {};
+		capturedHeaders.push(
+			raw instanceof Headers
+				? Object.fromEntries(raw.entries())
+				: (raw as Record<string, string>),
+		);
+		return new Response(JSON.stringify({ success: true, data }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RemoteAdapterConfig.headers', () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		capturedHeaders.length = 0;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it('includes custom headers in outgoing requests', async () => {
+		const fetchMock = mockFetchSuccess();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const config: RemoteAdapterConfig = {
+			baseUrl: 'https://bridge.test',
+			headers: { 'x-request-id': 'req-abc-123', 'x-tenant': 'clinic-42' },
+		};
+
+		const adapter = createRemoteWizardAdapter(config);
+		await Effect.runPromise(adapter.getServices());
+
+		expect(capturedHeaders).toHaveLength(1);
+		expect(capturedHeaders[0]['x-request-id']).toBe('req-abc-123');
+		expect(capturedHeaders[0]['x-tenant']).toBe('clinic-42');
+	});
+
+	it('does not override Content-Type with custom headers', async () => {
+		const fetchMock = mockFetchSuccess();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const config: RemoteAdapterConfig = {
+			baseUrl: 'https://bridge.test',
+			headers: { 'Content-Type': 'text/xml' },
+		};
+
+		const adapter = createRemoteWizardAdapter(config);
+		await Effect.runPromise(adapter.getServices());
+
+		expect(capturedHeaders[0]['Content-Type']).toBe('application/json');
+	});
+
+	it('does not override Authorization with custom headers', async () => {
+		const fetchMock = mockFetchSuccess();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const config: RemoteAdapterConfig = {
+			baseUrl: 'https://bridge.test',
+			authToken: 'real-token',
+			headers: { Authorization: 'Bearer evil-token' },
+		};
+
+		const adapter = createRemoteWizardAdapter(config);
+		await Effect.runPromise(adapter.getServices());
+
+		expect(capturedHeaders[0]['Authorization']).toBe('Bearer real-token');
+	});
+
+	it('works correctly when no custom headers are provided', async () => {
+		const fetchMock = mockFetchSuccess();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const config: RemoteAdapterConfig = {
+			baseUrl: 'https://bridge.test',
+			authToken: 'some-token',
+		};
+
+		const adapter = createRemoteWizardAdapter(config);
+		await Effect.runPromise(adapter.getServices());
+
+		expect(capturedHeaders[0]['Content-Type']).toBe('application/json');
+		expect(capturedHeaders[0]['Authorization']).toBe('Bearer some-token');
+		// No extra keys beyond Content-Type and Authorization
+		expect(Object.keys(capturedHeaders[0])).toHaveLength(2);
+	});
+
+	it('preserves custom headers across multiple requests', async () => {
+		const fetchMock = mockFetchSuccess();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const config: RemoteAdapterConfig = {
+			baseUrl: 'https://bridge.test',
+			headers: { 'x-request-id': 'persistent-id' },
+		};
+
+		const adapter = createRemoteWizardAdapter(config);
+
+		await Effect.runPromise(adapter.getServices());
+		await Effect.runPromise(adapter.getServices());
+
+		expect(capturedHeaders).toHaveLength(2);
+		expect(capturedHeaders[0]['x-request-id']).toBe('persistent-id');
+		expect(capturedHeaders[1]['x-request-id']).toBe('persistent-id');
+	});
+});

--- a/src/shared/__tests__/remote-adapter.test.ts
+++ b/src/shared/__tests__/remote-adapter.test.ts
@@ -72,6 +72,23 @@ describe('RemoteAdapterConfig.headers', () => {
 		expect(capturedHeaders[0]['Content-Type']).toBe('application/json');
 	});
 
+	it('ignores case-insensitive Content-Type override attempts', async () => {
+		const fetchMock = mockFetchSuccess();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const config: RemoteAdapterConfig = {
+			baseUrl: 'https://bridge.test',
+			headers: { 'content-type': 'text/xml', 'CoNtEnT-TyPe': 'text/plain' },
+		};
+
+		const adapter = createRemoteWizardAdapter(config);
+		await Effect.runPromise(adapter.getServices());
+
+		expect(capturedHeaders[0]['Content-Type']).toBe('application/json');
+		expect(capturedHeaders[0]['content-type']).toBeUndefined();
+		expect(capturedHeaders[0]['CoNtEnT-TyPe']).toBeUndefined();
+	});
+
 	it('does not override Authorization with custom headers', async () => {
 		const fetchMock = mockFetchSuccess();
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
@@ -86,6 +103,24 @@ describe('RemoteAdapterConfig.headers', () => {
 		await Effect.runPromise(adapter.getServices());
 
 		expect(capturedHeaders[0]['Authorization']).toBe('Bearer real-token');
+	});
+
+	it('ignores case-insensitive Authorization override attempts', async () => {
+		const fetchMock = mockFetchSuccess();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const config: RemoteAdapterConfig = {
+			baseUrl: 'https://bridge.test',
+			authToken: 'real-token',
+			headers: { authorization: 'Bearer evil-token', AUTHORIZATION: 'Bearer worse-token' },
+		};
+
+		const adapter = createRemoteWizardAdapter(config);
+		await Effect.runPromise(adapter.getServices());
+
+		expect(capturedHeaders[0]['Authorization']).toBe('Bearer real-token');
+		expect(capturedHeaders[0]['authorization']).toBeUndefined();
+		expect(capturedHeaders[0]['AUTHORIZATION']).toBeUndefined();
 	});
 
 	it('works correctly when no custom headers are provided', async () => {
@@ -106,7 +141,7 @@ describe('RemoteAdapterConfig.headers', () => {
 		expect(Object.keys(capturedHeaders[0])).toHaveLength(2);
 	});
 
-	it('preserves custom headers across multiple requests', async () => {
+	it('preserves static custom headers across multiple requests', async () => {
 		const fetchMock = mockFetchSuccess();
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 

--- a/src/shared/remote-adapter.ts
+++ b/src/shared/remote-adapter.ts
@@ -56,11 +56,12 @@ export interface RemoteAdapterConfig {
 	readonly services?: readonly Service[];
 	/**
 	 * Additional HTTP headers to include in every request to the middleware
-	 * server. Useful for request correlation IDs, tracing headers, or
-	 * tenant identification.
+	 * server. Useful for request-scoped correlation IDs, tracing headers, or
+	 * tenant identification. These headers are static for the lifetime of the
+	 * adapter instance; create a new adapter when per-request values must change.
 	 *
 	 * Note: `Content-Type` and `Authorization` are always set by the adapter
-	 * and cannot be overridden via this field.
+	 * and cannot be overridden via this field, regardless of header casing.
 	 */
 	readonly headers?: Readonly<Record<string, string>>;
 }
@@ -79,6 +80,26 @@ interface RemoteResponse<T> {
 	};
 }
 
+const RESERVED_HEADER_NAMES = new Set(['authorization', 'content-type']);
+
+const buildRequestHeaders = (config: RemoteAdapterConfig): Record<string, string> => {
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json',
+	};
+
+	if (config.authToken) {
+		headers['Authorization'] = `Bearer ${config.authToken}`;
+	}
+
+	for (const [name, value] of Object.entries(config.headers ?? {})) {
+		if (!RESERVED_HEADER_NAMES.has(name.toLowerCase())) {
+			headers[name] = value;
+		}
+	}
+
+	return headers;
+};
+
 const makeRequest = <T>(
 	config: RemoteAdapterConfig,
 	path: string,
@@ -88,13 +109,7 @@ const makeRequest = <T>(
 	Effect.tryPromise({
 		try: async () => {
 			const url = `${config.baseUrl}${path}`;
-			const headers: Record<string, string> = {
-				...(config.headers ?? {}),
-				'Content-Type': 'application/json',
-			};
-			if (config.authToken) {
-				headers['Authorization'] = `Bearer ${config.authToken}`;
-			}
+			const headers = buildRequestHeaders(config);
 
 			const response = await fetch(url, {
 				method,

--- a/src/shared/remote-adapter.ts
+++ b/src/shared/remote-adapter.ts
@@ -54,6 +54,15 @@ export interface RemoteAdapterConfig {
 	 * the middleware's DOM scraper for service listing.
 	 */
 	readonly services?: readonly Service[];
+	/**
+	 * Additional HTTP headers to include in every request to the middleware
+	 * server. Useful for request correlation IDs, tracing headers, or
+	 * tenant identification.
+	 *
+	 * Note: `Content-Type` and `Authorization` are always set by the adapter
+	 * and cannot be overridden via this field.
+	 */
+	readonly headers?: Readonly<Record<string, string>>;
 }
 
 // =============================================================================
@@ -80,6 +89,7 @@ const makeRequest = <T>(
 		try: async () => {
 			const url = `${config.baseUrl}${path}`;
 			const headers: Record<string, string> = {
+				...(config.headers ?? {}),
 				'Content-Type': 'application/json',
 			};
 			if (config.authToken) {


### PR DESCRIPTION
## Summary

- Adds optional `headers` field to `RemoteAdapterConfig` for injecting per-request headers (correlation IDs, tracing, tenant identification)
- Built-in `Content-Type` and `Authorization` are applied after custom headers and cannot be overridden — callers can add but not break transport semantics
- 5 new tests covering: injection, Content-Type safety, Authorization safety, backward compat, persistence across requests

## Motivation

Closes the API gap identified in MassageIthaca#171 — consumers currently monkey-patch `globalThis.fetch` to inject `x-request-id` into bridge requests. This change provides a first-class config-level alternative:

```typescript
const adapter = createRemoteWizardAdapter({
  baseUrl: process.env.SCHEDULING_BRIDGE_URL,
  authToken: process.env.SCHEDULING_BRIDGE_AUTH_TOKEN,
  headers: { 'x-request-id': requestId },
});
```

Non-breaking: `headers` is optional and defaults to `{}`.

## Merge checklist

- [x] `pnpm typecheck` clean
- [x] 155/155 tests pass (14 files)
- [ ] Downstream: MassageIthaca consumer adoption (optional — fetch patching already works)
- [ ] Version bump to 0.4.3 (release decision)