### PR TITLE
Fix Acuity month navigation for URL availability reads

### DIFF
--- a/src/adapters/acuity/__tests__/wizard-calendar.test.ts
+++ b/src/adapters/acuity/__tests__/wizard-calendar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { MONTH_NAMES } from '../wizard-calendar.js';
+import { MONTH_NAMES, parseYearMonthKey } from '../wizard-calendar.js';
 
 describe('MONTH_NAMES', () => {
 	it('has 12 entries', () => {
@@ -24,5 +24,18 @@ describe('MONTH_NAMES', () => {
 		expect(MONTH_NAMES.indexOf('march')).toBe(2);
 		expect(MONTH_NAMES.indexOf('december')).toBe(11);
 		expect(MONTH_NAMES.indexOf('invalid')).toBe(-1);
+	});
+});
+
+describe('parseYearMonthKey', () => {
+	it('parses a YYYY-MM key to zero-based calendar month', () => {
+		expect(parseYearMonthKey('2026-07')).toEqual({ year: 2026, month: 6 });
+	});
+
+	it('rejects malformed or out-of-range month keys', () => {
+		expect(parseYearMonthKey('2026-7')).toBeNull();
+		expect(parseYearMonthKey('2026-00')).toBeNull();
+		expect(parseYearMonthKey('2026-13')).toBeNull();
+		expect(parseYearMonthKey('july-2026')).toBeNull();
 	});
 });

--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -17,6 +17,7 @@ import { observePageOpEffect } from '../../../shared/metrics.js';
 import { WizardStepError } from '../errors.js';
 import { Selectors } from '../selectors.js';
 import { parseSlotText, buildIsoDatetime } from '../slot-parser.js';
+import { navigateToMonth, parseYearMonthKey } from '../wizard-calendar.js';
 import {
 	buildSlotReadProfileEvent,
 	createSlotReadProfile,
@@ -44,6 +45,35 @@ const navigateForUrlRead = async (page: Page, url: URL, timeout: number): Promis
 	// useful. Bound the network-idle wait so empty days do not become 30s 500s.
 	await page.goto(url.toString(), { waitUntil: 'domcontentloaded', timeout });
 	await page.waitForLoadState('networkidle', { timeout: Math.min(timeout, 5000) }).catch(() => {});
+};
+
+const navigateToServiceCalendar = (
+	page: Page,
+	url: URL,
+	timeout: number,
+	step: 'read-availability' | 'read-slots',
+): Effect.Effect<void, WizardStepError> =>
+	Effect.tryPromise({
+		try: () => navigateForUrlRead(page, url, timeout),
+		catch: (e) => new WizardStepError({ step, message: `Navigation failed: ${e}` }),
+	});
+
+const navigateToTargetMonth = (
+	page: Page,
+	targetMonth: string | undefined,
+	step: 'read-availability' | 'read-slots',
+): Effect.Effect<void, WizardStepError> => {
+	if (!targetMonth) return Effect.void;
+
+	const parsed = parseYearMonthKey(targetMonth);
+	if (!parsed) {
+		return Effect.fail(new WizardStepError({
+			step,
+			message: `Invalid target month: ${targetMonth}`,
+		}));
+	}
+
+	return navigateToMonth(page, parsed.month, parsed.year, step);
 };
 
 const readEnabledCalendarDates = (
@@ -95,12 +125,9 @@ export const readDatesViaUrl = (
 
 		const url = new URL(config.baseUrl);
 		url.searchParams.set('appointmentType', serviceId);
-		if (targetMonth) url.searchParams.set('month', targetMonth);
 
-		yield* Effect.tryPromise({
-			try: () => navigateForUrlRead(page, url, config.timeout),
-			catch: (e) => new WizardStepError({ step: 'read-availability', message: `Navigation failed: ${e}` }),
-		});
+		yield* navigateToServiceCalendar(page, url, config.timeout, 'read-availability');
+		yield* navigateToTargetMonth(page, targetMonth, 'read-availability');
 
 		// Wait for calendar tiles using the Selectors registry
 		const calendarSelector = Selectors.calendarDay.join(', ');
@@ -133,6 +160,7 @@ export const readDatesViaUrl = (
 			try: () => navigateForUrlRead(page, url, config.timeout),
 			catch: (e) => new WizardStepError({ step: 'read-availability', message: `Retry navigation failed: ${e}` }),
 		});
+		yield* navigateToTargetMonth(page, targetMonth, 'read-availability');
 		yield* Effect.tryPromise({
 			try: () => page.waitForSelector(calendarSelector, { timeout: 10000 }),
 			catch: () => null,
@@ -178,12 +206,11 @@ export const readSlotsViaUrl = (
 		const url = new URL(config.baseUrl);
 		url.searchParams.set('appointmentType', serviceId);
 		url.searchParams.set('date', date);
+		const targetMonth = date.slice(0, 7);
 
 		const navigationStartedAt = Date.now();
-		yield* Effect.tryPromise({
-			try: () => navigateForUrlRead(page, url, config.timeout),
-			catch: (e) => new WizardStepError({ step: 'read-slots', message: `Navigation failed: ${e}` }),
-		});
+		yield* navigateToServiceCalendar(page, url, config.timeout, 'read-slots');
+		yield* navigateToTargetMonth(page, targetMonth, 'read-slots');
 		navigationMs = Date.now() - navigationStartedAt;
 
 		// Click the target date on the calendar. Disabled dates are a valid

--- a/src/adapters/acuity/wizard-calendar.ts
+++ b/src/adapters/acuity/wizard-calendar.ts
@@ -19,6 +19,24 @@ export const MONTH_NAMES: readonly string[] = [
 	'july', 'august', 'september', 'october', 'november', 'december',
 ];
 
+export interface CalendarMonth {
+	readonly month: number;
+	readonly year: number;
+}
+
+export const parseYearMonthKey = (value: string): CalendarMonth | null => {
+	const match = value.match(/^(\d{4})-(\d{2})$/);
+	if (!match) return null;
+
+	const year = Number(match[1]);
+	const month = Number(match[2]) - 1;
+	if (!Number.isInteger(year) || !Number.isInteger(month) || month < 0 || month > 11) {
+		return null;
+	}
+
+	return { month, year };
+};
+
 // =============================================================================
 // CALENDAR MONTH PARSING
 // =============================================================================
@@ -32,7 +50,7 @@ export const MONTH_NAMES: readonly string[] = [
  */
 export const getCurrentCalendarMonth = (
 	page: Page,
-): Effect.Effect<{ month: number; year: number } | null, never> =>
+): Effect.Effect<CalendarMonth | null, never> =>
 	Effect.gen(function* () {
 		for (let attempt = 0; attempt < 3; attempt++) {
 			if (attempt > 0) {

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -88,6 +88,14 @@ const SERVICE_CACHE_TTL_MS = (() => {
 	const parsed = Number(process.env.ACUITY_SERVICE_CACHE_TTL_MS ?? 5 * 60_000);
 	return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5 * 60_000;
 })();
+const READ_CACHE_TTL_SECONDS = (() => {
+	const parsed = Number(process.env.ACUITY_READ_CACHE_TTL_SECONDS ?? 20 * 60);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 20 * 60;
+})();
+const EMPTY_READ_CACHE_TTL_SECONDS = (() => {
+	const parsed = Number(process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS ?? 2 * 60);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 2 * 60;
+})();
 
 const browserConfig: BrowserConfig = {
 	...defaultBrowserConfig,
@@ -336,6 +344,62 @@ const serviceCatalog = createAcuityServiceCatalog({
 const isSchedulingError = (error: unknown): error is SchedulingError =>
 	typeof error === 'object' && error !== null && '_tag' in error;
 
+const getBridgeReadCached = async <A>(key: string): Promise<A | undefined> => {
+	if (!redisClient) return undefined;
+	try {
+		const raw = await redisClient.get(key);
+		return raw ? (JSON.parse(raw) as A) : undefined;
+	} catch (error) {
+		logEvent('ERROR', 'Bridge read cache get failed', {
+			event: 'bridge_read_cache_get_failed',
+			error: describeLogValue(error),
+		});
+		return undefined;
+	}
+};
+
+const setBridgeReadCached = async <A>(
+	key: string,
+	value: A,
+	ttlSeconds: number,
+): Promise<void> => {
+	if (!redisClient) return;
+	try {
+		await redisClient.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+	} catch (error) {
+		logEvent('ERROR', 'Bridge read cache set failed', {
+			event: 'bridge_read_cache_set_failed',
+			error: describeLogValue(error),
+		});
+	}
+};
+
+const runCachedBridgeRead = async <A>(
+	context: RequestContext,
+	cacheKind: string,
+	cacheKey: string,
+	read: () => Promise<Result<A>>,
+): Promise<Result<A>> => {
+	const cached = await getBridgeReadCached<A>(cacheKey);
+	if (cached !== undefined) {
+		logRequestEvent('INFO', 'Bridge read cache hit', context, {
+			event: 'bridge_read_cache_hit',
+			cacheKind,
+		});
+		return { ok: true, value: cached };
+	}
+
+	const result = await read();
+	if (!result.ok) return result;
+
+	const ttlSeconds =
+		Array.isArray(result.value) && result.value.length === 0
+			? EMPTY_READ_CACHE_TTL_SECONDS
+			: READ_CACHE_TTL_SECONDS;
+	await setBridgeReadCached(cacheKey, result.value, ttlSeconds);
+	return result;
+};
+
 const resolveServiceName = async (serviceId: string, serviceName?: string): Promise<string> => {
 	try {
 		return await serviceCatalog.resolveServiceName(serviceId, serviceName);
@@ -449,15 +513,18 @@ const handleGetService = async (serviceId: string, res: ServerResponse) => {
 
 const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, context: RequestContext) => {
 	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; startDate?: string };
+	const targetMonth = body.startDate?.slice(0, 7);
 	logRequestEvent('INFO', 'Availability dates requested', context, {
 		event: 'availability_dates_requested',
 		serviceId: body.serviceId,
 		serviceName: body.serviceName,
 		startDate: body.startDate,
 	});
-	const result = isAcuityAppointmentTypeId(body.serviceId)
-		? await runEffect(readDatesViaUrl(body.serviceId, body.startDate?.slice(0, 7)))
-		: await (async () => {
+	const cacheKey = `bridge-read:v2:dates:${ACUITY_BASE_URL}:${body.serviceId}:${targetMonth ?? 'current'}`;
+	const result = await runCachedBridgeRead(context, 'availability_dates', cacheKey, () =>
+		isAcuityAppointmentTypeId(body.serviceId)
+			? runEffect(readDatesViaUrl(body.serviceId, targetMonth))
+			: (async () => {
 				const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
 				logRequestEvent('INFO', 'Availability dates resolved service name', context, {
 					event: 'availability_dates_resolved_service',
@@ -468,11 +535,12 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 				return runEffect(
 					readAvailableDates({
 						serviceName,
-						targetMonth: body.startDate?.slice(0, 7),
+						targetMonth,
 						monthsToScan: 2,
 					}),
 				);
-			})();
+			})(),
+	);
 
 	if (!result.ok) {
 		const err = result.error;
@@ -500,15 +568,17 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 		serviceName: body.serviceName,
 		date: body.date,
 	});
-	const result = isAcuityAppointmentTypeId(body.serviceId)
-		? await runEffect(
+	const cacheKey = `bridge-read:v2:slots:${ACUITY_BASE_URL}:${body.serviceId}:${body.date}`;
+	const result = await runCachedBridgeRead(context, 'availability_slots', cacheKey, () =>
+		isAcuityAppointmentTypeId(body.serviceId)
+			? runEffect(
 				readSlotsViaUrl(
 					body.serviceId,
 					body.date,
 					createSlotReadTelemetryContext(context, 'availability_slots'),
 				),
 			)
-		: await (async () => {
+			: (async () => {
 				const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
 				logRequestEvent('INFO', 'Availability slots resolved service name', context, {
 					event: 'availability_slots_resolved_service',
@@ -522,7 +592,8 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 						date: body.date,
 					}),
 				);
-			})();
+			})(),
+	);
 
 	if (!result.ok) {
 		const err = result.error;


### PR DESCRIPTION
## Summary
- explicitly navigate Acuity's React calendar to the requested month for numeric appointment-type date reads
- explicitly navigate to the target month before slot reads so future dates are not read from the initial month
- add bridge Redis caching for date/slot reads, separate from the service catalog cache
- add tests for YYYY-MM month-key parsing

## Validation
- pnpm exec vitest run src/adapters/acuity/__tests__/wizard-calendar.test.ts tests/slot-read-profile.test.ts
- pnpm typecheck
- pnpm build