### PR TITLE
chore: harden bridge workflow authority guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@462272a83640c0fddbe2925a87064a7d2575c03a
@@ -27,6 +34,6 @@ jobs:
       bazel_targets: "//:pkg"
       package_dir: ./bazel-bin/pkg
       npm_access: public
+      npm_publish_provenance: true
       github_package_name: "@jesssullivan/scheduling-bridge"
       dry_run: true
-    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,12 @@ on:
 permissions:
   actions: read
   contents: read
+  id-token: write
   packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   package:
@@ -37,6 +42,7 @@ jobs:
       bazel_targets: "//:pkg"
       package_dir: ./bazel-bin/pkg
       npm_access: public
+      npm_publish_provenance: true
       github_package_name: "@jesssullivan/scheduling-bridge"
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
     secrets:

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -59,6 +59,38 @@ lane, but it must consume the same materialized package and launch the same
 `dist/server/handler.js` entrypoint. Provider-specific deployment mechanics
 must not fork the bridge protocol or package artifact.
 
+## Bazel Cache Contract
+
+Local Bazel use defaults to the repo-local disk cache in `.bazelrc`:
+
+```bash
+bazel build //:pkg
+bazel test //:test
+```
+
+Contributor machines can opt into a remote cache by adding a private
+`user.bazelrc`; this repository intentionally keeps private cache topology out
+of public source. CI remote-cache behavior is owned by the shared
+`js-bazel-package` workflow and its runner environment. The public contract is
+that CI must still publish the Bazel package artifact from `./bazel-bin/pkg`
+with local fallback available when the remote cache is unavailable.
+
+## Release Checklist
+
+Before cutting a bridge release, verify these surfaces together:
+
+- npm package: `@tummycrypt/scheduling-bridge`
+- GitHub Packages package: `@jesssullivan/scheduling-bridge`
+- tag and GitHub release for the package version
+- Bazel package artifact from `./bazel-bin/pkg`
+- Docker and Modal runtime images built from the materialized `pkg/` surface
+- `/health` release tuple for the deployed bridge
+
+The shared `js-bazel-package` workflow owns npm provenance when running on
+eligible hosted runners. SBOM or package attestation beyond npm provenance is
+deferred to the shared workflow contract so this repo does not grow a parallel
+release authority.
+
 ## Nix
 
 Use `nix develop` or `direnv allow` to enter the Node 24, pnpm, Bazelisk,

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -136,6 +136,8 @@ const usesPinnedPackageWorkflow = (workflow) =>
   /uses:\s*tinyland-inc\/ci-templates\/\.github\/workflows\/js-bazel-package\.yml@[0-9a-fA-F]{40}/.test(
     workflow,
   );
+const hasWorkflowConcurrency = (workflow) => /\nconcurrency:\n/.test(workflow);
+const doesNotInheritAllSecrets = (workflow) => !/secrets:\s*inherit/.test(workflow);
 
 const checks = [
   {
@@ -234,6 +236,21 @@ const checks = [
     expected: 'true',
   },
   {
+    label: 'CI contents permission',
+    actual: scalar(extract(ciWorkflow, /contents:\s*([^\n]+)/, 'CI contents permission')),
+    expected: 'read',
+  },
+  {
+    label: 'CI concurrency',
+    actual: String(hasWorkflowConcurrency(ciWorkflow)),
+    expected: 'true',
+  },
+  {
+    label: 'CI least privilege secrets',
+    actual: String(doesNotInheritAllSecrets(ciWorkflow)),
+    expected: 'true',
+  },
+  {
     label: 'CI runner mode',
     actual: scalar(extract(ciWorkflow, /runner_mode:\s*([^\n]+)/, 'CI runner_mode')),
     expected: 'shared',
@@ -247,6 +264,13 @@ const checks = [
     label: 'CI package artifact path',
     actual: scalar(extract(ciWorkflow, /package_dir:\s*([^\n]+)/, 'CI package_dir')),
     expected: './bazel-bin/pkg',
+  },
+  {
+    label: 'CI npm provenance intent',
+    actual: scalar(
+      extract(ciWorkflow, /npm_publish_provenance:\s*([^\n]+)/, 'CI npm provenance'),
+    ),
+    expected: 'true',
   },
   {
     label: 'CI Bazel package target',
@@ -268,6 +292,11 @@ const checks = [
     expected: 'true',
   },
   {
+    label: 'publish concurrency',
+    actual: String(hasWorkflowConcurrency(publishWorkflow)),
+    expected: 'true',
+  },
+  {
     label: 'publish packages permission',
     actual: scalar(
       extract(publishWorkflow, /packages:\s*([^\n]+)/, 'publish packages permission'),
@@ -275,9 +304,27 @@ const checks = [
     expected: 'write',
   },
   {
+    label: 'publish provenance permission',
+    actual: scalar(
+      extract(publishWorkflow, /id-token:\s*([^\n]+)/, 'publish id-token permission'),
+    ),
+    expected: 'write',
+  },
+  {
     label: 'publish package artifact path',
     actual: scalar(extract(publishWorkflow, /package_dir:\s*([^\n]+)/, 'publish package_dir')),
     expected: './bazel-bin/pkg',
+  },
+  {
+    label: 'publish npm provenance',
+    actual: scalar(
+      extract(
+        publishWorkflow,
+        /npm_publish_provenance:\s*([^\n]+)/,
+        'publish npm provenance',
+      ),
+    ),
+    expected: 'true',
   },
   {
     label: 'publish Bazel package target',


### PR DESCRIPTION
## Summary
- add explicit workflow permissions and concurrency to CI and publish lanes
- require npm provenance intent and publish id-token permission in release metadata checks
- document the public Bazel cache contract and bridge release checklist without private cache topology

Refs #78.

## Validation
- pnpm check:release-metadata
- git diff --check
- actionlint .github/workflows/ci.yml .github/workflows/publish.yml
- remote CI: package / validate matrix
- remote CI: docker-ghcr build-push