### PR TITLE
ci: inherit Bazel fetch retry template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c9e81f802fe9520260a5389121f8291049e030e1
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@304bd18ba1b46a1b07f58aa36a99253e4f287178
     with:
       runner_mode: shared
       shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@304bd18ba1b46a1b07f58aa36a99253e4f287178
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0d3a9c1fb5198d0670b773e78d9dad6cc5867a98
     with:
       runner_mode: shared
       shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@304bd18ba1b46a1b07f58aa36a99253e4f287178
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0d3a9c1fb5198d0670b773e78d9dad6cc5867a98
     with:
       runner_mode: shared
       shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c9e81f802fe9520260a5389121f8291049e030e1
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@304bd18ba1b46a1b07f58aa36a99253e4f287178
     with:
       runner_mode: shared
       shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}


### PR DESCRIPTION
## Summary

- Bump the reusable `js-bazel-package` workflow pin to `tinyland-inc/ci-templates@0d3a9c1fb5198d0670b773e78d9dad6cc5867a98`.
- Apply the same pin to CI and publish workflows.
- This inherits the Bazel fetch retry hardening from `tinyland-inc/ci-templates#17` plus the `NODE_VERSION` retry-log fix from `tinyland-inc/ci-templates#18`.

## Validation

- `git diff --check`
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/ci.yml .github/workflows/publish.yml`

## Notes

This is intentionally a SHA-only consumer update. No package code or release metadata changed.
