### PR TITLE
feat(bazel): wire scheduling-bridge into tinyland building-block ecosystem

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,8 @@
 # =============================================================================
 
 common --enable_bzlmod
+common --registry=https://raw.githubusercontent.com/tinyland-inc/bazel-registry/main
+common --registry=https://bcr.bazel.build
 
 # Build performance
 build --jobs=auto

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Operationally relevant truth:
 
 - the pending package metadata on this branch is `@tummycrypt/scheduling-bridge`
   `0.4.4`
-- `0.4.4` depends on `@tummycrypt/scheduling-kit ^0.7.2`
+- `0.4.4` depends on `@tummycrypt/scheduling-kit ^0.7.4`
 - as of `2026-04-25`, npm `latest`, git tag `v0.4.3`, and the GitHub release
   all point at `0.4.3`; deployed bridge runtime tuple remains a separate
   verification surface

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,7 +28,7 @@ module(
 # Core Bazel dependencies
 # =============================================================================
 
-bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
@@ -40,6 +40,16 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3")
 bazel_dep(name = "aspect_rules_js", version = "2.9.1")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.4")
 bazel_dep(name = "aspect_rules_swc", version = "2.6.1")
+
+# =============================================================================
+# Inter-module dependencies (tinyland building blocks + scheduling-kit)
+# =============================================================================
+
+# Primary dependency: scheduling-kit (peer; bridge orchestrates over kit's adapters).
+bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.2")
+
+# Auth surface (payment capability types come through tinyland-auth).
+bazel_dep(name = "tummycrypt_tinyland_auth", version = "0.3.0")
 
 # =============================================================================
 # Node.js toolchain

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,7 +46,7 @@ bazel_dep(name = "aspect_rules_swc", version = "2.6.1")
 # =============================================================================
 
 # Primary dependency: scheduling-kit (peer; bridge orchestrates over kit's adapters).
-bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.2")
+bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.0")  # bump to 0.7.2 once registered
 
 # Auth surface (payment capability types come through tinyland-auth).
 bazel_dep(name = "tummycrypt_tinyland_auth", version = "0.3.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,7 +46,7 @@ bazel_dep(name = "aspect_rules_swc", version = "2.6.1")
 # =============================================================================
 
 # Primary dependency: scheduling-kit (peer; bridge orchestrates over kit's adapters).
-bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.0")  # bump to 0.7.2 once registered
+bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.4")
 
 # Auth surface (payment capability types come through tinyland-auth).
 bazel_dep(name = "tummycrypt_tinyland_auth", version = "0.3.0")

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "paper:dev": "node docs/paper/watch.mjs"
   },
   "dependencies": {
-    "@tummycrypt/scheduling-kit": "^0.7.2",
+    "@tummycrypt/scheduling-kit": "^0.7.4",
     "effect": "^3.19.14",
     "ioredis": "^5",
     "playwright-core": "1.58.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@tummycrypt/scheduling-kit':
-        specifier: ^0.7.2
-        version: 0.7.2(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
+        specifier: ^0.7.4
+        version: 0.7.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
       effect:
         specifier: ^3.19.14
         version: 3.21.0
@@ -373,8 +373,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@tummycrypt/scheduling-kit@0.7.2':
-    resolution: {integrity: sha512-AO2kju5cvM7jiBGM2MMw0YAOZxh3qxh2VcRN3q1TSdo6lt9ne6BtbN1ynf+WybavkIx6D8kQ/+c3LPCmlBKY8w==}
+  '@tummycrypt/scheduling-kit@0.7.4':
+    resolution: {integrity: sha512-S0s0uAiZHyclY1S64Hw9EAuHDy47XyjDp+v0hHm8dia7w/NPhPwihMt/+w+vlN9YtiVRFk3AqY/vIrqi1GfzEQ==}
     engines: {node: '>=20 <25'}
     peerDependencies:
       '@skeletonlabs/skeleton': ^4.0.0
@@ -386,10 +386,10 @@ packages:
       '@skeletonlabs/skeleton-svelte':
         optional: true
 
-  '@tummycrypt/tinyland-auth-pg@0.1.1':
-    resolution: {integrity: sha512-ASAeuCRKptgt6c0piTq32FahJgErwo1iQLwcGN3Pzh1EDZh9IB8BEaXHpg5KwaGcM5klrjdgW/hH47agmcC5FQ==}
+  '@tummycrypt/tinyland-auth-pg@0.2.4':
+    resolution: {integrity: sha512-Z4n8R4iD7+CWqmwEDDu919jIWwiW66Oq/48YSrdKQ+rqO61+ZiPfnEA7G++aMaVU3G96DkK46+KNtbOY4ZffKw==}
     peerDependencies:
-      '@tummycrypt/tinyland-auth': ^0.2.0
+      '@tummycrypt/tinyland-auth': ^0.2.0 || ^0.3.0
 
   '@tummycrypt/tinyland-auth@0.2.0':
     resolution: {integrity: sha512-XL3UfRyBNeuILZw56r5iw+WtUAZ0l7f5zjbDsHGOeR5O0D0rpRZjUMSTqNoHWYjU4NkKl07YKmDphXsTwC6dLA==}
@@ -856,6 +856,12 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
@@ -864,12 +870,33 @@ packages:
     resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
     engines: {node: '>=4'}
 
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
   pg-protocol@1.13.0:
     resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
 
   pg-types@4.1.0:
     resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
     engines: {node: '>=10'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -891,17 +918,33 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
   postgres-array@3.0.4:
     resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
     engines: {node: '>=12'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
 
   postgres-bytea@3.0.0:
     resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
     engines: {node: '>= 6'}
 
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
   postgres-date@2.1.0:
     resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
     engines: {node: '>=12'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   postgres-interval@3.0.0:
     resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
@@ -972,6 +1015,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
@@ -1132,6 +1179,10 @@ packages:
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -1367,10 +1418,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tummycrypt/scheduling-kit@0.7.2(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
+  '@tummycrypt/scheduling-kit@0.7.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
     dependencies:
-      '@tummycrypt/tinyland-auth-pg': 0.1.1(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)
+      '@tummycrypt/tinyland-auth-pg': 0.2.4(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(pg@8.20.0)
       effect: 3.21.0
       svelte: 5.55.1(@typescript-eslint/types@8.58.0)
       zod: 4.3.6
@@ -1399,16 +1450,18 @@ snapshots:
       - kysely
       - mysql2
       - pg
+      - pg-native
       - postgres
       - prisma
       - sql.js
       - sqlite3
 
-  '@tummycrypt/tinyland-auth-pg@0.1.1(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)':
+  '@tummycrypt/tinyland-auth-pg@0.2.4(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)':
     dependencies:
       '@neondatabase/serverless': 0.10.4
       '@tummycrypt/tinyland-auth': 0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0))
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(pg@8.20.0)
+      pg: 8.20.0
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -1431,7 +1484,7 @@ snapshots:
       - knex
       - kysely
       - mysql2
-      - pg
+      - pg-native
       - postgres
       - prisma
       - sql.js
@@ -1574,11 +1627,12 @@ snapshots:
 
   dijkstrajs@1.0.3: {}
 
-  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6):
+  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(pg@8.20.0):
     optionalDependencies:
       '@neondatabase/serverless': 0.10.4
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.11.6
+      pg: 8.20.0
 
   effect@3.21.0:
     dependencies:
@@ -1791,11 +1845,28 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
   pg-int8@1.0.1: {}
 
   pg-numeric@1.0.2: {}
 
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
   pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
 
   pg-types@4.1.0:
     dependencies:
@@ -1806,6 +1877,20 @@ snapshots:
       postgres-date: 2.1.0
       postgres-interval: 3.0.0
       postgres-range: 1.1.4
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -1821,13 +1906,23 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
   postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.1: {}
 
   postgres-bytea@3.0.0:
     dependencies:
       obuf: 1.1.2
 
+  postgres-date@1.0.7: {}
+
   postgres-date@2.1.0: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postgres-interval@3.0.0: {}
 
@@ -1902,6 +1997,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   sprintf-js@1.1.3: {}
 
@@ -2036,6 +2133,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  xtend@4.0.2: {}
 
   y18n@4.0.3: {}
 


### PR DESCRIPTION
## Summary

Part of TIN-678. Adds the missing inter-module `bazel_dep` edges:

- `bazel_dep(tummycrypt_scheduling_kit@0.7.2)` — primary dep, bridge orchestrates over kit's adapters
- `bazel_dep(tummycrypt_tinyland_auth@0.3.0)` — payment capability types come through tinyland-auth
- `.bazelrc`: add tinyland registry

## Blocked on

- `tummycrypt_scheduling_kit@0.7.2` registry entry (needs `Jesssullivan/scheduling-kit#85` to land first)
- `tummycrypt_tinyland_auth@0.3.0` is already registered

After both registrations, this PR will be unblocked.