### PR TITLE
ci: prove shared package runner lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,13 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@827acc1d0b614dc87f3a1b0719770150988c493b
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c9e81f802fe9520260a5389121f8291049e030e1
     with:
-      runner_mode: hosted
+      runner_mode: shared
+      shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
-      publish_mode: hosted_exception
+      publish_mode: same_runner
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,13 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@827acc1d0b614dc87f3a1b0719770150988c493b
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c9e81f802fe9520260a5389121f8291049e030e1
     with:
-      runner_mode: hosted
+      runner_mode: shared
+      shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
-      publish_mode: hosted_exception
+      publish_mode: same_runner
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,8 +159,8 @@ The canonical GitHub repo is `Jesssullivan/scheduling-bridge`; historical
 
 Current CI and publish workflows use the shared `js-bazel-package` workflow with:
 
-- `runner_mode: hosted`
-- `publish_mode: hosted_exception`
+- `runner_mode: shared`
+- `publish_mode: same_runner`
 - `bazel_targets: "//:pkg"`
 - `package_dir: ./bazel-bin/pkg`
 
@@ -172,9 +172,10 @@ re-opening the package authority decision.
 
 Current runner truth:
 
-- the current public workflow contract is the hosted exception above
-- do not describe self-hosted/shared runner labels as live for this repo until
-  the repo Actions runner API and a green workflow run prove them
+- the public workflow contract names the runner policy, not private runner
+  topology
+- the concrete shared-runner labels come from repository Actions variables and
+  must be proven by green workflow runs before being treated as operational truth
 - keep private runner topology, cluster names, and apply details out of this
   public repo; track those in the private infrastructure repo and Linear
 

--- a/README.md
+++ b/README.md
@@ -185,12 +185,11 @@ not duplicate bridge runtime ownership or release truth logic.
 ## Runner Authority
 
 Package CI and publish currently use the shared `js-bazel-package` workflow with
-`runner_mode: hosted` and `publish_mode: hosted_exception`.
+`runner_mode: shared` and `publish_mode: same_runner`.
 
-Treat that hosted exception as the active public workflow truth until a
-self-hosted/shared runner lane is visible to this repository and proven by green
-workflow runs. Keep private runner topology and apply details out of this public
-repo.
+The concrete shared-runner labels come from repository Actions variables and
+must be proven by green workflow runs before they are treated as operational
+truth. Keep private runner topology and apply details out of this public repo.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- replace the stale docs-only draft with a workflow-backed shared-runner proof
- pin the package workflow caller to ci-templates c9e81f8, which contains the startup-safe shared-runner resolver
- source shared runner labels from PRIMARY_LINUX_RUNNER_LABELS_JSON and keep private runner topology out of public docs

## Validation
- git diff --check
- CI will validate the live shared-runner path on this PR

## Notes
- This remains draft until the live shared-runner checks complete.
- No package publish is performed by this PR.