### PR TITLE
fix: warm catalog during readiness cold starts

### DIFF
--- a/src/server/__tests__/handler.test.ts
+++ b/src/server/__tests__/handler.test.ts
@@ -135,6 +135,54 @@ describe('runReadyChecks', () => {
 		expect(checks.catalog).toEqual({ status: 'empty' });
 	});
 
+	it('warms catalog when Redis and browser are ok but L1/L2 are empty', async () => {
+		let warmCalls = 0;
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			catalogL1Count: () => 0,
+			catalogL2Exists: async () => 0,
+			catalogWarm: async () => {
+				warmCalls += 1;
+				return 10;
+			},
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(warmCalls).toBe(1);
+		expect(checks.catalog).toEqual({ status: 'ok', size: 10, source: 'warmup' });
+	});
+
+	it('does not warm catalog when Redis is unreachable', async () => {
+		let warmCalls = 0;
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			redisPing: async () => { throw new Error('ECONNREFUSED'); },
+			catalogL1Count: () => 0,
+			catalogL2Exists: async () => 0,
+			catalogWarm: async () => {
+				warmCalls += 1;
+				return 10;
+			},
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(warmCalls).toBe(0);
+		expect(checks.redis).toBe('unreachable');
+		expect(checks.catalog).toEqual({ status: 'empty' });
+	});
+
+	it('returns catalog error when cold-start warmup fails', async () => {
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			catalogL1Count: () => 0,
+			catalogL2Exists: async () => 0,
+			catalogWarm: async () => { throw new Error('acuity unavailable'); },
+		};
+		const checks = await runReadyChecks(deps);
+
+		expect(checks.catalog).toEqual({ status: 'error', error: 'acuity unavailable' });
+	});
+
 	it('returns catalog ok with source l2 when L1 is empty but L2 has data', async () => {
 		const deps: ReadyDeps = {
 			...happyDeps(),
@@ -290,6 +338,23 @@ describe('handleReady', () => {
 		expect(mock.status).toBe(503);
 		const body = mock.body() as { status: string; checks: ReadyChecks };
 		expect(body.checks.catalog).toEqual({ status: 'empty' });
+	});
+
+	it('returns 200 after catalog cold-start warmup succeeds', async () => {
+		const mock = makeRes();
+		const deps: ReadyDeps = {
+			...happyDeps(),
+			catalogL1Count: () => 0,
+			catalogL2Exists: async () => 0,
+			catalogWarm: async () => 10,
+		};
+
+		await handleReady(mock.raw, deps);
+
+		expect(mock.status).toBe(200);
+		const body = mock.body() as { status: string; checks: ReadyChecks };
+		expect(body.status).toBe('ready');
+		expect(body.checks.catalog).toEqual({ status: 'ok', size: 10, source: 'warmup' });
 	});
 
 	it('returns 200 with catalog.source: "l2" when L1 empty but L2 has data', async () => {

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -362,10 +362,11 @@ const CATALOG_REDIS_KEY = `acuity:services:v1:${ACUITY_BASE_URL}`;
 /**
  * Real-liveness readiness handler wired to the module-level singletons.
  *
- * Checks (in parallel, under ~3 s combined budget):
+ * Checks:
  *  1. Redis ping
  *  2. Browser pool `isConnected()` via BrowserProcess Effect service
  *  3. Catalog has data in L1 (getCachedCount) or L2 (Redis EXISTS)
+ *  4. If Redis + browser pass but catalog is cold, one bounded catalog warmup
  *
  * Returns HTTP 200 when all pass; 503 otherwise.
  */
@@ -380,6 +381,7 @@ const handleReady = (res: ServerResponse) =>
 		catalogL2Exists: redisClient
 			? () => redisClient!.exists(CATALOG_REDIS_KEY)
 			: null,
+		catalogWarm: async () => (await serviceCatalog.getServices()).length,
 	});
 
 const handleHealth = (_req: IncomingMessage, res: ServerResponse) => {

--- a/src/server/ready.ts
+++ b/src/server/ready.ts
@@ -15,7 +15,7 @@ export type RedisStatus = 'ok' | 'unreachable';
 export type BrowserStatus = 'ok' | 'unavailable' | 'timeout';
 
 export type CatalogResult =
-	| { status: 'ok'; size: number; source: 'l1' | 'l2' }
+	| { status: 'ok'; size: number; source: 'l1' | 'l2' | 'warmup' }
 	| { status: 'empty' }
 	| { status: 'error'; error: string };
 
@@ -34,8 +34,12 @@ export interface ReadyDeps {
 	catalogL1Count: () => number;
 	/** Check if the catalog key exists in L2 Redis (1 = yes, 0/null = no/error). */
 	catalogL2Exists: (() => Promise<number | null>) | null;
+	/** Populate the catalog when readiness sees a cold empty cache. Returns the warmed service count. */
+	catalogWarm?: () => Promise<number>;
 	/** Timeout in ms for the browser probe (default: 2000). */
 	browserTimeoutMs?: number;
+	/** Timeout in ms for the optional catalog warmup (default: 3000). */
+	catalogWarmTimeoutMs?: number;
 }
 
 // =============================================================================
@@ -43,6 +47,7 @@ export interface ReadyDeps {
 // =============================================================================
 
 const BROWSER_DEFAULT_TIMEOUT_MS = 2000;
+const CATALOG_WARM_DEFAULT_TIMEOUT_MS = 3000;
 
 const probeRedis = async (redisPing: (() => Promise<string>) | null): Promise<RedisStatus> => {
 	if (!redisPing) return 'ok';
@@ -94,6 +99,49 @@ const probeCatalog = async (
 	}
 };
 
+const withTimeout = async <A>(
+	fn: () => Promise<A>,
+	timeoutMs: number,
+	onTimeout: () => A,
+): Promise<A> => {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			fn(),
+			new Promise<A>((resolve) => {
+				timeout = setTimeout(() => resolve(onTimeout()), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+};
+
+const probeCatalogWarm = async (
+	catalogWarm: () => Promise<number>,
+	timeoutMs: number,
+): Promise<CatalogResult> => {
+	try {
+		const warmedCount = await withTimeout(
+			catalogWarm,
+			timeoutMs,
+			() => Number.NaN,
+		);
+
+		if (!Number.isFinite(warmedCount)) {
+			return { status: 'error', error: 'catalog warmup timed out' };
+		}
+
+		if (warmedCount > 0) {
+			return { status: 'ok', size: warmedCount, source: 'warmup' };
+		}
+
+		return { status: 'empty' };
+	} catch (e) {
+		return { status: 'error', error: e instanceof Error ? e.message : String(e) };
+	}
+};
+
 // =============================================================================
 // READINESS CHECK
 // =============================================================================
@@ -104,12 +152,27 @@ const probeCatalog = async (
  */
 export const runReadyChecks = async (deps: ReadyDeps): Promise<ReadyChecks> => {
 	const timeoutMs = deps.browserTimeoutMs ?? BROWSER_DEFAULT_TIMEOUT_MS;
+	const catalogWarmTimeoutMs =
+		deps.catalogWarmTimeoutMs ?? CATALOG_WARM_DEFAULT_TIMEOUT_MS;
 
 	const [redis, browser, catalog] = await Promise.all([
 		probeRedis(deps.redisPing),
 		probeBrowser(deps.browserConnected, timeoutMs),
 		probeCatalog(deps.catalogL1Count, deps.catalogL2Exists),
 	]);
+
+	if (
+		redis === 'ok' &&
+		browser === 'ok' &&
+		catalog.status === 'empty' &&
+		deps.catalogWarm
+	) {
+		return {
+			redis,
+			browser,
+			catalog: await probeCatalogWarm(deps.catalogWarm, catalogWarmTimeoutMs),
+		};
+	}
 
 	return { redis, browser, catalog };
 };


### PR DESCRIPTION
## Summary

Fixes the K8s cold-start readiness gap where `/ready` could remain 503 with `catalog=empty` even though Redis and the browser pool were healthy.

The readiness check now performs one bounded catalog warmup when Redis and browser probes pass but both L1 and L2 catalog caches are empty. If warmup returns services, `/ready` reports `catalog.source = "warmup"`; if warmup fails or times out, readiness stays failed with an explicit catalog error.

Closes #88.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:package`
- `pnpm check:artifact-authority`
- `pnpm check:release-metadata`
- `git diff --check`

Note: local validation emitted the expected Node engine warning because this host is on Node 22.20.0 while the package declares Node >=24 <25; the Bazel package path uses Node 24.13.0.
