### PR TITLE
ci: pin package workflow to reachable template ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@26cc90926d727b0830748b0c846082952860be0d
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@827acc1d0b614dc87f3a1b0719770150988c493b
     with:
       runner_mode: hosted
       workspace_mode: isolated

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@26cc90926d727b0830748b0c846082952860be0d
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@827acc1d0b614dc87f3a1b0719770150988c493b
     with:
       runner_mode: hosted
       workspace_mode: isolated


### PR DESCRIPTION
## Summary
- pin package workflows to the reachable ci-templates#13 merge commit
- keep the hosted validation lane unchanged

## Validation
- git diff --check
- verified the reusable workflow file resolves at the pinned ref

This is a CI-only follow-up after #68 merged.