### PR TITLE
fix(runtime): restore Node 22 package support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
       publish_mode: same_runner
-      node_versions: '["24"]'
-      publish_node_version: "24"
+      node_versions: '["22","24"]'
+      publish_node_version: "22"
       pnpm_version: "9.15.9"
       metadata_check_command: pnpm check:release-metadata
       typecheck_command: pnpm typecheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,8 @@ jobs:
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
       publish_mode: same_runner
-      node_versions: '["24"]'
-      publish_node_version: "24"
+      node_versions: '["22","24"]'
+      publish_node_version: "22"
       pnpm_version: "9.15.9"
       metadata_check_command: pnpm check:release-metadata
       typecheck_command: pnpm typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,10 @@ As of `2026-04-25`, the active structural work here is:
 Operationally relevant truth:
 
 - the pending package metadata on this branch is `@tummycrypt/scheduling-bridge`
-  `0.4.4`
-- `0.4.4` depends on `@tummycrypt/scheduling-kit ^0.7.4`
+  `0.4.5`
+- `0.4.5` depends on `@tummycrypt/scheduling-kit ^0.7.4`
+- the public npm package supports Node 22 through Node 24; Modal and Docker
+  deployment images intentionally remain on Node 24
 - as of `2026-04-25`, npm `latest`, git tag `v0.4.3`, and the GitHub release
   all point at `0.4.3`; deployed bridge runtime tuple remains a separate
   verification surface

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.4",
+    version = "0.4.5",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.4",
+    version = "0.4.5",
     compatibility_level = 1,
 )
 
@@ -56,7 +56,7 @@ bazel_dep(name = "tummycrypt_tinyland_auth", version = "0.3.0")
 # =============================================================================
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-node.toolchain(node_version = "24.13.0")
+node.toolchain(node_version = "22.13.1")
 
 # =============================================================================
 # pnpm toolchain

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ The bridge emits NDJSON logs to stdout/stderr for runtime analysis.
 
 ### Standalone Node.js
 
+The npm package supports Node.js 22 through Node.js 24. Modal and Docker
+deployment images intentionally run Node.js 24; downstream app consumers on
+Node.js 22 should consume the published package rather than infer runtime
+policy from the Modal/Docker images.
+
 ```bash
 pnpm install
 pnpm dev           # Development with tsx against src/server/handler.ts

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -27,5 +27,7 @@ through Bazel so local and CI paths exercise the same package graph.
 
 ## Nix
 
-Use `nix develop` or `direnv allow` to enter the Node 24, pnpm, Bazelisk,
-Playwright, MkDocs, and paper-tooling shell.
+Use `nix develop` or `direnv allow` to enter the Node 22 package-validation
+shell with pnpm, Bazelisk, Playwright, MkDocs, and paper tooling. Modal and
+Docker deployment images remain on Node 24, so release checks validate the
+package on Node 22 and Node 24 while keeping runtime image policy explicit.

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,21 +10,21 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.4.4`
-- Bazel module version: `0.4.4`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.4`
+- package version: `0.4.5`
+- Bazel module version: `0.4.5`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.5`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains
 
 - Bazelisk version file: `8.1.1`
-- Bazel Node toolchain: `24.13.0`
-- flake Node package major: `24`
+- Bazel Node toolchain: `22.13.1`
+- flake Node package major: `22`
 - pnpm toolchain: `9.15.9`
 - package manager: `pnpm@9.15.9`
-- engines: `>=24 <25`
-- CI node matrix: `24`
-- CI publish node: `24`
+- engines: `>=22 <25`
+- CI node matrix: `22, 24`
+- CI publish node: `22`
 
 ## Release Surface
 

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
             docsPython
             git
             jdk21_headless
-            nodejs_24
+            nodejs_22
             pnpm
             playwright-driver.browsers
             ripgrep

--- a/llms.txt
+++ b/llms.txt
@@ -14,13 +14,13 @@ Authority:
 
 Toolchains:
 - Bazelisk: `8.1.1`
-- Node toolchain: `24.13.0`
-- flake Node major: `24`
+- Node toolchain: `22.13.1`
+- flake Node major: `22`
 - pnpm toolchain: `9.15.9`
 - package manager: `pnpm@9.15.9`
-- engines: `>=24 <25`
-- CI node matrix: `24`
-- CI publish node: `24`
+- engines: `>=22 <25`
+- CI node matrix: `22, 24`
+- CI publish node: `22`
 
 Protocol:
 - version: `1.0.0`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
@@ -56,7 +56,7 @@
     "prom-client": "^15"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0",
+    "@types/node": "^22.0.0",
     "ioredis-mock": "^8.13.1",
     "publint": "^0.3.18",
     "tsx": "^4.0.0",
@@ -75,6 +75,6 @@
     }
   },
   "engines": {
-    "node": ">=24 <25"
+    "node": ">=22 <25"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         version: 15.1.3
     devDependencies:
       '@types/node':
-        specifier: ^24.0.0
-        version: 24.12.2
+        specifier: ^22.0.0
+        version: 22.19.17
       ioredis-mock:
         specifier: ^8.13.1
         version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.10.1))(ioredis@5.10.1)
@@ -44,7 +44,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.0
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 
@@ -420,8 +420,8 @@ packages:
     peerDependencies:
       ioredis: '>=5'
 
-  '@types/node@24.12.2':
-    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/pg@8.11.6':
     resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
@@ -1087,8 +1087,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   vite@8.0.3:
     resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
@@ -1517,13 +1517,13 @@ snapshots:
     dependencies:
       ioredis: 5.10.1
 
-  '@types/node@24.12.2':
+  '@types/node@22.19.17':
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 6.21.0
 
   '@types/pg@8.11.6':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 22.19.17
       pg-protocol: 1.13.0
       pg-types: 4.1.0
 
@@ -1541,13 +1541,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -2075,9 +2075,9 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.16.0: {}
+  undici-types@6.21.0: {}
 
-  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0):
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2085,7 +2085,7 @@ snapshots:
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 22.19.17
       esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.21.0
@@ -2093,10 +2093,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -2113,11 +2113,11 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 24.12.2
+      '@types/node': 22.19.17
     transitivePeerDependencies:
       - msw
 

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -63,7 +63,11 @@ const parseSupportedNodeMajors = (engineRange) => {
 };
 
 const supportedNodeMajors = parseSupportedNodeMajors(packageJson.engines.node);
-const canonicalNodeMajor = String(supportedNodeMajors.lower);
+const packageNodeMajor = String(supportedNodeMajors.lower);
+const runtimeNodeMajor = String(supportedNodeMajors.upper - 1);
+const validationNodeMajors = Array.from(
+  new Set([packageNodeMajor, runtimeNodeMajor]),
+);
 const nodeTypesMajor = parseMajor(
   packageJson.devDependencies['@types/node'],
   '@types/node version',
@@ -156,47 +160,47 @@ const checks = [
   {
     label: 'MODULE.bazel Node major',
     actual: String(bazelNodeMajor),
-    expected: canonicalNodeMajor,
+    expected: packageNodeMajor,
   },
   {
     label: 'flake Node major',
     actual: String(flakeNodeMajor),
-    expected: canonicalNodeMajor,
+    expected: packageNodeMajor,
   },
   {
     label: 'Docker Node major',
     actual: String(dockerNodeMajor),
-    expected: canonicalNodeMajor,
+    expected: runtimeNodeMajor,
   },
   {
     label: 'Modal Node major',
     actual: String(modalNodeMajor),
-    expected: canonicalNodeMajor,
+    expected: runtimeNodeMajor,
   },
   {
     label: '@types/node major',
     actual: String(nodeTypesMajor),
-    expected: canonicalNodeMajor,
+    expected: packageNodeMajor,
   },
   {
     label: 'CI node versions',
     actual: JSON.stringify(ciNodeVersions),
-    expected: JSON.stringify(supportedNodeMajors.majors),
+    expected: JSON.stringify(validationNodeMajors),
   },
   {
     label: 'publish workflow node versions',
     actual: JSON.stringify(publishNodeVersions),
-    expected: JSON.stringify(supportedNodeMajors.majors),
+    expected: JSON.stringify(validationNodeMajors),
   },
   {
     label: 'CI publish node version',
     actual: ciPublishNodeVersion,
-    expected: canonicalNodeMajor,
+    expected: packageNodeMajor,
   },
   {
     label: 'publish workflow node version',
     actual: publishWorkflowNodeVersion,
-    expected: canonicalNodeMajor,
+    expected: packageNodeMajor,
   },
   {
     label: 'CI build command',


### PR DESCRIPTION
## What changed

- Restores public package support for Node.js 22 through Node.js 24 in `package.json` and release metadata.
- Moves the Bazel/package-validation toolchain and Nix shell back to Node 22, while keeping Modal and Docker runtime images on Node 24.
- Updates reusable workflow inputs to validate both Node 22 and Node 24, publishing from Node 22.
- Bumps `@tummycrypt/scheduling-bridge` metadata to `0.4.5` and regenerates repo facts/LLM docs.

## Why

MassageIthaca main/Vercel still runs on Node 22, while bridge `0.4.4` declared `>=24 <25`. The bridge code validates on Node 22, so this narrows the policy mismatch without changing the Modal/Docker deployment runtime.

Fixes #91.
Refs Jesssullivan/MassageIthaca#285.

## Validation

- `pnpm install --frozen-lockfile=false`
- `pnpm check:release-metadata`
- `pnpm docs:generate`
- `pnpm docs:check`
- `pnpm exec vitest run`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm check:package`
- `pnpm check:artifact-authority`
- `node -e "import('./dist/server/handler.js').then(() => console.log(process.version))"` on Node 22.20.0
- `git diff --check`
