### PR TITLE
[codex] Single-flight bridge read cache

### DIFF
--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -49,6 +49,10 @@ import {
 	type ServiceCatalogRedisL2,
 } from '../shared/acuity-service-catalog.js';
 import { getCached as redisL2GetCached, RedisL2 } from '../shared/redis-l2.js';
+import {
+	runBridgeReadCached,
+	type BridgeReadCacheClient,
+} from '../shared/bridge-read-cache.js';
 import { metrics, renderMetrics } from '../shared/metrics.js';
 import { toSchedulingError, type MiddlewareError } from '../adapters/acuity/errors.js';
 import {
@@ -344,60 +348,33 @@ const serviceCatalog = createAcuityServiceCatalog({
 const isSchedulingError = (error: unknown): error is SchedulingError =>
 	typeof error === 'object' && error !== null && '_tag' in error;
 
-const getBridgeReadCached = async <A>(key: string): Promise<A | undefined> => {
-	if (!redisClient) return undefined;
-	try {
-		const raw = await redisClient.get(key);
-		return raw ? (JSON.parse(raw) as A) : undefined;
-	} catch (error) {
-		logEvent('ERROR', 'Bridge read cache get failed', {
-			event: 'bridge_read_cache_get_failed',
-			error: describeLogValue(error),
-		});
-		return undefined;
-	}
-};
-
-const setBridgeReadCached = async <A>(
-	key: string,
-	value: A,
-	ttlSeconds: number,
-): Promise<void> => {
-	if (!redisClient) return;
-	try {
-		await redisClient.set(key, JSON.stringify(value), 'EX', ttlSeconds);
-	} catch (error) {
-		logEvent('ERROR', 'Bridge read cache set failed', {
-			event: 'bridge_read_cache_set_failed',
-			error: describeLogValue(error),
-		});
-	}
-};
-
 const runCachedBridgeRead = async <A>(
 	context: RequestContext,
 	cacheKind: string,
 	cacheKey: string,
 	read: () => Promise<Result<A>>,
 ): Promise<Result<A>> => {
-	const cached = await getBridgeReadCached<A>(cacheKey);
-	if (cached !== undefined) {
-		logRequestEvent('INFO', 'Bridge read cache hit', context, {
-			event: 'bridge_read_cache_hit',
-			cacheKind,
-		});
-		return { ok: true, value: cached };
-	}
-
-	const result = await read();
-	if (!result.ok) return result;
-
-	const ttlSeconds =
-		Array.isArray(result.value) && result.value.length === 0
-			? EMPTY_READ_CACHE_TTL_SECONDS
-			: READ_CACHE_TTL_SECONDS;
-	await setBridgeReadCached(cacheKey, result.value, ttlSeconds);
-	return result;
+	return runBridgeReadCached({
+		redisClient: redisClient as BridgeReadCacheClient | null,
+		cacheKind,
+		cacheKey,
+		ttlSeconds: READ_CACHE_TTL_SECONDS,
+		emptyTtlSeconds: EMPTY_READ_CACHE_TTL_SECONDS,
+		read,
+		log: ({ event, cacheKind, waitMs, error }) => {
+			logRequestEvent(
+				error ? 'ERROR' : 'INFO',
+				'Bridge read cache event',
+				context,
+				{
+					event,
+					cacheKind,
+					...(waitMs === undefined ? {} : { waitMs }),
+					...(error === undefined ? {} : { error: describeLogValue(error) }),
+				},
+			);
+		},
+	});
 };
 
 const resolveServiceName = async (serviceId: string, serviceName?: string): Promise<string> => {

--- a/src/shared/bridge-read-cache.test.ts
+++ b/src/shared/bridge-read-cache.test.ts
@@ -1,0 +1,118 @@
+import IORedisMock from 'ioredis-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	runBridgeReadCached,
+	type BridgeReadCacheClient,
+	type BridgeReadCacheEvent,
+} from './bridge-read-cache.js';
+
+describe('runBridgeReadCached', () => {
+	let mock: IORedisMock;
+	let events: BridgeReadCacheEvent[];
+
+	beforeEach(async () => {
+		mock = new IORedisMock();
+		await mock.flushall();
+		events = [];
+	});
+
+	const run = <A>(
+		key: string,
+		read: () => Promise<{ ok: true; value: A } | { ok: false; error: Error }>,
+	) =>
+		runBridgeReadCached({
+			redisClient: mock as unknown as BridgeReadCacheClient,
+			cacheKind: 'availability_slots',
+			cacheKey: key,
+			ttlSeconds: 60,
+			emptyTtlSeconds: 10,
+			read,
+			log: (event) => events.push(event),
+			waitTimeoutMs: 1000,
+			pollIntervalMs: 10,
+		});
+
+	it('returns a cached value without running the bridge read', async () => {
+		await mock.set('slot-key', JSON.stringify([{ datetime: '2026-05-03T14:00:00' }]));
+		const read = vi.fn(async () => ({
+			ok: true as const,
+			value: [{ datetime: 'fresh' }],
+		}));
+
+		const result = await run('slot-key', read);
+
+		expect(result).toEqual({
+			ok: true,
+			value: [{ datetime: '2026-05-03T14:00:00' }],
+		});
+		expect(read).not.toHaveBeenCalled();
+		expect(events.map((event) => event.event)).toContain('bridge_read_cache_hit');
+	});
+
+	it('single-flights concurrent misses so only one caller reads Acuity', async () => {
+		let calls = 0;
+		const read = vi.fn(async () => {
+			calls += 1;
+			await new Promise((resolve) => setTimeout(resolve, 120));
+			return {
+				ok: true as const,
+				value: [{ datetime: `2026-05-03T14:0${calls}:00` }],
+			};
+		});
+
+		const results = await Promise.all(
+			Array.from({ length: 5 }, () => run('shared-slot-key', read)),
+		);
+
+		expect(read).toHaveBeenCalledTimes(1);
+		expect(results).toEqual(
+			Array.from({ length: 5 }, () => ({
+				ok: true,
+				value: [{ datetime: '2026-05-03T14:01:00' }],
+			})),
+		);
+		expect(events.map((event) => event.event)).toContain('bridge_read_cache_wait');
+		expect(await mock.get('lock:shared-slot-key')).toBeNull();
+	});
+
+	it('does not cache failed bridge reads', async () => {
+		const error = new Error('acuity failed');
+		const read = vi.fn(async () => ({ ok: false as const, error }));
+
+		const result = await run('failed-slot-key', read);
+
+		expect(result).toEqual({ ok: false, error });
+		expect(await mock.get('failed-slot-key')).toBeNull();
+		expect(await mock.get('lock:failed-slot-key')).toBeNull();
+	});
+
+	it('falls through when the single-flight winner does not publish before the wait budget', async () => {
+		await mock.set('lock:slow-slot-key', 'winner-token', 'PX', 30_000, 'NX');
+		const read = vi.fn(async () => ({
+			ok: true as const,
+			value: [{ datetime: '2026-05-04T15:00:00' }],
+		}));
+
+		const result = await runBridgeReadCached({
+			redisClient: mock as unknown as BridgeReadCacheClient,
+			cacheKind: 'availability_slots',
+			cacheKey: 'slow-slot-key',
+			ttlSeconds: 60,
+			emptyTtlSeconds: 10,
+			read,
+			log: (event) => events.push(event),
+			waitTimeoutMs: 30,
+			pollIntervalMs: 5,
+		});
+
+		expect(result).toEqual({
+			ok: true,
+			value: [{ datetime: '2026-05-04T15:00:00' }],
+		});
+		expect(read).toHaveBeenCalledTimes(1);
+		expect(events.map((event) => event.event)).toContain(
+			'bridge_read_cache_wait_timeout',
+		);
+	});
+});

--- a/src/shared/bridge-read-cache.ts
+++ b/src/shared/bridge-read-cache.ts
@@ -1,0 +1,167 @@
+import { randomBytes } from 'node:crypto';
+
+export interface BridgeReadCacheClient {
+	get(key: string): Promise<string | null>;
+	set(key: string, value: string, ...args: Array<string | number>): Promise<unknown>;
+	eval(script: string, numKeys: number, ...args: string[]): Promise<unknown>;
+}
+
+export type BridgeReadResult<A, E> =
+	| { ok: true; value: A }
+	| { ok: false; error: E };
+
+export interface BridgeReadCacheEvent {
+	readonly event:
+		| 'bridge_read_cache_hit'
+		| 'bridge_read_cache_wait'
+		| 'bridge_read_cache_wait_timeout'
+		| 'bridge_read_cache_get_failed'
+		| 'bridge_read_cache_set_failed'
+		| 'bridge_read_cache_lock_failed'
+		| 'bridge_read_cache_unlock_failed';
+	readonly cacheKind: string;
+	readonly waitMs?: number;
+	readonly error?: unknown;
+}
+
+export interface RunBridgeReadCachedOptions<A, E> {
+	readonly redisClient: BridgeReadCacheClient | null;
+	readonly cacheKind: string;
+	readonly cacheKey: string;
+	readonly ttlSeconds: number;
+	readonly emptyTtlSeconds: number;
+	readonly read: () => Promise<BridgeReadResult<A, E>>;
+	readonly log?: (event: BridgeReadCacheEvent) => void;
+	readonly lockTtlMs?: number;
+	readonly waitTimeoutMs?: number;
+	readonly pollIntervalMs?: number;
+}
+
+const LOCK_TTL_MS = 30_000;
+const WAIT_TIMEOUT_MS = 12_000;
+const POLL_INTERVAL_MS = 50;
+
+const LUA_CAS_DEL = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end`;
+
+const lockKey = (key: string): string => `lock:${key}`;
+
+const delay = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+const readCached = async <A>(
+	client: BridgeReadCacheClient,
+	cacheKey: string,
+): Promise<A | undefined> => {
+	const raw = await client.get(cacheKey);
+	return raw ? (JSON.parse(raw) as A) : undefined;
+};
+
+const writeCached = async <A>(
+	client: BridgeReadCacheClient,
+	cacheKey: string,
+	value: A,
+	ttlSeconds: number,
+): Promise<void> => {
+	await client.set(cacheKey, JSON.stringify(value), 'EX', ttlSeconds);
+};
+
+const valueTtlSeconds = <A>(
+	value: A,
+	ttlSeconds: number,
+	emptyTtlSeconds: number,
+): number =>
+	Array.isArray(value) && value.length === 0 ? emptyTtlSeconds : ttlSeconds;
+
+export const runBridgeReadCached = async <A, E>({
+	redisClient,
+	cacheKind,
+	cacheKey,
+	ttlSeconds,
+	emptyTtlSeconds,
+	read,
+	log,
+	lockTtlMs = LOCK_TTL_MS,
+	waitTimeoutMs = WAIT_TIMEOUT_MS,
+	pollIntervalMs = POLL_INTERVAL_MS,
+}: RunBridgeReadCachedOptions<A, E>): Promise<BridgeReadResult<A, E>> => {
+	if (!redisClient) return read();
+
+	try {
+		const cached = await readCached<A>(redisClient, cacheKey);
+		if (cached !== undefined) {
+			log?.({ event: 'bridge_read_cache_hit', cacheKind });
+			return { ok: true, value: cached };
+		}
+	} catch (error) {
+		log?.({ event: 'bridge_read_cache_get_failed', cacheKind, error });
+		return read();
+	}
+
+	const token = randomBytes(16).toString('hex');
+	const keyLock = lockKey(cacheKey);
+	let acquired = false;
+	try {
+		acquired = (await redisClient.set(keyLock, token, 'PX', lockTtlMs, 'NX')) === 'OK';
+	} catch (error) {
+		log?.({ event: 'bridge_read_cache_lock_failed', cacheKind, error });
+		return read();
+	}
+
+	if (acquired) {
+		try {
+			const result = await read();
+			if (!result.ok) return result;
+
+			try {
+				await writeCached(
+					redisClient,
+					cacheKey,
+					result.value,
+					valueTtlSeconds(result.value, ttlSeconds, emptyTtlSeconds),
+				);
+			} catch (error) {
+				log?.({ event: 'bridge_read_cache_set_failed', cacheKind, error });
+			}
+
+			return result;
+		} finally {
+			try {
+				await redisClient.eval(LUA_CAS_DEL, 1, keyLock, token);
+			} catch (error) {
+				log?.({ event: 'bridge_read_cache_unlock_failed', cacheKind, error });
+			}
+		}
+	}
+
+	const startedAt = Date.now();
+	const deadline = startedAt + waitTimeoutMs;
+	while (Date.now() < deadline) {
+		await delay(pollIntervalMs);
+		try {
+			const cached = await readCached<A>(redisClient, cacheKey);
+			if (cached !== undefined) {
+				log?.({
+					event: 'bridge_read_cache_wait',
+					cacheKind,
+					waitMs: Date.now() - startedAt,
+				});
+				return { ok: true, value: cached };
+			}
+		} catch (error) {
+			log?.({ event: 'bridge_read_cache_get_failed', cacheKind, error });
+			break;
+		}
+	}
+
+	log?.({
+		event: 'bridge_read_cache_wait_timeout',
+		cacheKind,
+		waitMs: Date.now() - startedAt,
+	});
+	return read();
+};


### PR DESCRIPTION
## Summary

- Add Redis SETNX single-flight coordination around cold bridge read cache misses for availability dates and slots.
- Keep the existing cache-aside success semantics: successful reads are cached with the existing full/empty TTLs, failed bridge reads are not cached.
- Log cache hits, wait completions, timeouts, and cache/lock errors with the existing request context so K8s operators can distinguish duplicate scrape prevention from degraded fallthrough.

## Root Cause

The K8s bridge has two replicas. The bridge read cache was cache-aside only, so concurrent cold requests for the same slot/date key could both miss Redis and both drive Acuity. Live logs showed two pods reading service 53178494 / 2026-05-03 within two seconds: one completed in about 6.4s while the duplicate completed in about 14.3s.

## Validation

- pnpm typecheck
- pnpm test
- pnpm build
- pnpm check:release-metadata
- pnpm check:package
