### PR TITLE
chore: align bridge with scheduling-kit 0.7.5

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.5",
+    version = "0.4.6",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.5",
+    version = "0.4.6",
     compatibility_level = 1,
 )
 
@@ -46,7 +46,7 @@ bazel_dep(name = "aspect_rules_swc", version = "2.6.1")
 # =============================================================================
 
 # Primary dependency: scheduling-kit (peer; bridge orchestrates over kit's adapters).
-bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.4")
+bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.5")
 
 # Auth surface (payment capability types come through tinyland-auth).
 bazel_dep(name = "tummycrypt_tinyland_auth", version = "0.3.0")

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.4.5`
-- Bazel module version: `0.4.5`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.5`
+- package version: `0.4.6`
+- Bazel module version: `0.4.6`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.6`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
@@ -50,7 +50,7 @@
     "paper:dev": "node docs/paper/watch.mjs"
   },
   "dependencies": {
-    "@tummycrypt/scheduling-kit": "^0.7.4",
+    "@tummycrypt/scheduling-kit": "^0.7.5",
     "effect": "^3.19.14",
     "ioredis": "^5",
     "playwright-core": "1.58.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@tummycrypt/scheduling-kit':
-        specifier: ^0.7.4
-        version: 0.7.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
+        specifier: ^0.7.5
+        version: 0.7.5(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
       effect:
         specifier: ^3.19.14
         version: 3.21.0
@@ -373,8 +373,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@tummycrypt/scheduling-kit@0.7.4':
-    resolution: {integrity: sha512-S0s0uAiZHyclY1S64Hw9EAuHDy47XyjDp+v0hHm8dia7w/NPhPwihMt/+w+vlN9YtiVRFk3AqY/vIrqi1GfzEQ==}
+  '@tummycrypt/scheduling-kit@0.7.5':
+    resolution: {integrity: sha512-8bS4PME3Z29tWYKqsyRHadJcGaY1hQHjTbeJvezL2VT7lWEaPQ0GbRuErGgnGFEE7Tdzo5OICuQHIubtNtr5LQ==}
     engines: {node: '>=20 <25'}
     peerDependencies:
       '@skeletonlabs/skeleton': ^4.0.0
@@ -1418,7 +1418,7 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tummycrypt/scheduling-kit@0.7.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
+  '@tummycrypt/scheduling-kit@0.7.5(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
     dependencies:
       '@tummycrypt/tinyland-auth-pg': 0.2.4(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)
       drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(pg@8.20.0)


### PR DESCRIPTION
## Summary
- bump @tummycrypt/scheduling-bridge metadata to 0.4.6
- align npm dependency and Bazel inter-module edge to @tummycrypt/scheduling-kit 0.7.5
- refresh lockfile and generated repo facts

## Validation
- pnpm check:release-metadata
- pnpm check:artifact-authority
- pnpm check:package
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm docs:check
- git diff --check

## Notes
- `pnpm docs:build` requires MkDocs. Plain shell failed because `mkdocs` is missing; `nix develop -c pnpm docs:build` began building MkDocs dependencies but stalled with remote builder/cache warnings, so I interrupted it after the generated-doc check passed.