### PR TITLE
docs: clarify bridge runtime provider truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@21e0093a7586931ee69d716387e00556c6da7738
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@462272a83640c0fddbe2925a87064a7d2575c03a
     with:
       runner_mode: shared
       shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@21e0093a7586931ee69d716387e00556c6da7738
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@462272a83640c0fddbe2925a87064a7d2575c03a
     with:
       runner_mode: shared
       shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ It owns:
 - Playwright orchestration
 - Effect-based resource management around browser/page lifecycle
 - remote HTTP endpoints for services, availability, slots, booking, and health
-- Modal and Docker deployment surfaces
+- bridge runtime packaging for Modal, Docker, and Kubernetes/container targets
 
 It does **not** own:
 
@@ -24,6 +24,8 @@ It does **not** own:
 - application-specific environment switching
 - site-specific admin UI
 - reusable, backend-agnostic UI components
+- Kubernetes cluster state or public edge routing; those live in the
+  infrastructure repo
 
 ## Strategic Goal
 
@@ -42,7 +44,9 @@ As of `2026-04-25`, the active structural work here is:
 - `TIN-89` package, Bazel, CI, publish, and dependency truth across shared
   scheduling packages
 - `TIN-165` bazel-registry generation from standalone package truth
+- `TIN-189` Modal-to-K8s bridge migration and parity bake
 - release, tag, and npm authority cleanup tracked in GitHub issue `#76`
+- runtime/provider decoupling tracked in GitHub issue `#44`
 - runner reachability and shared-runner adoption, still pending proof before it
   becomes this public repo's live workflow contract
 
@@ -51,17 +55,34 @@ Operationally relevant truth:
 - the pending package metadata on this branch is `@tummycrypt/scheduling-bridge`
   `0.4.5`
 - `0.4.5` depends on `@tummycrypt/scheduling-kit ^0.7.4`
-- as of `2026-04-29`, npm `latest`, git tag `v0.4.4`, and the GitHub release
-  all point at `0.4.4`; deployed bridge runtime tuple remains a separate
-  verification surface
+- as of `2026-04-30`, npm `latest` and git tag `v0.4.5` point at `0.4.5`;
+  deployed bridge runtime tuple remains a separate verification surface
 - package metadata, git tags, npm dist-tags, and GitHub releases are separate
   authority surfaces until `#76` is resolved
 
 ## Deployment Truth
 
+### Runtime Contract
+
+The provider-agnostic bridge contract is the Node HTTP server plus `/health`
+runtime tuple. Consumers should talk about this service as the scheduling
+bridge, not as "Modal", unless they are discussing the Modal deployment itself.
+
+Current provider truth:
+
+- Modal remains the current live primary remote bridge surface until `TIN-189`
+  closes and the K8s parity bake is accepted.
+- K8s is an active shadow and next-primary execution lane, but cluster state,
+  tailnet exposure, and public-edge routing are infrastructure concerns.
+- Docker/container execution must mirror the same built Node entrypoint so K8s
+  and other providers do not become separate runtime implementations.
+- Downstream apps should configure bridge endpoints with
+  `SCHEDULING_BRIDGE_URL` / `SCHEDULING_BRIDGE_AUTH_TOKEN`; legacy `MODAL_*`
+  names are compatibility aliases outside this repo, not the forward contract.
+
 ### Modal
 
-Modal is the primary remote deployment surface.
+Modal is the current live primary remote deployment surface.
 
 Important facts:
 
@@ -69,11 +90,13 @@ Important facts:
 - the Modal image must stay aligned with the same built artifact used by `pnpm start`
 - warm-container behavior and concurrency settings are part of the real latency story
 
-### Docker
+### Docker / K8s Container
 
-Docker should mirror the same entrypoint and runtime assumptions as Modal.
+Docker and K8s containers should mirror the same entrypoint and runtime
+assumptions as Modal.
 
-If Modal and Docker drift from the actual Node entrypoint, that is an operational bug.
+If Modal, Docker, and K8s drift from the actual Node entrypoint, that is an
+operational bug.
 
 ### Release Coordination
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ The bridge emits NDJSON logs to stdout/stderr for runtime analysis.
 
 ## Deployment
 
+### Runtime Provider Truth
+
+The stable bridge contract is the Node HTTP server, protocol surface, and
+`/health` tuple. Modal is the current live primary deployment provider, but it
+is not the name of the consumer contract.
+
+- Current live primary: Modal, until the `TIN-189` K8s parity bake is accepted.
+- Active next-primary lane: K8s/container runtime managed from infrastructure.
+- Compatibility target: Docker image with the same `dist/server/handler.js`
+  entrypoint.
+- Consumer apps should configure the remote bridge with
+  `SCHEDULING_BRIDGE_URL` and `SCHEDULING_BRIDGE_AUTH_TOKEN`; legacy
+  `MODAL_*` names are transition aliases in consumer/infra repos.
+
 ## Node Runtime Policy
 
 The npm package supports active downstream consumer runtimes on Node 22 and
@@ -145,7 +159,7 @@ modal deploy modal-app.py
 
 #### Supported deployment path
 
-The supported deployment path for the live Acuity bridge is:
+The current Modal deployment path for the live Acuity bridge is:
 
 1. merge to `main`
 2. let `.github/workflows/deploy-modal.yml` deploy `modal-app.py`
@@ -183,7 +197,7 @@ The current publish + deploy shape is:
 2. Bazel validates/builds the publishable artifact
 3. CI dry-runs the extracted Bazel package surface before release
 4. GitHub Actions publishes that extracted artifact
-5. GitHub Actions deploys the Modal runtime from `main`
+5. GitHub Actions deploys the current Modal runtime from `main`
 6. downstream apps consume the published package and verify the live runtime
    tuple via `/health`
 

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -7,7 +7,8 @@ The release path is artifact-first.
 3. Build the package with `bazel build //:pkg`.
 4. Use `pnpm build` when local `pkg/` and `dist/` materialization is needed.
 5. Publish from `./bazel-bin/pkg`.
-6. Deploy Modal and Docker from the same materialized package surface.
+6. Deploy Modal, Docker, and K8s/container runtimes from the same materialized
+   package surface.
 
 ## Commands
 
@@ -44,10 +45,19 @@ Bridge-owned runtime and artifact authority remains Node 24:
 - Nix development shell
 - Docker runtime image
 - Modal runtime image
+- K8s/container runtime image
 - npm/GitHub Packages publish runner
 
 Do not collapse these two concerns. Consumer support is broader than the bridge
 runtime image, and package CI must prove both supported consumer majors.
+
+## Runtime Provider Policy
+
+Modal is the current live primary bridge provider until `TIN-189` closes and the
+K8s parity bake is accepted. K8s/container execution is the active next-primary
+lane, but it must consume the same materialized package and launch the same
+`dist/server/handler.js` entrypoint. Provider-specific deployment mechanics
+must not fork the bridge protocol or package artifact.
 
 ## Nix
 

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -10,3 +10,8 @@ Do not vendor this repo into app repositories. App repos should treat the bridge
 as a package plus a deployed runtime endpoint. If an app needs Acuity DOM
 selectors, browser orchestration, Modal build behavior, or bridge health tuple
 interpretation, that belongs here first.
+
+Consumer app configuration should use provider-neutral bridge names such as
+`SCHEDULING_BRIDGE_URL` and `SCHEDULING_BRIDGE_AUTH_TOKEN`. `MODAL_*` names may
+remain as compatibility aliases during migration, but they should not be used as
+the forward app contract.

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -38,6 +38,14 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 - CI build command: `node scripts/check-artifact-authority.mjs`
 - runtime start command: `node dist/server/handler.js`
 
+## Runtime Provider Truth
+
+- provider-agnostic contract: Node HTTP server plus `/health` tuple
+- current live primary provider: Modal, until `TIN-189` closes
+- active next-primary lane: K8s/container runtime from infrastructure
+- forward consumer env names: `SCHEDULING_BRIDGE_URL` and
+  `SCHEDULING_BRIDGE_AUTH_TOKEN`
+
 ## Exported Entry Points
 
 | Export | Types | Runtime |

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,12 @@
 `@tummycrypt/scheduling-bridge`.
 
 The repo owns browser automation, HTTP bridge endpoints, Modal and Docker
-runtime surfaces, and the bridge runtime truth exposed by `/health`.
+runtime surfaces, K8s/container runtime packaging, and the bridge runtime truth
+exposed by `/health`.
 
 It does not own app deployment, business-specific UI, or reusable
-backend-agnostic checkout components. Those are consumer app and
+backend-agnostic checkout components. It also does not own cluster state or
+public-edge routing. Those are consumer app, infrastructure, and
 `scheduling-kit` responsibilities.
 
 ## Authority Summary
@@ -15,6 +17,8 @@ backend-agnostic checkout components. Those are consumer app and
 - Bazel `//:pkg` builds the publishable package artifact.
 - `pnpm build` materializes local `pkg/` and `dist/` from `bazel-bin/pkg`.
 - CI and publish workflows extract `./bazel-bin/pkg`.
-- Modal and Docker consume the materialized `pkg/` artifact rather than
-  rebuilding from source inside runtime images.
+- Modal, Docker, and K8s/container runtimes consume the materialized `pkg/`
+  artifact rather than rebuilding from source inside runtime images.
+- Modal is the current live primary provider; K8s is the active next-primary
+  lane until `TIN-189` closes.
 - Generated facts live in `docs/generated/repo-facts.md`.

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -14,3 +14,18 @@ Downstream apps should use it to verify:
 Package metadata says what a consumer compiled against. `/health` says what the
 deployed bridge is actually running. Promotion and beta validation should check
 both when claims depend on the live bridge.
+
+## Provider Truth
+
+The bridge contract is provider-agnostic: a Node HTTP server exposing the
+protocol endpoints and `/health` tuple.
+
+- Modal is the current live primary remote provider until `TIN-189` closes and
+  the K8s parity bake is accepted.
+- K8s/container execution is the active next-primary lane, managed by the
+  infrastructure repo.
+- Docker is the local/container compatibility target and must mirror the same
+  `dist/server/handler.js` entrypoint.
+- Consumer apps should name the remote endpoint with `SCHEDULING_BRIDGE_URL`
+  and `SCHEDULING_BRIDGE_AUTH_TOKEN`; legacy `MODAL_*` aliases are transition
+  compatibility, not the forward contract.

--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,10 @@ Authority:
 - `pnpm build` materializes local `pkg/` and `dist/` from `bazel-bin/pkg`
 - CI and publish extract `./bazel-bin/pkg` / `./bazel-bin/pkg`
 - runtime start command is `node dist/server/handler.js`
+- provider-agnostic runtime contract is the Node HTTP server plus `/health` tuple
+- Modal is the current live primary provider until `TIN-189` closes
+- K8s/container execution is the active next-primary lane from infrastructure
+- consumer apps should use `SCHEDULING_BRIDGE_URL` and `SCHEDULING_BRIDGE_AUTH_TOKEN`
 
 Toolchains:
 - Bazelisk: `8.1.1`

--- a/scripts/generate-doc-surfaces.mjs
+++ b/scripts/generate-doc-surfaces.mjs
@@ -182,6 +182,14 @@ This page is generated from \`package.json\`, \`MODULE.bazel\`, \`BUILD.bazel\`,
 - CI build command: \`${ciBuildCommand}\`
 - runtime start command: \`${pkg.scripts.start}\`
 
+## Runtime Provider Truth
+
+- provider-agnostic contract: Node HTTP server plus \`/health\` tuple
+- current live primary provider: Modal, until \`TIN-189\` closes
+- active next-primary lane: K8s/container runtime from infrastructure
+- forward consumer env names: \`SCHEDULING_BRIDGE_URL\` and
+  \`SCHEDULING_BRIDGE_AUTH_TOKEN\`
+
 ## Exported Entry Points
 
 | Export | Types | Runtime |
@@ -220,6 +228,10 @@ const llms = [
   '- `pnpm build` materializes local `pkg/` and `dist/` from `bazel-bin/pkg`',
   `- CI and publish extract \`${ciPackageDir}\` / \`${publishPackageDir}\``,
   `- runtime start command is \`${pkg.scripts.start}\``,
+  '- provider-agnostic runtime contract is the Node HTTP server plus `/health` tuple',
+  '- Modal is the current live primary provider until `TIN-189` closes',
+  '- K8s/container execution is the active next-primary lane from infrastructure',
+  '- consumer apps should use `SCHEDULING_BRIDGE_URL` and `SCHEDULING_BRIDGE_AUTH_TOKEN`',
   '',
   'Toolchains:',
   `- Bazelisk: \`${bazelVersion}\``,


### PR DESCRIPTION
## Summary
- clarify that the bridge contract is provider-agnostic and exposed through `/health`
- document Modal as the current live primary provider until TIN-189 closes
- document K8s/container execution as the active next-primary lane and `SCHEDULING_BRIDGE_*` as the forward consumer env contract
- update generated repo facts / llms surfaces with the same truth

## Validation
- `git diff --check`
- `pnpm docs:check`
- `nix develop --command pnpm docs:build`