### PR TITLE
fix(ci): restore GHCR workflow + Dockerfile OCI metadata (T14)

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,60 @@
+name: docker-ghcr
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*', 'phase-*']
+  pull_request:
+    # Build-only (no push) on PRs touching the Dockerfile or this workflow
+    # so we catch build breakage before merge.
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-ghcr.yml'
+      - '.dockerignore'
+  workflow_dispatch:
+
+concurrency:
+  group: docker-ghcr-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      # Login only on push events; PR builds are validation-only (push=false below).
+      - if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/acuity-middleware
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          # Push on branch/tag events; build-only on PRs (validation).
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,13 @@
 #     -e ACUITY_BYPASS_COUPON=... \
 #     acuity-middleware
 #
-# Modal Labs:
-#   modal deploy modal-app.py
-
 FROM mcr.microsoft.com/playwright:v1.58.2-noble
+
+LABEL org.opencontainers.image.source="https://github.com/Jesssullivan/acuity-middleware"
+LABEL org.opencontainers.image.description="Acuity Scheduling middleware with Playwright browser automation"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.title="acuity-middleware"
+LABEL org.opencontainers.image.vendor="tummycrypt"
 
 # Install Node.js 22 LTS + pnpm
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
@@ -47,7 +50,7 @@ ENV PORT=3001
 ENV PLAYWRIGHT_HEADLESS=true
 ENV PLAYWRIGHT_TIMEOUT=30000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3001/health', (r) => r.statusCode === 200 ? process.exit(0) : process.exit(1))"
+HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
+  CMD wget -qO- --tries=1 http://localhost:3001/health
 
 CMD ["node", "dist/server/handler.js"]


### PR DESCRIPTION
## Summary

- Restores `.github/workflows/docker-ghcr.yml` and Dockerfile OCI metadata that were lost when PR #51's merge commit diverged from `main` during concurrent merges (#54-#58)
- Content extracted verbatim from PR #51's merge commit (`d0aaf62`)
- **Phase 1.0 exit blocker** — T15 first-apply needs a GHCR image, which requires this workflow on `main`

## What happened

PR #51 was squash-merged onto parent `1421252`, but PRs #54/#55/#56/#58 also landed on the same parent via separate merge paths. Current `main` (`d45fc8a`) traces through the #54→#58 lineage, not through #51. The `docker-ghcr.yml` file and Dockerfile OCI labels/HEALTHCHECK never reached the current `main` HEAD.

## Changes

| File | Source | Content |
|------|--------|---------|
| `.github/workflows/docker-ghcr.yml` | PR #51 (`d0aaf62`) | GHCR build+push on main push, SHA-pinned actions, concurrency guard |
| `Dockerfile` | PR #51 (`d0aaf62`) | OCI metadata labels, wget HEALTHCHECK with 45s start-period |

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, GHCR workflow triggers and produces `ghcr.io/jesssullivan/acuity-middleware:sha-*` image
- [ ] Image tag used to pin blahaj `variables.tf` for T15 first-apply