### PR TITLE
[codex] fix bridge parity slot contract

### DIFF
--- a/parity/README.md
+++ b/parity/README.md
@@ -1,8 +1,8 @@
 # Modal ↔ K8s Parity Harness
 
 Shadow-traffic parity check for the Modal → K8s migration (phase 1.1 bake).
-Compares `/availability/slots` responses between the Modal (production) backend
-and the K8s (shadow) backend, classifies divergence into `OK` / `WARN` /
+Compares `/availability/slots` responses between the Modal-backed reference
+backend and the K8s-native backend, classifies divergence into `OK` / `WARN` /
 `CRITICAL` buckets, and emits one NDJSON record per (service, date) probe.
 
 The harness is intended to run from a tailnet-reachable host (cron or Ansible
@@ -13,9 +13,10 @@ shared secret the middleware uses for upstream auth.
 
 During phase 1.1 of the Modal → K8s migration, the K8s cluster serves *shadow*
 traffic only: real reads are replayed against it for correctness comparison
-while Modal stays authoritative. This harness drives that comparison on a
-fixed cadence (nightly or every 10 minutes during active bake) so divergence
-can be surfaced via Loki alerts long before any cutover.
+while Modal remains the reference path. K8s-native middleware execution is the
+target production route after parity bake passes. This harness drives that
+comparison on a fixed cadence (nightly or every 10 minutes during active bake)
+so divergence can be surfaced via Loki alerts long before any cutover.
 
 ## Environment variables
 
@@ -40,13 +41,34 @@ Every request to both backends sends **two** auth mechanisms:
    enforce them; they are included now so the infrastructure is in place before
    enforcement is added.
 
-The HMAC signature is `HMAC-SHA256(secret, timestamp + path)` where `timestamp`
-is the Unix epoch in milliseconds and `path` is the request path including query
-string (e.g., `/availability/slots?service=12345&date=2026-05-01`).
+The HMAC signature is `HMAC-SHA256(secret, timestamp + path + bodyHash)` where
+`timestamp` is the Unix epoch in milliseconds, `path` is the request path, and
+`bodyHash` is the SHA-256 hex digest of the raw JSON request body. Bodyless GETs
+use the SHA-256 digest of the empty string. The current slot probe posts to
+`/availability/slots` with a JSON body:
+
+```json
+{"serviceId":"12345","date":"2026-05-01"}
+```
 
 Both `MODAL_URL` and `K8S_URL` must be tailnet-reachable from the harness host.
 The harness never punches out to the public internet — it relies on the same
 private routing the middleware itself uses.
+
+## Slot Contract
+
+Current bridge responses wrap available slots in the standard success envelope:
+
+```json
+{"success":true,"data":[{"datetime":"2026-05-01T10:00:00Z","available":true}]}
+```
+
+The harness also accepts the legacy raw `{ "slots": [...] }` shape so old
+captures can still be replayed during investigation. Slot identity is taken
+from `datetime`, with `start_iso` and `startIso` tolerated for historical
+fixtures. Slots marked `"available": false` are ignored for drift counts.
+Disabled Acuity calendar dates are a valid zero-slot result and should not be
+reported as scrape failures.
 
 ## Exit codes
 
@@ -76,7 +98,7 @@ cadence to hourly or nightly before promoting K8s to receive real traffic.
 
 ## Diff thresholds
 
-The classifier bins the symmetric-difference count of `start_iso` timestamps:
+The classifier bins the symmetric-difference count of available slot timestamps:
 
 | Drift (slots) | Level      | Action                                                    |
 | ------------- | ---------- | --------------------------------------------------------- |

--- a/parity/check.test.ts
+++ b/parity/check.test.ts
@@ -12,10 +12,10 @@ import {
 // ---------------------------------------------------------------------------
 describe('classifyDiff for /availability/slots', () => {
   const modal: SlotsResponse = {
-    service_id: 's1',
+    serviceId: 's1',
     slots: [
-      { start_iso: '2026-05-01T10:00:00Z' },
-      { start_iso: '2026-05-01T11:00:00Z' },
+      { datetime: '2026-05-01T10:00:00Z', available: true },
+      { datetime: '2026-05-01T11:00:00Z', available: true },
     ],
   };
 
@@ -26,16 +26,17 @@ describe('classifyDiff for /availability/slots', () => {
   it('OK for ≤ 2 slot drift', () => {
     const k8s: SlotsResponse = {
       ...modal,
-      slots: [...modal.slots, { start_iso: '2026-05-01T12:00:00Z' }],
+      slots: [...modal.slots, { datetime: '2026-05-01T12:00:00Z', available: true }],
     };
     expect(classifyDiff(modal, k8s).level).toBe('OK');
   });
 
   it('WARN for 3–5 slot drift', () => {
     const k8s: SlotsResponse = {
-      service_id: 's1',
+      serviceId: 's1',
       slots: ['10', '11', '12', '13', '14'].map(h => ({
-        start_iso: `2026-05-01T${h}:00:00Z`,
+        datetime: `2026-05-01T${h}:00:00Z`,
+        available: true,
       })),
     };
     expect(classifyDiff(modal, k8s).level).toBe('WARN');
@@ -43,12 +44,22 @@ describe('classifyDiff for /availability/slots', () => {
 
   it('CRITICAL for > 5 slot drift', () => {
     const k8s: SlotsResponse = {
-      service_id: 's1',
+      serviceId: 's1',
       slots: Array.from({ length: 10 }, (_, i) => ({
-        start_iso: `2026-05-01T${String(i + 10).padStart(2, '0')}:00:00Z`,
+        datetime: `2026-05-01T${String(i + 10).padStart(2, '0')}:00:00Z`,
+        available: true,
       })),
     };
     expect(classifyDiff(modal, k8s).level).toBe('CRITICAL');
+  });
+
+  it('ignores unavailable slots when classifying drift', () => {
+    const k8s: SlotsResponse = {
+      ...modal,
+      slots: [...modal.slots, { datetime: '2026-05-01T12:00:00Z', available: false }],
+    };
+    expect(classifyDiff(modal, k8s).level).toBe('OK');
+    expect(classifyDiff(modal, k8s).detail).toBe('drift=0');
   });
 });
 
@@ -58,7 +69,7 @@ describe('classifyDiff for /availability/slots', () => {
 describe('fetchWithHmac signature shape', () => {
   const SECRET = 'test-secret-abc';
   const BASE = 'https://modal.example.internal';
-  const PATH = '/availability/slots?service=99&date=2026-05-01';
+  const PATH = '/availability/services?scope=smoke';
   const BEARER = 'my-bearer-token';
 
   let capturedRequest: Request | undefined;
@@ -68,7 +79,7 @@ describe('fetchWithHmac signature shape', () => {
     restoreFetch = globalThis.fetch;
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       capturedRequest = new Request(input, init);
-      return new Response(JSON.stringify({ service_id: '99', slots: [] }), {
+      return new Response(JSON.stringify({ success: true, data: [] }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
@@ -107,7 +118,7 @@ describe('fetchWithHmac signature shape', () => {
   });
 
   it('sends POST with Content-Type JSON and stringified body when body provided', async () => {
-    const body = { service_id: '99', date: '2026-05-01' };
+    const body = { serviceId: '99', date: '2026-05-01' };
     await fetchWithHmac(BASE, '/availability/slots', SECRET, undefined, body);
 
     expect(capturedRequest!.method).toBe('POST');
@@ -141,7 +152,7 @@ describe('fetchWithHmac signature shape', () => {
       // Call 1: no body (GET)
       await fetchWithHmac(BASE, '/availability/slots', SECRET);
       // Call 2: with body (POST)
-      await fetchWithHmac(BASE, '/availability/slots', SECRET, undefined, { service_id: '99', date: '2026-05-01' });
+      await fetchWithHmac(BASE, '/availability/slots', SECRET, undefined, { serviceId: '99', date: '2026-05-01' });
       // Call 3: with explicit empty-string-equivalent body — JSON.stringify('') === '""', so this MUST differ from Call 1.
       // To verify the "empty body vs no body" equivalence, we pass an empty object and compare against no body separately.
 
@@ -166,8 +177,8 @@ describe('fetchWithHmac signature shape', () => {
 // ---------------------------------------------------------------------------
 describe('runParityCheck', () => {
   const makeSlotPayload = (slots: string[]): SlotsResponse => ({
-    service_id: 'svc1',
-    slots: slots.map(s => ({ start_iso: s })),
+    serviceId: 'svc1',
+    slots: slots.map(s => ({ datetime: s, available: true })),
   });
 
   const happyPayload = makeSlotPayload([
@@ -187,7 +198,7 @@ describe('runParityCheck', () => {
 
   it('happy path: identical payloads → classification OK with all structured fields', async () => {
     globalThis.fetch = vi.fn(async () =>
-      new Response(JSON.stringify(happyPayload), {
+      new Response(JSON.stringify({ success: true, data: happyPayload.slots }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }),
@@ -219,7 +230,7 @@ describe('runParityCheck', () => {
       if (url.startsWith('https://k8s.internal')) {
         throw new Error('connection refused');
       }
-      return new Response(JSON.stringify(happyPayload), {
+      return new Response(JSON.stringify({ success: true, data: happyPayload.slots }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });

--- a/parity/check.ts
+++ b/parity/check.ts
@@ -1,8 +1,14 @@
 // parity/check.ts
 import { createHash, createHmac } from 'node:crypto';
 
-export interface Slot { start_iso: string }
-export interface SlotsResponse { service_id: string; slots: Slot[] }
+export interface Slot {
+  readonly datetime?: string;
+  readonly start_iso?: string;
+  readonly startIso?: string;
+  readonly available?: boolean;
+}
+export interface SlotsResponse { serviceId: string; slots: Slot[] }
+interface BridgeSuccessResponse<T> { success: true; data: T }
 export type DiffLevel = 'OK' | 'WARN' | 'CRITICAL';
 
 export interface DiffResult {
@@ -28,9 +34,41 @@ const sign = (secret: string, path: string, ts: string, body?: string): string =
   return createHmac('sha256', secret).update(`${ts}${path}${bodyHash}`).digest('hex');
 };
 
+const slotKey = (slot: Slot): string =>
+  slot.datetime ?? slot.start_iso ?? slot.startIso ?? JSON.stringify(slot);
+
+const availableSlotKeys = (response: SlotsResponse): string[] =>
+  response.slots.filter(slot => slot.available !== false).map(slotKey);
+
+const unwrapSlotsResponse = (payload: unknown, serviceId: string): SlotsResponse => {
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'success' in payload &&
+    (payload as { success: unknown }).success === true &&
+    Array.isArray((payload as BridgeSuccessResponse<unknown[]>).data)
+  ) {
+    return { serviceId, slots: (payload as BridgeSuccessResponse<Slot[]>).data };
+  }
+
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    Array.isArray((payload as { slots?: unknown }).slots)
+  ) {
+    const response = payload as { serviceId?: string; service_id?: string; slots: Slot[] };
+    return {
+      serviceId: response.serviceId ?? response.service_id ?? serviceId,
+      slots: response.slots,
+    };
+  }
+
+  throw new Error('Unexpected /availability/slots response shape');
+};
+
 export const classifyDiff = (modal: SlotsResponse, k8s: SlotsResponse): { level: DiffLevel; detail: string } => {
-  const modalSet = new Set(modal.slots.map(s => s.start_iso));
-  const k8sSet = new Set(k8s.slots.map(s => s.start_iso));
+  const modalSet = new Set(availableSlotKeys(modal));
+  const k8sSet = new Set(availableSlotKeys(k8s));
   const onlyModal = [...modalSet].filter(s => !k8sSet.has(s));
   const onlyK8s = [...k8sSet].filter(s => !modalSet.has(s));
   const drift = onlyModal.length + onlyK8s.length;
@@ -86,16 +124,22 @@ export const runParityCheck = async (cfg: ParityConfig): Promise<DiffResult[]> =
       date.setDate(date.getDate() + d);
       const iso = date.toISOString().slice(0, 10);
       const path = `/availability/slots`;
-      const body = { service_id: sid, date: iso };
+      const body = { serviceId: sid, date: iso };
       try {
-        const modal = (await fetchWithHmac(cfg.modalUrl, path, cfg.hmacSecret, cfg.bearerToken, body)) as SlotsResponse;
-        const k8s = (await fetchWithHmac(cfg.k8sUrl, path, cfg.hmacSecret, cfg.bearerToken, body)) as SlotsResponse;
+        const modal = unwrapSlotsResponse(
+          await fetchWithHmac(cfg.modalUrl, path, cfg.hmacSecret, cfg.bearerToken, body),
+          sid,
+        );
+        const k8s = unwrapSlotsResponse(
+          await fetchWithHmac(cfg.k8sUrl, path, cfg.hmacSecret, cfg.bearerToken, body),
+          sid,
+        );
         const { level, detail } = classifyDiff(modal, k8s);
         results.push({
           service: sid,
           date: iso,
-          modalCount: modal.slots.length,
-          k8sCount: k8s.slots.length,
+          modalCount: availableSlotKeys(modal).length,
+          k8sCount: availableSlotKeys(k8s).length,
           level,
           detail,
         });

--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -179,9 +179,10 @@ export const readSlotsViaUrl = (
 		});
 		navigationMs = Date.now() - navigationStartedAt;
 
-		// Click the target date on the calendar
+		// Click the target date on the calendar. Disabled dates are a valid
+		// "no availability" result, not a scrape failure.
 		const tileSelector = Selectors.calendarDay[0];
-		yield* Effect.tryPromise({
+		const clickedTargetDate = yield* Effect.tryPromise({
 			try: async () => {
 				const calendarReadyStartedAt = Date.now();
 				await page.waitForSelector(tileSelector, { timeout: 10000 }).catch(() => {});
@@ -197,19 +198,61 @@ export const readSlotsViaUrl = (
 						const d = new Date(label);
 						if (d.toISOString().slice(0, 10) === date) {
 							matchedDateFound = true;
-							await tile.click();
-							break;
+							const disabled = await tile.evaluate((el) => {
+								const button = el as HTMLButtonElement;
+								return (
+									button.disabled ||
+									button.getAttribute('aria-disabled') === 'true' ||
+									button.classList.contains('react-calendar__tile--disabled')
+								);
+							});
+							if (disabled) {
+								dateSelectMs = Date.now() - dateSelectStartedAt;
+								return false;
+							}
+							await tile.click({ timeout: Math.min(config.timeout, 5000) });
+							dateSelectMs = Date.now() - dateSelectStartedAt;
+
+							const settleStartedAt = Date.now();
+							await page.waitForTimeout(2000);
+							postClickSettleMs = Date.now() - settleStartedAt;
+							return true;
 						}
 					}
 				}
 				dateSelectMs = Date.now() - dateSelectStartedAt;
-
-				const settleStartedAt = Date.now();
-				await page.waitForTimeout(2000);
-				postClickSettleMs = Date.now() - settleStartedAt;
+				return false;
 			},
 			catch: (e) => new WizardStepError({ step: 'read-slots', message: `Date click failed: ${e}` }),
 		});
+
+		if (!clickedTargetDate) {
+			const profile = createSlotReadProfile({
+				serviceId,
+				date,
+				thresholdMs: profileConfig.thresholdMs,
+				calendarTileCount,
+				matchedDateFound,
+				slotCount: 0,
+				parsedSlotCount: 0,
+				phases: {
+					navigationMs,
+					calendarReadyMs,
+					dateSelectMs,
+					postClickSettleMs,
+					slotWaitMs,
+					slotDomReadMs,
+					parseMs,
+				},
+				context,
+			});
+
+			if (shouldLogSlotReadProfile(profile, profileConfig)) {
+				ndjsonLog('INFO', 'Slot read profile', { ...buildSlotReadProfileEvent(profile) });
+			}
+
+			return [];
+		}
 
 		// Read time slots using the Selectors registry
 		const slotSelector = Selectors.timeSlot[0]; // button.time-selection


### PR DESCRIPTION
## Summary

- Align the parity harness with the current `/availability/slots` POST contract: `serviceId` request bodies and `{ success: true, data: [...] }` responses.
- Compare available slot datetimes only, while tolerating historical `start_iso` / raw `{ slots: [...] }` captures for replay.
- Treat disabled or missing Acuity target dates as zero-slot reads instead of clicking disabled calendar tiles and returning 500 after a long timeout.
- Update the parity README to reflect Modal as the reference path and K8s-native middleware as the production route after parity bake.

## Root Cause

The parity harness still spoke an older slot shape, while live K8s slot reads could try to click disabled Acuity calendar dates. That made normal empty days look like scrape failures during K8s parity proof.

## Validation

- `pnpm exec vitest run parity/check.test.ts`
- `pnpm typecheck`
- `git diff --cached --check`

## Notes

This ports the same fix from dev/k8s PR #95 onto the current 0.4.5 mainline runtime. The dev/k8s image tag `sha-c014255` was built by manual dispatch but should not be deployed because that branch is behind main on runtime/package authority.