### PR TITLE
test: guard bridge release provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "license": "MIT",
-  "homepage": "https://github.com/Jesssullivan/acuity-middleware",
+  "homepage": "https://github.com/Jesssullivan/scheduling-bridge",
   "bugs": {
-    "url": "https://github.com/Jesssullivan/acuity-middleware/issues"
+    "url": "https://github.com/Jesssullivan/scheduling-bridge/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Jesssullivan/acuity-middleware.git"
+    "url": "git+https://github.com/Jesssullivan/scheduling-bridge.git"
   },
   "exports": {
     ".": {

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -6,7 +6,17 @@ const read = (relativePath) =>
 const packageJson = JSON.parse(read('../package.json'));
 const moduleBazel = read('../MODULE.bazel');
 const buildBazel = read('../BUILD.bazel');
+const ciWorkflow = read('../.github/workflows/ci.yml');
+const publishWorkflow = read('../.github/workflows/publish.yml');
 const expectedPnpmVersion = packageJson.packageManager?.replace(/^pnpm@/, '');
+const expectedGitHubPackageName = '@jesssullivan/scheduling-bridge';
+const expectedRepositoryUrl = 'git+https://github.com/Jesssullivan/scheduling-bridge.git';
+const expectedHomepage = 'https://github.com/Jesssullivan/scheduling-bridge';
+const expectedBugsUrl = 'https://github.com/Jesssullivan/scheduling-bridge/issues';
+const usesPinnedPackageWorkflow = (workflow) =>
+	/uses:\s*tinyland-inc\/ci-templates\/\.github\/workflows\/js-bazel-package\.yml@[0-9a-f]{40}/.test(
+		workflow,
+	);
 
 const extract = (source, pattern, label) => {
 	const match = source.match(pattern);
@@ -37,6 +47,86 @@ const checks = [
 		actual: extract(moduleBazel, /pnpm_version = "([^"]+)"/, 'pnpm_version'),
 		expected: expectedPnpmVersion,
 	},
+	{
+		label: 'package.json repository',
+		actual: packageJson.repository?.url,
+		expected: expectedRepositoryUrl,
+	},
+	{
+		label: 'package.json homepage',
+		actual: packageJson.homepage,
+		expected: expectedHomepage,
+	},
+	{
+		label: 'package.json bugs URL',
+		actual: packageJson.bugs?.url,
+		expected: expectedBugsUrl,
+	},
+	{
+		label: 'CI reusable workflow pin',
+		actual: String(usesPinnedPackageWorkflow(ciWorkflow)),
+		expected: 'true',
+	},
+	{
+		label: 'CI runner mode',
+		actual: extract(ciWorkflow, /runner_mode:\s*([^\n]+)/, 'CI runner_mode').trim(),
+		expected: 'shared',
+	},
+	{
+		label: 'CI publish mode',
+		actual: extract(ciWorkflow, /publish_mode:\s*([^\n]+)/, 'CI publish_mode').trim(),
+		expected: 'same_runner',
+	},
+	{
+		label: 'CI package artifact path',
+		actual: extract(ciWorkflow, /package_dir:\s*([^\n]+)/, 'CI package_dir').trim(),
+		expected: './bazel-bin/pkg',
+	},
+	{
+		label: 'CI Bazel package target',
+		actual: String(
+			extract(ciWorkflow, /bazel_targets:\s*"([^"]+)"/, 'CI bazel_targets').includes(
+				'//:pkg',
+			),
+		),
+		expected: 'true',
+	},
+	{
+		label: 'CI GitHub Packages name',
+		actual: extract(ciWorkflow, /github_package_name:\s*"([^"]+)"/, 'CI github_package_name'),
+		expected: expectedGitHubPackageName,
+	},
+	{
+		label: 'publish reusable workflow pin',
+		actual: String(usesPinnedPackageWorkflow(publishWorkflow)),
+		expected: 'true',
+	},
+	{
+		label: 'publish packages permission',
+		actual: extract(publishWorkflow, /packages:\s*([^\n]+)/, 'publish packages permission').trim(),
+		expected: 'write',
+	},
+	{
+		label: 'publish package artifact path',
+		actual: extract(publishWorkflow, /package_dir:\s*([^\n]+)/, 'publish package_dir').trim(),
+		expected: './bazel-bin/pkg',
+	},
+	{
+		label: 'publish Bazel package target',
+		actual: String(
+			extract(
+				publishWorkflow,
+				/bazel_targets:\s*"([^"]+)"/,
+				'publish bazel_targets',
+			).includes('//:pkg'),
+		),
+		expected: 'true',
+	},
+	{
+		label: 'publish GitHub Packages name',
+		actual: extract(publishWorkflow, /github_package_name:\s*"([^"]+)"/, 'publish github_package_name'),
+		expected: expectedGitHubPackageName,
+	},
 ];
 
 const failures = checks.filter((check) => check.actual !== check.expected);
@@ -51,5 +141,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-	`release metadata aligned for ${packageJson.name}@${packageJson.version} (pnpm ${expectedPnpmVersion})`,
+	`release metadata aligned for ${packageJson.name}@${packageJson.version} (pnpm ${expectedPnpmVersion}, ${expectedGitHubPackageName})`,
 );


### PR DESCRIPTION
## Summary
- update public package metadata from legacy `acuity-middleware` URLs to canonical `scheduling-bridge` URLs
- extend `check-release-metadata` beyond package/Bazel version checks
- guard canonical repository metadata, pinned shared package workflow usage, shared/same-runner mode, `//:pkg`, `./bazel-bin/pkg`, and GitHub Packages package name

## Validation
- `pnpm check:release-metadata`
- `git diff --check`

Refs: #76, #78, TIN-89, TIN-557