### PR TITLE
fix: support Node 22 consumers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
       publish_mode: same_runner
-      node_versions: '["24"]'
+      node_versions: '["22","24"]'
       publish_node_version: "24"
       pnpm_version: "9.15.9"
       metadata_check_command: pnpm check:release-metadata
       typecheck_command: pnpm typecheck
-      unit_test_command: pnpm test
+      unit_test_command: pnpm test:host && pnpm test
       build_command: node scripts/check-artifact-authority.mjs
       package_check_command: pnpm check:package
       bazel_targets: "//:pkg"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,10 +49,10 @@ As of `2026-04-25`, the active structural work here is:
 Operationally relevant truth:
 
 - the pending package metadata on this branch is `@tummycrypt/scheduling-bridge`
-  `0.4.4`
-- `0.4.4` depends on `@tummycrypt/scheduling-kit ^0.7.4`
-- as of `2026-04-25`, npm `latest`, git tag `v0.4.3`, and the GitHub release
-  all point at `0.4.3`; deployed bridge runtime tuple remains a separate
+  `0.4.5`
+- `0.4.5` depends on `@tummycrypt/scheduling-kit ^0.7.4`
+- as of `2026-04-29`, npm `latest`, git tag `v0.4.4`, and the GitHub release
+  all point at `0.4.4`; deployed bridge runtime tuple remains a separate
   verification surface
 - package metadata, git tags, npm dist-tags, and GitHub releases are separate
   authority surfaces until `#76` is resolved

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.4",
+    version = "0.4.5",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.4",
+    version = "0.4.5",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ The bridge emits NDJSON logs to stdout/stderr for runtime analysis.
 
 ## Deployment
 
+## Node Runtime Policy
+
+The npm package supports active downstream consumer runtimes on Node 22 and
+Node 24. CI validates the host test suite on both majors.
+
+The bridge-owned Bazel toolchain, Nix dev shell, Docker image, Modal image, and
+publish workflow intentionally stay on Node 24. Downstream apps should not infer
+that they must also run Node 24 unless they deploy the bridge runtime itself.
+
 ### Standalone Node.js
 
 ```bash

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -25,6 +25,30 @@ pnpm docs:generate
 `pnpm typecheck`, `pnpm test`, `pnpm build`, and `pnpm check:package` route
 through Bazel so local and CI paths exercise the same package graph.
 
+`pnpm test:host` intentionally bypasses Bazel and runs Vitest under the host
+Node selected by CI. Keep it in the package workflow when widening consumer
+engine support so the matrix proves the published package can execute on every
+advertised downstream major.
+
+For sandboxed local validation where Bazel cannot write its default output root,
+set `BAZEL_OUTPUT_USER_ROOT=/tmp/<repo>-bazel-out`.
+
+## Node Policy
+
+The npm package advertises Node 22 and Node 24 consumer support. That is the
+downstream contract for apps such as MassageIthaca.
+
+Bridge-owned runtime and artifact authority remains Node 24:
+
+- Bazel Node toolchain
+- Nix development shell
+- Docker runtime image
+- Modal runtime image
+- npm/GitHub Packages publish runner
+
+Do not collapse these two concerns. Consumer support is broader than the bridge
+runtime image, and package CI must prove both supported consumer majors.
+
 ## Nix
 
 Use `nix develop` or `direnv allow` to enter the Node 24, pnpm, Bazelisk,

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.4.4`
-- Bazel module version: `0.4.4`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.4`
+- package version: `0.4.5`
+- Bazel module version: `0.4.5`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.5`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -22,8 +22,8 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 - flake Node package major: `24`
 - pnpm toolchain: `9.15.9`
 - package manager: `pnpm@9.15.9`
-- engines: `>=24 <25`
-- CI node matrix: `24`
+- engines: `^22.0.0 || ^24.0.0`
+- CI node matrix: `22, 24`
 - CI publish node: `24`
 
 ## Release Surface
@@ -34,7 +34,7 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 - local build command: `node scripts/build-derived-artifacts.mjs`
 - local derived package directory: `pkg/`
 - CI typecheck command: `pnpm typecheck`
-- CI unit test command: `pnpm test`
+- CI unit test command: `pnpm test:host && pnpm test`
 - CI build command: `node scripts/check-artifact-authority.mjs`
 - runtime start command: `node dist/server/handler.js`
 

--- a/llms.txt
+++ b/llms.txt
@@ -18,8 +18,8 @@ Toolchains:
 - flake Node major: `24`
 - pnpm toolchain: `9.15.9`
 - package manager: `pnpm@9.15.9`
-- engines: `>=24 <25`
-- CI node matrix: `24`
+- engines: `^22.0.0 || ^24.0.0`
+- CI node matrix: `22, 24`
 - CI publish node: `24`
 
 Protocol:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepublishOnly": "pnpm check:release-metadata && pnpm check:artifact-authority && pnpm build && pnpm check:package",
     "start": "node dist/server/handler.js",
     "dev": "tsx src/server/handler.ts",
+    "test:host": "vitest run --reporter=verbose --config vitest.config.ts",
     "test": "node scripts/run-bazel-target.mjs test //:test",
     "typecheck": "node scripts/run-bazel-target.mjs build //:typecheck",
     "docs:generate": "node scripts/generate-doc-surfaces.mjs",
@@ -56,7 +57,7 @@
     "prom-client": "^15"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0",
+    "@types/node": "^22.0.0",
     "ioredis-mock": "^8.13.1",
     "publint": "^0.3.18",
     "tsx": "^4.0.0",
@@ -75,6 +76,6 @@
     }
   },
   "engines": {
-    "node": ">=24 <25"
+    "node": "^22.0.0 || ^24.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         version: 15.1.3
     devDependencies:
       '@types/node':
-        specifier: ^24.0.0
-        version: 24.12.2
+        specifier: ^22.0.0
+        version: 22.19.17
       ioredis-mock:
         specifier: ^8.13.1
         version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.10.1))(ioredis@5.10.1)
@@ -44,7 +44,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.0
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 
@@ -420,8 +420,8 @@ packages:
     peerDependencies:
       ioredis: '>=5'
 
-  '@types/node@24.12.2':
-    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/pg@8.11.6':
     resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
@@ -1087,8 +1087,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   vite@8.0.3:
     resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
@@ -1517,13 +1517,13 @@ snapshots:
     dependencies:
       ioredis: 5.10.1
 
-  '@types/node@24.12.2':
+  '@types/node@22.19.17':
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 6.21.0
 
   '@types/pg@8.11.6':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 22.19.17
       pg-protocol: 1.13.0
       pg-types: 4.1.0
 
@@ -1541,13 +1541,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -2075,9 +2075,9 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.16.0: {}
+  undici-types@6.21.0: {}
 
-  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0):
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2085,7 +2085,7 @@ snapshots:
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 22.19.17
       esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.21.0
@@ -2093,10 +2093,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -2113,11 +2113,11 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 24.12.2
+      '@types/node': 22.19.17
     transitivePeerDependencies:
       - msw
 

--- a/scripts/bazel-helpers.mjs
+++ b/scripts/bazel-helpers.mjs
@@ -54,7 +54,9 @@ export const resolveBazelCommand = () => {
 
 export const runBazel = (...args) => {
   const bazel = resolveBazelCommand();
-  const result = run(bazel.command, [...bazel.prefixArgs, ...args]);
+  const outputUserRoot = process.env.BAZEL_OUTPUT_USER_ROOT;
+  const startupArgs = outputUserRoot ? [`--output_user_root=${outputUserRoot}`] : [];
+  const result = run(bazel.command, [...bazel.prefixArgs, ...startupArgs, ...args]);
 
   if (result.error) {
     fail(result.error.message);

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -47,23 +47,42 @@ const scalar = (value) =>
     .trim();
 
 const parseSupportedNodeMajors = (engineRange) => {
-  const match = engineRange.match(/^>=(\d+)\s+<(\d+)$/);
-  if (!match?.[1] || !match?.[2]) {
+  const majors = new Set();
+
+  for (const rawClause of engineRange.split('||')) {
+    const clause = rawClause.trim();
+    const caret = clause.match(/^\^(\d+)\.0\.0$/);
+    if (caret?.[1]) {
+      majors.add(caret[1]);
+      continue;
+    }
+
+    const bounded = clause.match(/^>=(\d+)\s+<(\d+)$/);
+    if (bounded?.[1] && bounded?.[2]) {
+      const lower = Number(bounded[1]);
+      const upper = Number(bounded[2]);
+      for (let major = lower; major < upper; major += 1) {
+        majors.add(String(major));
+      }
+      continue;
+    }
+
+    throw new Error(`Unsupported node engines clause "${clause}" in "${engineRange}"`);
+  }
+
+  const sorted = Array.from(majors).sort((a, b) => Number(a) - Number(b));
+  if (sorted.length === 0) {
     throw new Error(`Unsupported node engines range "${engineRange}"`);
   }
 
-  const lower = Number(match[1]);
-  const upper = Number(match[2]);
-
   return {
-    lower,
-    upper,
-    majors: Array.from({ length: upper - lower }, (_, index) => String(lower + index)),
+    lower: Number(sorted[0]),
+    majors: sorted,
   };
 };
 
 const supportedNodeMajors = parseSupportedNodeMajors(packageJson.engines.node);
-const canonicalNodeMajor = String(supportedNodeMajors.lower);
+const minimumConsumerNodeMajor = String(supportedNodeMajors.lower);
 const nodeTypesMajor = parseMajor(
   packageJson.devDependencies['@types/node'],
   '@types/node version',
@@ -112,6 +131,7 @@ const modalNodeMajor = parseMajor(
   extract(modalApp, /setup_(\d+)\.x/, 'Modal NodeSource major'),
   'Modal NodeSource major',
 );
+const nodeMajorSupported = (major) => supportedNodeMajors.majors.includes(String(major));
 const usesPinnedPackageWorkflow = (workflow) =>
   /uses:\s*tinyland-inc\/ci-templates\/\.github\/workflows\/js-bazel-package\.yml@[0-9a-fA-F]{40}/.test(
     workflow,
@@ -154,29 +174,29 @@ const checks = [
     expected: expectedBugsUrl,
   },
   {
-    label: 'MODULE.bazel Node major',
-    actual: String(bazelNodeMajor),
-    expected: canonicalNodeMajor,
+    label: 'MODULE.bazel Node major is supported',
+    actual: String(nodeMajorSupported(bazelNodeMajor)),
+    expected: 'true',
   },
   {
-    label: 'flake Node major',
-    actual: String(flakeNodeMajor),
-    expected: canonicalNodeMajor,
+    label: 'flake Node major is supported',
+    actual: String(nodeMajorSupported(flakeNodeMajor)),
+    expected: 'true',
   },
   {
-    label: 'Docker Node major',
-    actual: String(dockerNodeMajor),
-    expected: canonicalNodeMajor,
+    label: 'Docker Node major is supported',
+    actual: String(nodeMajorSupported(dockerNodeMajor)),
+    expected: 'true',
   },
   {
-    label: 'Modal Node major',
-    actual: String(modalNodeMajor),
-    expected: canonicalNodeMajor,
+    label: 'Modal Node major is supported',
+    actual: String(nodeMajorSupported(modalNodeMajor)),
+    expected: 'true',
   },
   {
-    label: '@types/node major',
+    label: '@types/node major matches minimum consumer Node',
     actual: String(nodeTypesMajor),
-    expected: canonicalNodeMajor,
+    expected: minimumConsumerNodeMajor,
   },
   {
     label: 'CI node versions',
@@ -184,19 +204,19 @@ const checks = [
     expected: JSON.stringify(supportedNodeMajors.majors),
   },
   {
-    label: 'publish workflow node versions',
-    actual: JSON.stringify(publishNodeVersions),
-    expected: JSON.stringify(supportedNodeMajors.majors),
+    label: 'publish workflow node versions are supported',
+    actual: String(publishNodeVersions.every(nodeMajorSupported)),
+    expected: 'true',
   },
   {
-    label: 'CI publish node version',
-    actual: ciPublishNodeVersion,
-    expected: canonicalNodeMajor,
+    label: 'CI publish node version is supported',
+    actual: String(nodeMajorSupported(ciPublishNodeVersion)),
+    expected: 'true',
   },
   {
-    label: 'publish workflow node version',
-    actual: publishWorkflowNodeVersion,
-    expected: canonicalNodeMajor,
+    label: 'publish workflow node version is supported',
+    actual: String(nodeMajorSupported(publishWorkflowNodeVersion)),
+    expected: 'true',
   },
   {
     label: 'CI build command',


### PR DESCRIPTION
## Summary

- widen the public npm engine contract from Node 24-only to Node 22 or Node 24
- keep bridge-owned Bazel, Nix, Docker, Modal, and publish runtime authority on Node 24
- add `test:host` and run it in CI on both Node 22 and Node 24 before the Bazel-backed test path
- make the release metadata guard understand multi-major consumer support
- let local/sandboxed validation set `BAZEL_OUTPUT_USER_ROOT` without changing CI defaults

## Why

`@tummycrypt/scheduling-bridge@0.4.4` published with `engines.node = >=24 <25`.
That is coherent for the bridge runtime image, but too narrow for reusable app
consumers such as MassageIthaca Vercel, which still runs Node 22. The code path
does not require Node 24-only APIs, so the package contract should describe the
consumer runtime surface separately from the bridge-owned runtime images.

Closes #91.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check:release-metadata`
- `pnpm test:host`
- `env NPM_CONFIG_CACHE=/tmp/scheduling-bridge-npm-cache npx --yes @bazel/bazelisk --output_user_root=/tmp/scheduling-bridge-bazel-out build //:typecheck`
- `env NPM_CONFIG_CACHE=/tmp/scheduling-bridge-npm-cache npx --yes @bazel/bazelisk --output_user_root=/tmp/scheduling-bridge-bazel-out test //:test`
- `env NPM_CONFIG_CACHE=/tmp/scheduling-bridge-npm-cache npx --yes @bazel/bazelisk --output_user_root=/tmp/scheduling-bridge-bazel-out build //:pkg`
- `node scripts/check-artifact-authority.mjs`
- `env NPM_CONFIG_CACHE=/tmp/scheduling-bridge-npm-cache BAZEL_OUTPUT_USER_ROOT=/tmp/scheduling-bridge-bazel-out pnpm check:package`
- `pnpm docs:check`
- `git diff --check`

Local Bazel emitted expected sandbox-only warnings while trying to write cache
entries under `/Users/jess/.cache/bazel-scheduling-bridge`, but all requested
targets completed successfully.
