### PR TITLE
Document runner authority truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-<!-- markdownlint-disable-file MD013 -->
-
 # scheduling-bridge Agent Notes
+
+<!-- markdownlint-disable MD013 -->
 
 This file is the working brief for AI agents and LLMs operating in the `acuity-middleware` repo, which publishes as `@tummycrypt/scheduling-bridge`.
 
@@ -149,6 +149,8 @@ The repo name is still `acuity-middleware`, but the package name is `scheduling-
 Today, the publish lane is still pnpm/npm-first. Bazel metadata exists, but it
 is not yet the artifact authority. `TIN-104` exists to change that deliberately
 rather than by implication.
+
+<!-- markdownlint-enable MD013 -->
 
 Current Phase 2 runner truth:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable-file MD013 -->
+
 # scheduling-bridge Agent Notes
 
 This file is the working brief for AI agents and LLMs operating in the `acuity-middleware` repo, which publishes as `@tummycrypt/scheduling-bridge`.
@@ -147,6 +149,14 @@ The repo name is still `acuity-middleware`, but the package name is `scheduling-
 Today, the publish lane is still pnpm/npm-first. Bazel metadata exists, but it
 is not yet the artifact authority. `TIN-104` exists to change that deliberately
 rather than by implication.
+
+Current Phase 2 runner truth:
+
+- canonical package CI/publish authority is repo-owned on GloriousFlywheel
+- the current proven runner contract is the plain repo label
+  `["acuity-middleware"]`
+- do not describe richer repo-owned self-hosted label arrays as current truth
+  unless the live workflow contract is explicitly reproven
 
 ## Important Files
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<!-- markdownlint-disable-file MD013 MD040 MD060 -->
-
 # scheduling-bridge
+
+<!-- markdownlint-disable MD013 MD040 MD060 -->
 
 Backend-agnostic scheduling adapter hub. Currently bridges Acuity Scheduling via Playwright browser automation, with architecture designed to support additional scheduling backends.
 
@@ -157,6 +157,8 @@ pnpm install
 pnpm dev
 ```
 
+<!-- markdownlint-enable MD013 MD040 MD060 -->
+
 ## Release Authority
 
 Current release authority:
@@ -172,7 +174,8 @@ The current publish + deploy shape is:
 3. CI dry-runs the extracted Bazel package surface before release
 4. GitHub Actions publishes that extracted artifact
 5. GitHub Actions deploys the Modal runtime from `main`
-6. downstream apps consume the published package and verify the live runtime tuple via `/health`
+6. downstream apps consume the published package and verify the live runtime
+   tuple via `/health`
 
 This repo is the sole owner of Acuity automation concerns. App repos and shared
 packages may consume the bridge and assert its runtime tuple, but they should
@@ -180,8 +183,8 @@ not duplicate bridge runtime ownership or release truth logic.
 
 ## Runner Authority
 
-Canonical package CI and publish now run on a repo-owned GloriousFlywheel lane.
-The current proven workflow contract is the plain repo label
+Canonical GitHub Actions package CI and publish now run on the repo-owned
+GloriousFlywheel self-hosted runner lane with the plain repo label
 `["acuity-middleware"]`.
 
 Treat that label as the active truth surface for package authority. Do not

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable-file MD013 MD040 MD060 -->
+
 # scheduling-bridge
 
 Backend-agnostic scheduling adapter hub. Currently bridges Acuity Scheduling via Playwright browser automation, with architecture designed to support additional scheduling backends.
@@ -175,6 +177,16 @@ The current publish + deploy shape is:
 This repo is the sole owner of Acuity automation concerns. App repos and shared
 packages may consume the bridge and assert its runtime tuple, but they should
 not duplicate bridge runtime ownership or release truth logic.
+
+## Runner Authority
+
+Canonical package CI and publish now run on a repo-owned GloriousFlywheel lane.
+The current proven workflow contract is the plain repo label
+`["acuity-middleware"]`.
+
+Treat that label as the active truth surface for package authority. Do not
+describe broader repo-owned self-hosted label arrays as live contract unless
+they are reproven from current runs.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- add runner-authority guidance to AGENTS.md and README.md
- add file-local markdownlint disable directives required for the existing document style

## Verification
- git diff --check
- pnpm dlx markdownlint-cli2 AGENTS.md README.md