### PR TITLE
feat(bench): k6 harness for Modal vs K8s parity benchmarks (T18)

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+results/*/
+!results/.gitkeep

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,94 @@
+# Acuity Middleware — k6 Benchmarking Harness
+
+Parity benchmarks for Modal vs Kubernetes deployments.
+Results feed `paper/data/phase1/` for the migration paper.
+
+## Prerequisites
+
+### 1. Install k6
+
+macOS:
+```bash
+brew install k6
+```
+
+Debian/Ubuntu:
+```bash
+sudo apt install k6
+```
+
+Other platforms: https://k6.io/docs/getting-started/installation/
+
+### 2. Network access
+
+Either:
+
+**Option A — Tailnet (recommended for K8s target):**
+The default `BASE_URL` resolves via MagicDNS. Verify your machine is on the
+tailnet and the service is reachable:
+```bash
+tailscale status | grep ts-acuity-mw
+curl http://ts-acuity-mw.ts.net:3001/services
+```
+
+**Option B — Direct URL (Modal or any reachable host):**
+Pass `--base-url` equivalent by setting `BASE_URL` in your environment:
+```bash
+BASE_URL=https://your-modal-endpoint.modal.run TARGET=modal ./run.sh
+```
+
+## Environment Variables
+
+| Variable                  | Default                              | Description                                      |
+|---------------------------|--------------------------------------|--------------------------------------------------|
+| `BASE_URL`                | `http://ts-acuity-mw.ts.net:3001`   | Base URL of the middleware under test            |
+| `AUTH_TOKEN`              | *(empty)*                            | Bearer token for Authorization header            |
+| `TARGET`                  | `unknown`                            | Result tag: `modal` or `k8s`                     |
+| `SERVICE_IDS`             | `1,2,3,4,5`                          | Comma-separated IDs rotated for slot requests    |
+| `EXPECTED_CACHE_HIT_RATIO`| `0.8`                                | Expected fast-response ratio (10k test, informational) |
+
+## Running
+
+```bash
+cd bench/
+
+# Against K8s (on tailnet):
+AUTH_TOKEN=xxx TARGET=k8s ./run.sh
+
+# Against Modal:
+BASE_URL=https://your-org--acuity-mw.modal.run AUTH_TOKEN=xxx TARGET=modal ./run.sh
+```
+
+`run.sh` runs all three scenarios in sequence and writes results to:
+```
+results/<ISO8601_timestamp>-<TARGET>/
+  smoke.json
+  load-1k.json
+  load-10k.json
+```
+
+## Scenarios
+
+| Script            | VUs       | Requests | Endpoints                               |
+|-------------------|-----------|----------|-----------------------------------------|
+| `k6-smoke.js`     | 1         | 100      | `GET /services`                         |
+| `k6-load-1k.js`   | 10 (ramped)| ~1000   | `GET /services`, `GET /availability/slots` |
+| `k6-load-10k.js`  | 20 (sustained 8min) | ~10000 | same as 1k              |
+
+## Thresholds
+
+| Scenario | `http_req_failed` | `http_req_duration p(99)` |
+|----------|-------------------|---------------------------|
+| smoke    | < 1%              | < 8 s                     |
+| load-1k  | < 2%              | < 10 s                    |
+| load-10k | < 5%              | < 15 s                    |
+
+## Interpreting Results
+
+The `--summary-export` JSON files contain aggregated metrics including
+`http_req_duration`, `http_req_failed`, and (for 10k) `cache_hint_fast_response`.
+
+Copy result directories into `paper/data/phase1/` to feed the comparison analysis:
+```bash
+cp -r results/<run>/ ../paper/data/phase1/<run>/
+```

--- a/bench/k6-load-10k.js
+++ b/bench/k6-load-10k.js
@@ -1,7 +1,7 @@
 // bench/k6-load-10k.js — ~10k req sustained load test
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { Trend, Rate } from 'k6/metrics';
+import { Rate } from 'k6/metrics';
 
 export const options = {
   stages: [
@@ -49,7 +49,10 @@ export default function () {
     });
     fastResponses.add(res.timings.duration < 200);
   } else {
-    const serviceId = SERVICE_IDS[__ITER % SERVICE_IDS.length];
+    // __ITER is always odd in this branch; using `__ITER % length` skips
+    // half the services when `SERVICE_IDS.length` is even. `Math.floor(__ITER / 2)`
+    // gives a dense 0,0,1,1,2,2,... index that rotates through every entry.
+    const serviceId = SERVICE_IDS[Math.floor(__ITER / 2) % SERVICE_IDS.length];
     const date = tomorrow();
     const res = http.get(
       `${BASE_URL}/availability/slots?serviceId=${serviceId}&date=${date}`,

--- a/bench/k6-load-10k.js
+++ b/bench/k6-load-10k.js
@@ -1,0 +1,76 @@
+// bench/k6-load-10k.js — ~10k req sustained load test
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+
+export const options = {
+  stages: [
+    { duration: '8m', target: 20 }, // 20 VUs sustained for 8 min
+    { duration: '30s', target: 0 }, // ramp down
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(99)<15000'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://ts-acuity-mw.ts.net:3001';
+const AUTH_TOKEN = __ENV.AUTH_TOKEN || '';
+const EXPECTED_CACHE_HIT_RATIO = parseFloat(
+  __ENV.EXPECTED_CACHE_HIT_RATIO || '0.8'
+);
+
+// Service IDs to rotate through for /availability/slots requests
+const RAW_IDS = __ENV.SERVICE_IDS || '1,2,3,4,5';
+const SERVICE_IDS = RAW_IDS.split(',').map((s) => s.trim());
+
+// Custom metric: track cache-hit-indicative fast responses (<200ms)
+const fastResponses = new Rate('cache_hint_fast_response');
+
+// Simple date helper: YYYY-MM-DD for tomorrow
+const tomorrow = () => {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+};
+
+export default function () {
+  const headers = { Authorization: `Bearer ${AUTH_TOKEN}` };
+  const tag = { target: __ENV.TARGET || 'unknown' };
+
+  // Alternate between /services and /availability/slots
+  const iteration = __ITER % 2;
+  if (iteration === 0) {
+    const res = http.get(`${BASE_URL}/services`, { headers, tags: tag });
+    check(res, {
+      'status 200': (r) => r.status === 200,
+      'services array present': (r) =>
+        Array.isArray(r.json('services')) || Array.isArray(r.json()),
+    });
+    fastResponses.add(res.timings.duration < 200);
+  } else {
+    const serviceId = SERVICE_IDS[__ITER % SERVICE_IDS.length];
+    const date = tomorrow();
+    const res = http.get(
+      `${BASE_URL}/availability/slots?serviceId=${serviceId}&date=${date}`,
+      { headers, tags: tag }
+    );
+    check(res, {
+      'status 200': (r) => r.status === 200,
+    });
+    fastResponses.add(res.timings.duration < 200);
+  }
+
+  sleep(0.05);
+}
+
+export function teardown() {
+  // Log expected vs observed cache-hit proxy at teardown.
+  // k6 does not expose aggregated custom metric values in teardown,
+  // so this is a reminder note only — inspect cache_hint_fast_response
+  // in the summary JSON to compare against EXPECTED_CACHE_HIT_RATIO.
+  console.log(
+    `Expected cache-hit ratio proxy: ${EXPECTED_CACHE_HIT_RATIO}. ` +
+      `Check 'cache_hint_fast_response' in summary JSON for observed value.`
+  );
+}

--- a/bench/k6-load-1k.js
+++ b/bench/k6-load-1k.js
@@ -42,7 +42,10 @@ export default function () {
         Array.isArray(r.json('services')) || Array.isArray(r.json()),
     });
   } else {
-    const serviceId = SERVICE_IDS[__ITER % SERVICE_IDS.length];
+    // __ITER is always odd in this branch; using `__ITER % length` skips
+    // half the services when `SERVICE_IDS.length` is even. `Math.floor(__ITER / 2)`
+    // gives a dense 0,0,1,1,2,2,... index that rotates through every entry.
+    const serviceId = SERVICE_IDS[Math.floor(__ITER / 2) % SERVICE_IDS.length];
     const date = tomorrow();
     const res = http.get(
       `${BASE_URL}/availability/slots?serviceId=${serviceId}&date=${date}`,

--- a/bench/k6-load-1k.js
+++ b/bench/k6-load-1k.js
@@ -1,0 +1,57 @@
+// bench/k6-load-1k.js — ~1000 req ramped load test
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 10 }, // ramp up to 10 VUs
+    { duration: '2m', target: 10 },  // hold at 10 VUs
+    { duration: '30s', target: 0 },  // ramp down
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.02'],
+    http_req_duration: ['p(99)<10000'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://ts-acuity-mw.ts.net:3001';
+const AUTH_TOKEN = __ENV.AUTH_TOKEN || '';
+
+// Service IDs to rotate through for /availability/slots requests
+const RAW_IDS = __ENV.SERVICE_IDS || '1,2,3,4,5';
+const SERVICE_IDS = RAW_IDS.split(',').map((s) => s.trim());
+
+// Simple date helper: YYYY-MM-DD for tomorrow
+const tomorrow = () => {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+};
+
+export default function () {
+  const headers = { Authorization: `Bearer ${AUTH_TOKEN}` };
+  const tag = { target: __ENV.TARGET || 'unknown' };
+
+  // Alternate between /services and /availability/slots
+  const iteration = __ITER % 2;
+  if (iteration === 0) {
+    const res = http.get(`${BASE_URL}/services`, { headers, tags: tag });
+    check(res, {
+      'status 200': (r) => r.status === 200,
+      'services array present': (r) =>
+        Array.isArray(r.json('services')) || Array.isArray(r.json()),
+    });
+  } else {
+    const serviceId = SERVICE_IDS[__ITER % SERVICE_IDS.length];
+    const date = tomorrow();
+    const res = http.get(
+      `${BASE_URL}/availability/slots?serviceId=${serviceId}&date=${date}`,
+      { headers, tags: tag }
+    );
+    check(res, {
+      'status 200': (r) => r.status === 200,
+    });
+  }
+
+  sleep(0.1);
+}

--- a/bench/k6-smoke.js
+++ b/bench/k6-smoke.js
@@ -1,0 +1,28 @@
+// bench/k6-smoke.js — 100 req smoke test, 1 VU
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 1,
+  iterations: 100,
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(99)<8000'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://ts-acuity-mw.ts.net:3001';
+const AUTH_TOKEN = __ENV.AUTH_TOKEN || '';
+
+export default function () {
+  const res = http.get(`${BASE_URL}/services`, {
+    headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    tags: { target: __ENV.TARGET || 'unknown' },
+  });
+  check(res, {
+    'status 200': (r) => r.status === 200,
+    'services array present': (r) =>
+      Array.isArray(r.json('services')) || Array.isArray(r.json()),
+  });
+  sleep(0.1);
+}

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+TARGET="${TARGET:-unknown}"
+OUT="results/${TS}-${TARGET}"
+mkdir -p "$OUT"
+
+echo ">>> Smoke (100 req)"
+k6 run --summary-export="${OUT}/smoke.json" k6-smoke.js
+
+echo ">>> Load 1k"
+k6 run --summary-export="${OUT}/load-1k.json" k6-load-1k.js
+
+echo ">>> Load 10k"
+k6 run --summary-export="${OUT}/load-10k.json" k6-load-10k.js
+
+echo ">>> Done. Results under ${OUT}/"


### PR DESCRIPTION
## Summary

- k6 smoke/load/10k benchmark scripts for Modal vs K8s endpoint parity comparison
- Dense service-ID rotation for realistic cache pressure
- `bench/run.sh` wrapper with timestamped results directory

## Context

Phase 1.0 exit evidence (T18/M6). Stranded feature branch from prior session — rebased onto current main.

Directly advances [TIN-92](https://linear.app/tinyland/issue/TIN-92) (middleware cold-path profiling).

## Test plan

- [ ] k6 scripts load without syntax errors (`k6 inspect bench/k6-smoke.js`)
- [ ] `bench/run.sh` produces JSON output in `bench/results/`