### PR TITLE
[codex] tune bridge read cache wait budget

### DIFF
--- a/src/shared/bridge-read-cache.test.ts
+++ b/src/shared/bridge-read-cache.test.ts
@@ -1,118 +1,135 @@
-import IORedisMock from 'ioredis-mock';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import IORedisMock from "ioredis-mock";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-	runBridgeReadCached,
-	type BridgeReadCacheClient,
-	type BridgeReadCacheEvent,
-} from './bridge-read-cache.js';
+  BRIDGE_READ_CACHE_DEFAULTS,
+  runBridgeReadCached,
+  type BridgeReadCacheClient,
+  type BridgeReadCacheEvent,
+} from "./bridge-read-cache.js";
 
-describe('runBridgeReadCached', () => {
-	let mock: IORedisMock;
-	let events: BridgeReadCacheEvent[];
+describe("runBridgeReadCached", () => {
+  let mock: IORedisMock;
+  let events: BridgeReadCacheEvent[];
 
-	beforeEach(async () => {
-		mock = new IORedisMock();
-		await mock.flushall();
-		events = [];
-	});
+  beforeEach(async () => {
+    mock = new IORedisMock();
+    await mock.flushall();
+    events = [];
+  });
 
-	const run = <A>(
-		key: string,
-		read: () => Promise<{ ok: true; value: A } | { ok: false; error: Error }>,
-	) =>
-		runBridgeReadCached({
-			redisClient: mock as unknown as BridgeReadCacheClient,
-			cacheKind: 'availability_slots',
-			cacheKey: key,
-			ttlSeconds: 60,
-			emptyTtlSeconds: 10,
-			read,
-			log: (event) => events.push(event),
-			waitTimeoutMs: 1000,
-			pollIntervalMs: 10,
-		});
+  const run = <A>(
+    key: string,
+    read: () => Promise<{ ok: true; value: A } | { ok: false; error: Error }>,
+  ) =>
+    runBridgeReadCached({
+      redisClient: mock as unknown as BridgeReadCacheClient,
+      cacheKind: "availability_slots",
+      cacheKey: key,
+      ttlSeconds: 60,
+      emptyTtlSeconds: 10,
+      read,
+      log: (event) => events.push(event),
+      waitTimeoutMs: 1000,
+      pollIntervalMs: 10,
+    });
 
-	it('returns a cached value without running the bridge read', async () => {
-		await mock.set('slot-key', JSON.stringify([{ datetime: '2026-05-03T14:00:00' }]));
-		const read = vi.fn(async () => ({
-			ok: true as const,
-			value: [{ datetime: 'fresh' }],
-		}));
+  it("returns a cached value without running the bridge read", async () => {
+    await mock.set(
+      "slot-key",
+      JSON.stringify([{ datetime: "2026-05-03T14:00:00" }]),
+    );
+    const read = vi.fn(async () => ({
+      ok: true as const,
+      value: [{ datetime: "fresh" }],
+    }));
 
-		const result = await run('slot-key', read);
+    const result = await run("slot-key", read);
 
-		expect(result).toEqual({
-			ok: true,
-			value: [{ datetime: '2026-05-03T14:00:00' }],
-		});
-		expect(read).not.toHaveBeenCalled();
-		expect(events.map((event) => event.event)).toContain('bridge_read_cache_hit');
-	});
+    expect(result).toEqual({
+      ok: true,
+      value: [{ datetime: "2026-05-03T14:00:00" }],
+    });
+    expect(read).not.toHaveBeenCalled();
+    expect(events.map((event) => event.event)).toContain(
+      "bridge_read_cache_hit",
+    );
+  });
 
-	it('single-flights concurrent misses so only one caller reads Acuity', async () => {
-		let calls = 0;
-		const read = vi.fn(async () => {
-			calls += 1;
-			await new Promise((resolve) => setTimeout(resolve, 120));
-			return {
-				ok: true as const,
-				value: [{ datetime: `2026-05-03T14:0${calls}:00` }],
-			};
-		});
+  it("single-flights concurrent misses so only one caller reads Acuity", async () => {
+    let calls = 0;
+    const read = vi.fn(async () => {
+      calls += 1;
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      return {
+        ok: true as const,
+        value: [{ datetime: `2026-05-03T14:0${calls}:00` }],
+      };
+    });
 
-		const results = await Promise.all(
-			Array.from({ length: 5 }, () => run('shared-slot-key', read)),
-		);
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => run("shared-slot-key", read)),
+    );
 
-		expect(read).toHaveBeenCalledTimes(1);
-		expect(results).toEqual(
-			Array.from({ length: 5 }, () => ({
-				ok: true,
-				value: [{ datetime: '2026-05-03T14:01:00' }],
-			})),
-		);
-		expect(events.map((event) => event.event)).toContain('bridge_read_cache_wait');
-		expect(await mock.get('lock:shared-slot-key')).toBeNull();
-	});
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(results).toEqual(
+      Array.from({ length: 5 }, () => ({
+        ok: true,
+        value: [{ datetime: "2026-05-03T14:01:00" }],
+      })),
+    );
+    expect(events.map((event) => event.event)).toContain(
+      "bridge_read_cache_wait",
+    );
+    expect(await mock.get("lock:shared-slot-key")).toBeNull();
+  });
 
-	it('does not cache failed bridge reads', async () => {
-		const error = new Error('acuity failed');
-		const read = vi.fn(async () => ({ ok: false as const, error }));
+  it("keeps the default wait budget above the observed Acuity cold-read envelope", () => {
+    expect(BRIDGE_READ_CACHE_DEFAULTS.waitTimeoutMs).toBeGreaterThanOrEqual(
+      35_000,
+    );
+    expect(BRIDGE_READ_CACHE_DEFAULTS.lockTtlMs).toBeGreaterThan(
+      BRIDGE_READ_CACHE_DEFAULTS.waitTimeoutMs,
+    );
+  });
 
-		const result = await run('failed-slot-key', read);
+  it("does not cache failed bridge reads", async () => {
+    const error = new Error("acuity failed");
+    const read = vi.fn(async () => ({ ok: false as const, error }));
 
-		expect(result).toEqual({ ok: false, error });
-		expect(await mock.get('failed-slot-key')).toBeNull();
-		expect(await mock.get('lock:failed-slot-key')).toBeNull();
-	});
+    const result = await run("failed-slot-key", read);
 
-	it('falls through when the single-flight winner does not publish before the wait budget', async () => {
-		await mock.set('lock:slow-slot-key', 'winner-token', 'PX', 30_000, 'NX');
-		const read = vi.fn(async () => ({
-			ok: true as const,
-			value: [{ datetime: '2026-05-04T15:00:00' }],
-		}));
+    expect(result).toEqual({ ok: false, error });
+    expect(await mock.get("failed-slot-key")).toBeNull();
+    expect(await mock.get("lock:failed-slot-key")).toBeNull();
+  });
 
-		const result = await runBridgeReadCached({
-			redisClient: mock as unknown as BridgeReadCacheClient,
-			cacheKind: 'availability_slots',
-			cacheKey: 'slow-slot-key',
-			ttlSeconds: 60,
-			emptyTtlSeconds: 10,
-			read,
-			log: (event) => events.push(event),
-			waitTimeoutMs: 30,
-			pollIntervalMs: 5,
-		});
+  it("falls through when the single-flight winner does not publish before the wait budget", async () => {
+    await mock.set("lock:slow-slot-key", "winner-token", "PX", 30_000, "NX");
+    const read = vi.fn(async () => ({
+      ok: true as const,
+      value: [{ datetime: "2026-05-04T15:00:00" }],
+    }));
 
-		expect(result).toEqual({
-			ok: true,
-			value: [{ datetime: '2026-05-04T15:00:00' }],
-		});
-		expect(read).toHaveBeenCalledTimes(1);
-		expect(events.map((event) => event.event)).toContain(
-			'bridge_read_cache_wait_timeout',
-		);
-	});
+    const result = await runBridgeReadCached({
+      redisClient: mock as unknown as BridgeReadCacheClient,
+      cacheKind: "availability_slots",
+      cacheKey: "slow-slot-key",
+      ttlSeconds: 60,
+      emptyTtlSeconds: 10,
+      read,
+      log: (event) => events.push(event),
+      waitTimeoutMs: 30,
+      pollIntervalMs: 5,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: [{ datetime: "2026-05-04T15:00:00" }],
+    });
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(events.map((event) => event.event)).toContain(
+      "bridge_read_cache_wait_timeout",
+    );
+  });
 });

--- a/src/shared/bridge-read-cache.ts
+++ b/src/shared/bridge-read-cache.ts
@@ -1,45 +1,51 @@
-import { randomBytes } from 'node:crypto';
+import { randomBytes } from "node:crypto";
 
 export interface BridgeReadCacheClient {
-	get(key: string): Promise<string | null>;
-	set(key: string, value: string, ...args: Array<string | number>): Promise<unknown>;
-	eval(script: string, numKeys: number, ...args: string[]): Promise<unknown>;
+  get(key: string): Promise<string | null>;
+  set(
+    key: string,
+    value: string,
+    ...args: Array<string | number>
+  ): Promise<unknown>;
+  eval(script: string, numKeys: number, ...args: string[]): Promise<unknown>;
 }
 
 export type BridgeReadResult<A, E> =
-	| { ok: true; value: A }
-	| { ok: false; error: E };
+  | { ok: true; value: A }
+  | { ok: false; error: E };
 
 export interface BridgeReadCacheEvent {
-	readonly event:
-		| 'bridge_read_cache_hit'
-		| 'bridge_read_cache_wait'
-		| 'bridge_read_cache_wait_timeout'
-		| 'bridge_read_cache_get_failed'
-		| 'bridge_read_cache_set_failed'
-		| 'bridge_read_cache_lock_failed'
-		| 'bridge_read_cache_unlock_failed';
-	readonly cacheKind: string;
-	readonly waitMs?: number;
-	readonly error?: unknown;
+  readonly event:
+    | "bridge_read_cache_hit"
+    | "bridge_read_cache_wait"
+    | "bridge_read_cache_wait_timeout"
+    | "bridge_read_cache_get_failed"
+    | "bridge_read_cache_set_failed"
+    | "bridge_read_cache_lock_failed"
+    | "bridge_read_cache_unlock_failed";
+  readonly cacheKind: string;
+  readonly waitMs?: number;
+  readonly error?: unknown;
 }
 
 export interface RunBridgeReadCachedOptions<A, E> {
-	readonly redisClient: BridgeReadCacheClient | null;
-	readonly cacheKind: string;
-	readonly cacheKey: string;
-	readonly ttlSeconds: number;
-	readonly emptyTtlSeconds: number;
-	readonly read: () => Promise<BridgeReadResult<A, E>>;
-	readonly log?: (event: BridgeReadCacheEvent) => void;
-	readonly lockTtlMs?: number;
-	readonly waitTimeoutMs?: number;
-	readonly pollIntervalMs?: number;
+  readonly redisClient: BridgeReadCacheClient | null;
+  readonly cacheKind: string;
+  readonly cacheKey: string;
+  readonly ttlSeconds: number;
+  readonly emptyTtlSeconds: number;
+  readonly read: () => Promise<BridgeReadResult<A, E>>;
+  readonly log?: (event: BridgeReadCacheEvent) => void;
+  readonly lockTtlMs?: number;
+  readonly waitTimeoutMs?: number;
+  readonly pollIntervalMs?: number;
 }
 
-const LOCK_TTL_MS = 30_000;
-const WAIT_TIMEOUT_MS = 12_000;
-const POLL_INTERVAL_MS = 50;
+export const BRIDGE_READ_CACHE_DEFAULTS = {
+  lockTtlMs: 60_000,
+  waitTimeoutMs: 35_000,
+  pollIntervalMs: 50,
+} as const;
 
 const LUA_CAS_DEL = `
 if redis.call("GET", KEYS[1]) == ARGV[1] then
@@ -51,117 +57,118 @@ end`;
 const lockKey = (key: string): string => `lock:${key}`;
 
 const delay = (ms: number): Promise<void> =>
-	new Promise((resolve) => setTimeout(resolve, ms));
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 const readCached = async <A>(
-	client: BridgeReadCacheClient,
-	cacheKey: string,
+  client: BridgeReadCacheClient,
+  cacheKey: string,
 ): Promise<A | undefined> => {
-	const raw = await client.get(cacheKey);
-	return raw ? (JSON.parse(raw) as A) : undefined;
+  const raw = await client.get(cacheKey);
+  return raw ? (JSON.parse(raw) as A) : undefined;
 };
 
 const writeCached = async <A>(
-	client: BridgeReadCacheClient,
-	cacheKey: string,
-	value: A,
-	ttlSeconds: number,
+  client: BridgeReadCacheClient,
+  cacheKey: string,
+  value: A,
+  ttlSeconds: number,
 ): Promise<void> => {
-	await client.set(cacheKey, JSON.stringify(value), 'EX', ttlSeconds);
+  await client.set(cacheKey, JSON.stringify(value), "EX", ttlSeconds);
 };
 
 const valueTtlSeconds = <A>(
-	value: A,
-	ttlSeconds: number,
-	emptyTtlSeconds: number,
+  value: A,
+  ttlSeconds: number,
+  emptyTtlSeconds: number,
 ): number =>
-	Array.isArray(value) && value.length === 0 ? emptyTtlSeconds : ttlSeconds;
+  Array.isArray(value) && value.length === 0 ? emptyTtlSeconds : ttlSeconds;
 
 export const runBridgeReadCached = async <A, E>({
-	redisClient,
-	cacheKind,
-	cacheKey,
-	ttlSeconds,
-	emptyTtlSeconds,
-	read,
-	log,
-	lockTtlMs = LOCK_TTL_MS,
-	waitTimeoutMs = WAIT_TIMEOUT_MS,
-	pollIntervalMs = POLL_INTERVAL_MS,
+  redisClient,
+  cacheKind,
+  cacheKey,
+  ttlSeconds,
+  emptyTtlSeconds,
+  read,
+  log,
+  lockTtlMs = BRIDGE_READ_CACHE_DEFAULTS.lockTtlMs,
+  waitTimeoutMs = BRIDGE_READ_CACHE_DEFAULTS.waitTimeoutMs,
+  pollIntervalMs = BRIDGE_READ_CACHE_DEFAULTS.pollIntervalMs,
 }: RunBridgeReadCachedOptions<A, E>): Promise<BridgeReadResult<A, E>> => {
-	if (!redisClient) return read();
+  if (!redisClient) return read();
 
-	try {
-		const cached = await readCached<A>(redisClient, cacheKey);
-		if (cached !== undefined) {
-			log?.({ event: 'bridge_read_cache_hit', cacheKind });
-			return { ok: true, value: cached };
-		}
-	} catch (error) {
-		log?.({ event: 'bridge_read_cache_get_failed', cacheKind, error });
-		return read();
-	}
+  try {
+    const cached = await readCached<A>(redisClient, cacheKey);
+    if (cached !== undefined) {
+      log?.({ event: "bridge_read_cache_hit", cacheKind });
+      return { ok: true, value: cached };
+    }
+  } catch (error) {
+    log?.({ event: "bridge_read_cache_get_failed", cacheKind, error });
+    return read();
+  }
 
-	const token = randomBytes(16).toString('hex');
-	const keyLock = lockKey(cacheKey);
-	let acquired = false;
-	try {
-		acquired = (await redisClient.set(keyLock, token, 'PX', lockTtlMs, 'NX')) === 'OK';
-	} catch (error) {
-		log?.({ event: 'bridge_read_cache_lock_failed', cacheKind, error });
-		return read();
-	}
+  const token = randomBytes(16).toString("hex");
+  const keyLock = lockKey(cacheKey);
+  let acquired = false;
+  try {
+    acquired =
+      (await redisClient.set(keyLock, token, "PX", lockTtlMs, "NX")) === "OK";
+  } catch (error) {
+    log?.({ event: "bridge_read_cache_lock_failed", cacheKind, error });
+    return read();
+  }
 
-	if (acquired) {
-		try {
-			const result = await read();
-			if (!result.ok) return result;
+  if (acquired) {
+    try {
+      const result = await read();
+      if (!result.ok) return result;
 
-			try {
-				await writeCached(
-					redisClient,
-					cacheKey,
-					result.value,
-					valueTtlSeconds(result.value, ttlSeconds, emptyTtlSeconds),
-				);
-			} catch (error) {
-				log?.({ event: 'bridge_read_cache_set_failed', cacheKind, error });
-			}
+      try {
+        await writeCached(
+          redisClient,
+          cacheKey,
+          result.value,
+          valueTtlSeconds(result.value, ttlSeconds, emptyTtlSeconds),
+        );
+      } catch (error) {
+        log?.({ event: "bridge_read_cache_set_failed", cacheKind, error });
+      }
 
-			return result;
-		} finally {
-			try {
-				await redisClient.eval(LUA_CAS_DEL, 1, keyLock, token);
-			} catch (error) {
-				log?.({ event: 'bridge_read_cache_unlock_failed', cacheKind, error });
-			}
-		}
-	}
+      return result;
+    } finally {
+      try {
+        await redisClient.eval(LUA_CAS_DEL, 1, keyLock, token);
+      } catch (error) {
+        log?.({ event: "bridge_read_cache_unlock_failed", cacheKind, error });
+      }
+    }
+  }
 
-	const startedAt = Date.now();
-	const deadline = startedAt + waitTimeoutMs;
-	while (Date.now() < deadline) {
-		await delay(pollIntervalMs);
-		try {
-			const cached = await readCached<A>(redisClient, cacheKey);
-			if (cached !== undefined) {
-				log?.({
-					event: 'bridge_read_cache_wait',
-					cacheKind,
-					waitMs: Date.now() - startedAt,
-				});
-				return { ok: true, value: cached };
-			}
-		} catch (error) {
-			log?.({ event: 'bridge_read_cache_get_failed', cacheKind, error });
-			break;
-		}
-	}
+  const startedAt = Date.now();
+  const deadline = startedAt + waitTimeoutMs;
+  while (Date.now() < deadline) {
+    await delay(pollIntervalMs);
+    try {
+      const cached = await readCached<A>(redisClient, cacheKey);
+      if (cached !== undefined) {
+        log?.({
+          event: "bridge_read_cache_wait",
+          cacheKind,
+          waitMs: Date.now() - startedAt,
+        });
+        return { ok: true, value: cached };
+      }
+    } catch (error) {
+      log?.({ event: "bridge_read_cache_get_failed", cacheKind, error });
+      break;
+    }
+  }
 
-	log?.({
-		event: 'bridge_read_cache_wait_timeout',
-		cacheKind,
-		waitMs: Date.now() - startedAt,
-	});
-	return read();
+  log?.({
+    event: "bridge_read_cache_wait_timeout",
+    cacheKind,
+    waitMs: Date.now() - startedAt,
+  });
+  return read();
 };


### PR DESCRIPTION
## Summary
- raise the Redis single-flight bridge read lock TTL to 60s
- raise the loser wait budget to 35s so observed long Acuity cold reads publish before duplicate fallthrough
- make the cache defaults explicit and covered by package tests

## Root cause
The first single-flight fix prevented duplicate reads only when the winner finished inside the previous 12s wait budget. Live app probing showed an Acuity cold slot read could exceed that, causing the loser to wait 12s and then start a second browser read.

## Validation
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm check:release-metadata
- pnpm check:package
- pnpm exec prettier --check src/shared/bridge-read-cache.ts src/shared/bridge-read-cache.test.ts
- git diff --check

Live proof before this patch: direct bridge concurrent slot requests on 2026-10-08 returned in ~9.3s with one slot_read_profile and one bridge_read_cache_wait. App-level probing against a longer 2026-10-07 cold read showed the previous 12s wait budget was still too short for the long tail.