### PR TITLE
chore(release): bump scheduling-bridge to 0.4.3

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.2",
+    version = "0.4.3",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.2",
+    version = "0.4.3",
     compatibility_level = 1,
 )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

- bump `@tummycrypt/scheduling-bridge` metadata to `0.4.3`
- keep `package.json`, `MODULE.bazel`, and `BUILD.bazel` aligned

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check:release-metadata`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm check:package` after build output exists
- `npx --yes @bazel/bazelisk build //:pkg --verbose_failures`

Notes: this only prepares release metadata for the current public `main` line. It does not change build authority, Docker/Modal runtime behavior, or runner selection.
