### PR TITLE
docs: refresh bridge agent truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 <!-- markdownlint-disable MD013 -->
 
-This file is the working brief for AI agents and LLMs operating in the `acuity-middleware` repo, which publishes as `@tummycrypt/scheduling-bridge`.
+This file is the working brief for AI agents and LLMs operating in the
+`scheduling-bridge` repo, formerly `acuity-middleware`, which publishes as
+`@tummycrypt/scheduling-bridge`.
 
 ## Repo Role
 
@@ -152,7 +154,9 @@ Current publish flow targets:
 - npm as `@tummycrypt/scheduling-bridge`
 - GitHub Packages as `@jesssullivan/scheduling-bridge`
 
-The repo name is still `acuity-middleware`, but the package name is `scheduling-bridge`. Preserve that distinction.
+The canonical GitHub repo is `Jesssullivan/scheduling-bridge`; historical
+`Jesssullivan/acuity-middleware` URLs may redirect. The npm package name is
+`@tummycrypt/scheduling-bridge`. Preserve that distinction.
 
 Current CI and publish workflows use the shared `js-bazel-package` workflow with:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,10 @@ As of `2026-04-25`, the active structural work here is:
 Operationally relevant truth:
 
 - the current package metadata on `main` is `@tummycrypt/scheduling-bridge`
-  `0.4.2`
-- `0.4.2` depends on `@tummycrypt/scheduling-kit ^0.7.2`
-- pull request `#75` is the pending `0.4.3` metadata bump for custom-header
-  support; do not describe `0.4.3` as published until tag, npm, and GitHub
-  release state are verified
+  `0.4.3`
+- `0.4.3` depends on `@tummycrypt/scheduling-kit ^0.7.2`
+- `0.4.3` package metadata has landed on `main`, but npm, git tag, and GitHub
+  release state must still be verified before describing it as published
 - package metadata, git tags, npm dist-tags, and GitHub releases are separate
   authority surfaces until `#76` is resolved
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,17 +35,25 @@ That makes this repo central to the migration paper and to the operational beta-
 
 ## Current Tracking
 
-As of `2026-04-15`, the active structural work here is:
+As of `2026-04-25`, the active structural work here is:
 
-- `TIN-101` mini sprint: toolchain authority and hermetic package convergence
-- `TIN-104` adopt Bazel-built artifact truth in package publish lanes
-- package dependency convergence with `@tummycrypt/scheduling-kit 0.7.x`
+- `TIN-89` package, Bazel, CI, publish, and dependency truth across shared
+  scheduling packages
+- `TIN-165` bazel-registry generation from standalone package truth
+- release, tag, and npm authority cleanup tracked in GitHub issue `#76`
+- runner reachability and shared-runner adoption, still pending proof before it
+  becomes this public repo's live workflow contract
 
 Operationally relevant truth:
 
-- the current published bridge line is `0.4.1`
-- the current ESM artifact fix bumps metadata to `0.4.2`
-- that branch aligns the bridge dependency on `@tummycrypt/scheduling-kit ^0.7.1`
+- the current package metadata on `main` is `@tummycrypt/scheduling-bridge`
+  `0.4.2`
+- `0.4.2` depends on `@tummycrypt/scheduling-kit ^0.7.2`
+- pull request `#75` is the pending `0.4.3` metadata bump for custom-header
+  support; do not describe `0.4.3` as published until tag, npm, and GitHub
+  release state are verified
+- package metadata, git tags, npm dist-tags, and GitHub releases are separate
+  authority surfaces until `#76` is resolved
 
 ## Deployment Truth
 
@@ -146,19 +154,26 @@ Current publish flow targets:
 
 The repo name is still `acuity-middleware`, but the package name is `scheduling-bridge`. Preserve that distinction.
 
-Today, the publish lane is still pnpm/npm-first. Bazel metadata exists, but it
-is not yet the artifact authority. `TIN-104` exists to change that deliberately
-rather than by implication.
+Current CI and publish workflows use the shared `js-bazel-package` workflow with:
+
+- `runner_mode: hosted`
+- `publish_mode: hosted_exception`
+- `bazel_targets: "//:pkg"`
+- `package_dir: ./bazel-bin/pkg`
+
+That means Bazel-built package output is already part of the CI/publish path.
+Do not regress publish lanes back to ad hoc pnpm packaging without explicitly
+re-opening the package authority decision.
 
 <!-- markdownlint-enable MD013 -->
 
-Current Phase 2 runner truth:
+Current runner truth:
 
-- canonical package CI/publish authority is repo-owned on GloriousFlywheel
-- the current proven runner contract is the plain repo label
-  `["acuity-middleware"]`
-- do not describe richer repo-owned self-hosted label arrays as current truth
-  unless the live workflow contract is explicitly reproven
+- the current public workflow contract is the hosted exception above
+- do not describe self-hosted/shared runner labels as live for this repo until
+  the repo Actions runner API and a green workflow run prove them
+- keep private runner topology, cluster names, and apply details out of this
+  public repo; track those in the private infrastructure repo and Linear
 
 ## Important Files
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,19 @@
 # for running the Acuity wizard automation remotely.
 #
 # Usage:
-#   docker build -t acuity-middleware .
+#   docker build -t scheduling-bridge .
 #   docker run -p 3001:3001 \
 #     -e AUTH_TOKEN=... \
 #     -e ACUITY_BASE_URL=https://MassageIthaca.as.me \
 #     -e ACUITY_BYPASS_COUPON=... \
-#     acuity-middleware
+#     scheduling-bridge
 #
 FROM mcr.microsoft.com/playwright:v1.58.2-noble
 
-LABEL org.opencontainers.image.source="https://github.com/Jesssullivan/acuity-middleware"
+LABEL org.opencontainers.image.source="https://github.com/Jesssullivan/scheduling-bridge"
 LABEL org.opencontainers.image.description="Acuity Scheduling middleware with Playwright browser automation"
 LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.title="acuity-middleware"
+LABEL org.opencontainers.image.title="scheduling-bridge"
 LABEL org.opencontainers.image.vendor="tummycrypt"
 
 # Install Node.js 22 LTS + pnpm

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Backend-agnostic scheduling adapter hub. Currently bridges Acuity Scheduling via Playwright browser automation, with architecture designed to support additional scheduling backends.
 
-> Formerly `acuity-middleware`. The GitHub repo and npm package history retain the old name.
+> Formerly `acuity-middleware`. Historical GitHub URLs may redirect, but the
+> canonical repo is `Jesssullivan/scheduling-bridge`.
 
 ## Architecture
 
@@ -163,7 +164,7 @@ pnpm dev
 
 Current release authority:
 
-- canonical repo: `Jesssullivan/acuity-middleware`
+- canonical repo: `Jesssullivan/scheduling-bridge`
 - npm package: `@tummycrypt/scheduling-bridge`
 - GitHub Packages mirror: `@jesssullivan/scheduling-bridge`
 
@@ -183,13 +184,13 @@ not duplicate bridge runtime ownership or release truth logic.
 
 ## Runner Authority
 
-Canonical GitHub Actions package CI and publish now run on the repo-owned
-GloriousFlywheel self-hosted runner lane with the plain repo label
-`["acuity-middleware"]`.
+Package CI and publish currently use the shared `js-bazel-package` workflow with
+`runner_mode: hosted` and `publish_mode: hosted_exception`.
 
-Treat that label as the active truth surface for package authority. Do not
-describe broader repo-owned self-hosted label arrays as live contract unless
-they are reproven from current runs.
+Treat that hosted exception as the active public workflow truth until a
+self-hosted/shared runner lane is visible to this repository and proven by green
+workflow runs. Keep private runner topology and apply details out of this public
+repo.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- refresh AGENTS tracking from the old 2026-04-15 / 0.4.1 guidance to the current 2026-04-25 package state
- document that main package metadata is now @tummycrypt/scheduling-bridge@0.4.3 with @tummycrypt/scheduling-kit ^0.7.2
- clarify that 0.4.3 metadata landing is separate from npm, git tag, and GitHub release publication proof
- clarify the current public CI/publish contract: hosted exception plus Bazel package output from ./bazel-bin/pkg
- update README and Dockerfile metadata from historical acuity-middleware naming to canonical Jesssullivan/scheduling-bridge, while leaving the existing GHCR image workflow untouched

## Validation
- git diff --check

Docs/metadata only; no runtime/package metadata changes beyond rebasing over #75.
