### PR TITLE
fix: use package-scoped npm repo in Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,8 +16,8 @@ Architecture:
 
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//:vitest/package_json.bzl", vitest_bin = "bin")
+load("@tummycrypt_scheduling_bridge_npm//:defs.bzl", "npm_link_all_packages")
+load("@tummycrypt_scheduling_bridge_npm//:vitest/package_json.bzl", vitest_bin = "bin")
 
 # =============================================================================
 # npm link

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,13 +66,13 @@ use_repo(pnpm, "pnpm")
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 
 npm.npm_translate_lock(
-    name = "npm",
+    name = "tummycrypt_scheduling_bridge_npm",
     npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
     data = ["//:package.json"],
 )
 
-use_repo(npm, "npm")
+use_repo(npm, "tummycrypt_scheduling_bridge_npm")
 
 # =============================================================================
 # TypeScript toolchain


### PR DESCRIPTION
## Summary
- Give the Aspect npm extension a package-scoped repository name, `tummycrypt_scheduling_bridge_npm`.
- Update Bazel loads to consume that repository instead of the generic `@npm` alias.

## Why
Standalone Bzlmod modules that all export an `npm` repo collide when composed in a consumer graph. This keeps scheduling-bridge composable with tinyvectors, tinyland-auth-redis, tinyland-auth-pg, and scheduling-kit while preserving the existing package artifact target.

## Validation
- `bazel build //:pkg //:typecheck //:test --verbose_failures`
- `bazel test //:test --verbose_failures`
- `git diff --check`
- Cross-module `bazel mod graph` smoke with local overrides for scheduling-bridge, scheduling-kit, tinyvectors, tinyland-auth-redis, and tinyland-auth-pg

Refs: TIN-678, TIN-679
