### PR TITLE
[codex] document k8s bridge as next production route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,13 +52,13 @@ As of `2026-04-25`, the active structural work here is:
 
 Operationally relevant truth:
 
-- the pending package metadata on this branch is `@tummycrypt/scheduling-bridge`
-  `0.4.5`
-- `0.4.5` depends on `@tummycrypt/scheduling-kit ^0.7.4`
-- as of `2026-04-30`, npm `latest` and git tag `v0.4.5` point at `0.4.5`;
-  deployed bridge runtime tuple remains a separate verification surface
-- package metadata, git tags, npm dist-tags, and GitHub releases are separate
-  authority surfaces until `#76` is resolved
+- current package metadata is `@tummycrypt/scheduling-bridge` `0.4.6`
+- `0.4.6` depends on `@tummycrypt/scheduling-kit ^0.7.5`
+- as of `2026-05-02`, npm `latest`, git tag `v0.4.6`, and the K8s bridge
+  shadow runtime are aligned on the `0.4.6` release edge
+- package metadata, git tags, npm dist-tags, GitHub releases, and deployed
+  bridge runtime tuples remain separate authority surfaces and should be
+  verified explicitly
 
 ## Deployment Truth
 
@@ -70,10 +70,12 @@ bridge, not as "Modal", unless they are discussing the Modal deployment itself.
 
 Current provider truth:
 
-- Modal remains the current live primary remote bridge surface until `TIN-189`
-  closes and the K8s parity bake is accepted.
-- K8s is an active shadow and next-primary execution lane, but cluster state,
-  tailnet exposure, and public-edge routing are infrastructure concerns.
+- K8s/container execution is the accepted next-production bridge route and is
+  the current K8s shadow runtime for MassageIthaca scheduling-bridge traffic.
+- Modal remains legacy proofing/fallback context, and may still serve stable
+  live consumer traffic until that traffic is deliberately moved to K8s.
+- Cluster state, tailnet exposure, and public-edge routing are infrastructure
+  concerns outside this repo.
 - Docker/container execution must mirror the same built Node entrypoint so K8s
   and other providers do not become separate runtime implementations.
 - Downstream apps should configure bridge endpoints with
@@ -82,18 +84,20 @@ Current provider truth:
 
 ### Modal
 
-Modal is the current live primary remote deployment surface.
+Modal is the legacy proofing/fallback remote deployment surface.
 
 Important facts:
 
 - the deployed server should run `dist/server/handler.js`
 - the Modal image must stay aligned with the same built artifact used by `pnpm start`
 - warm-container behavior and concurrency settings are part of the real latency story
+- Modal-specific docs and workflows are retained until fallback/live-beta
+  traffic is retired deliberately
 
 ### Docker / K8s Container
 
-Docker and K8s containers should mirror the same entrypoint and runtime
-assumptions as Modal.
+Docker and K8s containers should mirror the same `dist/server/handler.js`
+entrypoint and runtime assumptions as every other provider.
 
 If Modal, Docker, and K8s drift from the actual Node entrypoint, that is an
 operational bug.

--- a/README.md
+++ b/README.md
@@ -108,11 +108,13 @@ The bridge emits NDJSON logs to stdout/stderr for runtime analysis.
 ### Runtime Provider Truth
 
 The stable bridge contract is the Node HTTP server, protocol surface, and
-`/health` tuple. Modal is the current live primary deployment provider, but it
-is not the name of the consumer contract.
+`/health` tuple. Provider names are deployment details, not the consumer
+contract.
 
-- Current live primary: Modal, until the `TIN-189` K8s parity bake is accepted.
-- Active next-primary lane: K8s/container runtime managed from infrastructure.
+- Accepted next-production route: K8s/container runtime managed from
+  infrastructure.
+- Current fallback/proofing provider: Modal, retained until remaining stable
+  consumer traffic is deliberately moved.
 - Compatibility target: Docker image with the same `dist/server/handler.js`
   entrypoint.
 - Consumer apps should configure the remote bridge with
@@ -157,9 +159,9 @@ docker run -p 3001:3001 \
 modal deploy modal-app.py
 ```
 
-#### Supported deployment path
+#### Supported fallback deployment path
 
-The current Modal deployment path for the live Acuity bridge is:
+The Modal deployment path remains available for fallback/proofing traffic:
 
 1. merge to `main`
 2. let `.github/workflows/deploy-modal.yml` deploy `modal-app.py`
@@ -169,7 +171,8 @@ The current Modal deployment path for the live Acuity bridge is:
 
 Operationally, this means:
 
-- Modal deployment is part of release truth, not a side channel
+- Modal deployment can be part of release truth when it is the selected
+  provider, not a side channel
 - the live bridge should be identified by the `/health` release + protocol tuple
 - downstream apps should validate the tuple they expect before making rollout claims
 
@@ -197,8 +200,10 @@ The current publish + deploy shape is:
 2. Bazel validates/builds the publishable artifact
 3. CI dry-runs the extracted Bazel package surface before release
 4. GitHub Actions publishes that extracted artifact
-5. GitHub Actions deploys the current Modal runtime from `main`
-6. downstream apps consume the published package and verify the live runtime
+5. GitHub Actions can deploy the Modal fallback runtime from `main`
+6. infrastructure can deploy the K8s/container runtime from the same package
+   artifact and image entrypoint
+7. downstream apps consume the published package and verify the live runtime
    tuple via `/health`
 
 This repo is the sole owner of Acuity automation concerns. App repos and shared

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -53,9 +53,10 @@ runtime image, and package CI must prove both supported consumer majors.
 
 ## Runtime Provider Policy
 
-Modal is the current live primary bridge provider until `TIN-189` closes and the
-K8s parity bake is accepted. K8s/container execution is the active next-primary
-lane, but it must consume the same materialized package and launch the same
+K8s/container execution is the accepted next-production bridge route. Modal
+remains legacy proofing/fallback context, and may still serve stable live
+consumer traffic until that traffic is deliberately moved. Every provider must
+consume the same materialized package and launch the same
 `dist/server/handler.js` entrypoint. Provider-specific deployment mechanics
 must not fork the bridge protocol or package artifact.
 
@@ -83,7 +84,8 @@ Before cutting a bridge release, verify these surfaces together:
 - GitHub Packages package: `@jesssullivan/scheduling-bridge`
 - tag and GitHub release for the package version
 - Bazel package artifact from `./bazel-bin/pkg`
-- Docker and Modal runtime images built from the materialized `pkg/` surface
+- Docker, K8s/container, and Modal fallback runtime images built from the
+  materialized `pkg/` surface
 - `/health` release tuple for the deployed bridge
 
 The shared `js-bazel-package` workflow owns npm provenance when running on

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -41,8 +41,8 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Runtime Provider Truth
 
 - provider-agnostic contract: Node HTTP server plus `/health` tuple
-- current live primary provider: Modal, until `TIN-189` closes
-- active next-primary lane: K8s/container runtime from infrastructure
+- accepted next-production provider: K8s/container runtime from infrastructure
+- fallback/proofing provider: Modal, until remaining live traffic moves
 - forward consumer env names: `SCHEDULING_BRIDGE_URL` and
   `SCHEDULING_BRIDGE_AUTH_TOKEN`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@
 `scheduling-bridge` is the remote Acuity automation service published as
 `@tummycrypt/scheduling-bridge`.
 
-The repo owns browser automation, HTTP bridge endpoints, Modal and Docker
-runtime surfaces, K8s/container runtime packaging, and the bridge runtime truth
-exposed by `/health`.
+The repo owns browser automation, HTTP bridge endpoints, Docker and
+K8s/container runtime packaging, Modal fallback/proofing runtime support, and
+the bridge runtime truth exposed by `/health`.
 
 It does not own app deployment, business-specific UI, or reusable
 backend-agnostic checkout components. It also does not own cluster state or
@@ -17,8 +17,9 @@ public-edge routing. Those are consumer app, infrastructure, and
 - Bazel `//:pkg` builds the publishable package artifact.
 - `pnpm build` materializes local `pkg/` and `dist/` from `bazel-bin/pkg`.
 - CI and publish workflows extract `./bazel-bin/pkg`.
-- Modal, Docker, and K8s/container runtimes consume the materialized `pkg/`
-  artifact rather than rebuilding from source inside runtime images.
-- Modal is the current live primary provider; K8s is the active next-primary
-  lane until `TIN-189` closes.
+- Docker, K8s/container, and Modal fallback runtimes consume the materialized
+  `pkg/` artifact rather than rebuilding from source inside runtime images.
+- K8s/container execution is the accepted next-production bridge route; Modal
+  remains legacy proofing/fallback context until remaining live consumer traffic
+  is deliberately moved.
 - Generated facts live in `docs/generated/repo-facts.md`.

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -20,9 +20,11 @@ both when claims depend on the live bridge.
 The bridge contract is provider-agnostic: a Node HTTP server exposing the
 protocol endpoints and `/health` tuple.
 
-- Modal is the current live primary remote provider until `TIN-189` closes and
-  the K8s parity bake is accepted.
-- K8s/container execution is the active next-primary lane, managed by the
+- K8s/container execution is the accepted next-production bridge route and is
+  the current MassageIthaca K8s shadow runtime.
+- Modal remains legacy proofing/fallback context, and may still serve stable
+  live consumer traffic until that traffic is deliberately moved.
+- Provider state, tailnet exposure, and public-edge routing are managed by the
   infrastructure repo.
 - Docker is the local/container compatibility target and must mirror the same
   `dist/server/handler.js` entrypoint.

--- a/llms.txt
+++ b/llms.txt
@@ -12,8 +12,8 @@ Authority:
 - CI and publish extract `./bazel-bin/pkg` / `./bazel-bin/pkg`
 - runtime start command is `node dist/server/handler.js`
 - provider-agnostic runtime contract is the Node HTTP server plus `/health` tuple
-- Modal is the current live primary provider until `TIN-189` closes
-- K8s/container execution is the active next-primary lane from infrastructure
+- K8s/container execution is the accepted next-production provider from infrastructure
+- Modal remains fallback/proofing context until remaining live traffic moves
 - consumer apps should use `SCHEDULING_BRIDGE_URL` and `SCHEDULING_BRIDGE_AUTH_TOKEN`
 
 Toolchains:

--- a/scripts/generate-doc-surfaces.mjs
+++ b/scripts/generate-doc-surfaces.mjs
@@ -185,8 +185,8 @@ This page is generated from \`package.json\`, \`MODULE.bazel\`, \`BUILD.bazel\`,
 ## Runtime Provider Truth
 
 - provider-agnostic contract: Node HTTP server plus \`/health\` tuple
-- current live primary provider: Modal, until \`TIN-189\` closes
-- active next-primary lane: K8s/container runtime from infrastructure
+- accepted next-production provider: K8s/container runtime from infrastructure
+- fallback/proofing provider: Modal, until remaining live traffic moves
 - forward consumer env names: \`SCHEDULING_BRIDGE_URL\` and
   \`SCHEDULING_BRIDGE_AUTH_TOKEN\`
 
@@ -229,8 +229,8 @@ const llms = [
   `- CI and publish extract \`${ciPackageDir}\` / \`${publishPackageDir}\``,
   `- runtime start command is \`${pkg.scripts.start}\``,
   '- provider-agnostic runtime contract is the Node HTTP server plus `/health` tuple',
-  '- Modal is the current live primary provider until `TIN-189` closes',
-  '- K8s/container execution is the active next-primary lane from infrastructure',
+  '- K8s/container execution is the accepted next-production provider from infrastructure',
+  '- Modal remains fallback/proofing context until remaining live traffic moves',
   '- consumer apps should use `SCHEDULING_BRIDGE_URL` and `SCHEDULING_BRIDGE_AUTH_TOKEN`',
   '',
   'Toolchains:',


### PR DESCRIPTION
## Summary
- update runtime/provider docs so K8s/container execution is the accepted next-production bridge route
- keep Modal documented as fallback/proofing context rather than the forward consumer contract
- refresh generated repo facts and llms.txt from the doc generator

## Validation
- pnpm docs:generate
- pnpm docs:check
- pnpm check:release-metadata
- uvx --with mkdocs-material mkdocs build --strict
- git diff --check

Note: direct `pnpm docs:build` outside the repo dev shell failed because `mkdocs` was not on PATH in the bare worktree; the strict MkDocs build was rerun successfully through `uvx --with mkdocs-material`.