### PR TITLE
Instrument bridge read cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,10 @@ As of `2026-04-25`, the active structural work here is:
 
 Operationally relevant truth:
 
-- current package metadata is `@tummycrypt/scheduling-bridge` `0.4.6`
-- `0.4.6` depends on `@tummycrypt/scheduling-kit ^0.7.5`
+- current package metadata is `@tummycrypt/scheduling-bridge` `0.4.7`
+- `0.4.7` depends on `@tummycrypt/scheduling-kit ^0.7.5`
 - as of `2026-05-02`, npm `latest`, git tag `v0.4.6`, and the K8s bridge
-  shadow runtime are aligned on the `0.4.6` release edge
+  shadow runtime are aligned on the previous `0.4.6` release edge
 - package metadata, git tags, npm dist-tags, GitHub releases, and deployed
   bridge runtime tuples remain separate authority surfaces and should be
   verified explicitly

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.6",
+    version = "0.4.7",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.6",
+    version = "0.4.7",
     compatibility_level = 1,
 )
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.4.6`
-- Bazel module version: `0.4.6`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.6`
+- package version: `0.4.7`
+- Bazel module version: `0.4.7`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.7`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -47,6 +47,26 @@ const navigateForUrlRead = async (page: Page, url: URL, timeout: number): Promis
 	await page.waitForLoadState('networkidle', { timeout: Math.min(timeout, 5000) }).catch(() => {});
 };
 
+const postClickSlotSettleMs = (): number => {
+	const raw = Number(process.env.ACUITY_POST_CLICK_SLOT_SETTLE_MS);
+	return Number.isFinite(raw) && raw >= 0 ? raw : 900;
+};
+
+const waitForSlotUiAfterDateClick = async (
+	page: Page,
+	slotSelector: string,
+	timeout: number,
+): Promise<void> => {
+	const waitMs = Math.min(timeout, postClickSlotSettleMs());
+	if (waitMs <= 0) return;
+
+	await Promise.race([
+		page.waitForSelector(slotSelector, { timeout: waitMs }).then(() => undefined),
+		page.waitForLoadState('networkidle', { timeout: waitMs }).then(() => undefined).catch(() => undefined),
+		page.waitForTimeout(waitMs).then(() => undefined),
+	]).catch(() => undefined);
+};
+
 const navigateToServiceCalendar = (
 	page: Page,
 	url: URL,
@@ -207,6 +227,8 @@ export const readSlotsViaUrl = (
 		url.searchParams.set('appointmentType', serviceId);
 		url.searchParams.set('date', date);
 		const targetMonth = date.slice(0, 7);
+		const slotSelector = Selectors.timeSlot[0]; // button.time-selection
+		const fallbackSelector = Selectors.timeSlot.join(', ');
 
 		const navigationStartedAt = Date.now();
 		yield* navigateToServiceCalendar(page, url, config.timeout, 'read-slots');
@@ -244,14 +266,14 @@ export const readSlotsViaUrl = (
 								dateSelectMs = Date.now() - dateSelectStartedAt;
 								return false;
 							}
-							await tile.click({ timeout: Math.min(config.timeout, 5000) });
-							dateSelectMs = Date.now() - dateSelectStartedAt;
+								await tile.click({ timeout: Math.min(config.timeout, 5000) });
+								dateSelectMs = Date.now() - dateSelectStartedAt;
 
-							const settleStartedAt = Date.now();
-							await page.waitForTimeout(2000);
-							postClickSettleMs = Date.now() - settleStartedAt;
-							return true;
-						}
+								const settleStartedAt = Date.now();
+								await waitForSlotUiAfterDateClick(page, fallbackSelector, config.timeout);
+								postClickSettleMs = Date.now() - settleStartedAt;
+								return true;
+							}
 					}
 				}
 				dateSelectMs = Date.now() - dateSelectStartedAt;
@@ -288,10 +310,8 @@ export const readSlotsViaUrl = (
 			return [];
 		}
 
-		// Read time slots using the Selectors registry
-		const slotSelector = Selectors.timeSlot[0]; // button.time-selection
-		const fallbackSelector = Selectors.timeSlot.join(', ');
-		const slotWaitStartedAt = Date.now();
+			// Read time slots using the Selectors registry
+			const slotWaitStartedAt = Date.now();
 		yield* Effect.tryPromise({
 			try: () => page.waitForSelector(fallbackSelector, { timeout: 10000 }),
 			catch: () => null,

--- a/src/shared/bridge-read-cache.test.ts
+++ b/src/shared/bridge-read-cache.test.ts
@@ -7,6 +7,7 @@ import {
   type BridgeReadCacheClient,
   type BridgeReadCacheEvent,
 } from "./bridge-read-cache.js";
+import { metrics } from "./metrics.js";
 
 describe("runBridgeReadCached", () => {
   let mock: IORedisMock;
@@ -34,6 +35,17 @@ describe("runBridgeReadCached", () => {
       pollIntervalMs: 10,
     });
 
+  const metricCount = async (event: string): Promise<number> => {
+    const snap = await metrics.bridgeReadCacheEventsTotal.get();
+    return (
+      snap.values.find(
+        (value) =>
+          value.labels.cache_kind === "availability_slots" &&
+          value.labels.event === event,
+      )?.value ?? 0
+    );
+  };
+
   it("returns a cached value without running the bridge read", async () => {
     await mock.set(
       "slot-key",
@@ -43,6 +55,7 @@ describe("runBridgeReadCached", () => {
       ok: true as const,
       value: [{ datetime: "fresh" }],
     }));
+    const beforeHitCount = await metricCount("hit");
 
     const result = await run("slot-key", read);
 
@@ -54,6 +67,7 @@ describe("runBridgeReadCached", () => {
     expect(events.map((event) => event.event)).toContain(
       "bridge_read_cache_hit",
     );
+    expect(await metricCount("hit")).toBe(beforeHitCount + 1);
   });
 
   it("single-flights concurrent misses so only one caller reads Acuity", async () => {
@@ -66,6 +80,7 @@ describe("runBridgeReadCached", () => {
         value: [{ datetime: `2026-05-03T14:0${calls}:00` }],
       };
     });
+    const beforeWaitHitCount = await metricCount("wait_hit");
 
     const results = await Promise.all(
       Array.from({ length: 5 }, () => run("shared-slot-key", read)),
@@ -81,6 +96,7 @@ describe("runBridgeReadCached", () => {
     expect(events.map((event) => event.event)).toContain(
       "bridge_read_cache_wait",
     );
+    expect(await metricCount("wait_hit")).toBeGreaterThan(beforeWaitHitCount);
     expect(await mock.get("lock:shared-slot-key")).toBeNull();
   });
 

--- a/src/shared/bridge-read-cache.ts
+++ b/src/shared/bridge-read-cache.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { metrics } from "./metrics.js";
 
 export interface BridgeReadCacheClient {
   get(key: string): Promise<string | null>;
@@ -95,18 +96,30 @@ export const runBridgeReadCached = async <A, E>({
   waitTimeoutMs = BRIDGE_READ_CACHE_DEFAULTS.waitTimeoutMs,
   pollIntervalMs = BRIDGE_READ_CACHE_DEFAULTS.pollIntervalMs,
 }: RunBridgeReadCachedOptions<A, E>): Promise<BridgeReadResult<A, E>> => {
-  if (!redisClient) return read();
+  const record = (event: string): void => {
+    metrics.recordBridgeReadCacheEvent(cacheKind, event);
+  };
+  const observeRead = (): Promise<BridgeReadResult<A, E>> =>
+    metrics.observeBridgeRead(cacheKind, read);
+
+  if (!redisClient) {
+    record("bypass");
+    return observeRead();
+  }
 
   try {
     const cached = await readCached<A>(redisClient, cacheKey);
     if (cached !== undefined) {
+      record("hit");
       log?.({ event: "bridge_read_cache_hit", cacheKind });
       return { ok: true, value: cached };
     }
   } catch (error) {
+    record("get_failed");
     log?.({ event: "bridge_read_cache_get_failed", cacheKind, error });
-    return read();
+    return observeRead();
   }
+  record("miss");
 
   const token = randomBytes(16).toString("hex");
   const keyLock = lockKey(cacheKey);
@@ -115,13 +128,15 @@ export const runBridgeReadCached = async <A, E>({
     acquired =
       (await redisClient.set(keyLock, token, "PX", lockTtlMs, "NX")) === "OK";
   } catch (error) {
+    record("lock_failed");
     log?.({ event: "bridge_read_cache_lock_failed", cacheKind, error });
-    return read();
+    return observeRead();
   }
 
   if (acquired) {
     try {
-      const result = await read();
+      record("lock_winner");
+      const result = await observeRead();
       if (!result.ok) return result;
 
       try {
@@ -132,6 +147,7 @@ export const runBridgeReadCached = async <A, E>({
           valueTtlSeconds(result.value, ttlSeconds, emptyTtlSeconds),
         );
       } catch (error) {
+        record("set_failed");
         log?.({ event: "bridge_read_cache_set_failed", cacheKind, error });
       }
 
@@ -140,6 +156,7 @@ export const runBridgeReadCached = async <A, E>({
       try {
         await redisClient.eval(LUA_CAS_DEL, 1, keyLock, token);
       } catch (error) {
+        record("unlock_failed");
         log?.({ event: "bridge_read_cache_unlock_failed", cacheKind, error });
       }
     }
@@ -152,23 +169,30 @@ export const runBridgeReadCached = async <A, E>({
     try {
       const cached = await readCached<A>(redisClient, cacheKey);
       if (cached !== undefined) {
+        const waitMs = Date.now() - startedAt;
+        record("wait_hit");
+        metrics.recordBridgeReadCacheWait(cacheKind, "hit", waitMs);
         log?.({
           event: "bridge_read_cache_wait",
           cacheKind,
-          waitMs: Date.now() - startedAt,
+          waitMs,
         });
         return { ok: true, value: cached };
       }
     } catch (error) {
+      record("get_failed");
       log?.({ event: "bridge_read_cache_get_failed", cacheKind, error });
       break;
     }
   }
 
+  const waitMs = Date.now() - startedAt;
+  record("wait_timeout");
+  metrics.recordBridgeReadCacheWait(cacheKind, "timeout", waitMs);
   log?.({
     event: "bridge_read_cache_wait_timeout",
     cacheKind,
-    waitMs: Date.now() - startedAt,
+    waitMs,
   });
-  return read();
+  return observeRead();
 };

--- a/src/shared/browser-service.test.ts
+++ b/src/shared/browser-service.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createPageConcurrencyLimiter } from './browser-service.js';
+
+describe('createPageConcurrencyLimiter', () => {
+	it('queues page acquisition beyond the configured per-process cap', async () => {
+		const limiter = createPageConcurrencyLimiter();
+		const releaseFirst = await limiter.acquire(1, 1000);
+		let secondAcquired = false;
+
+		const second = limiter.acquire(1, 1000).then((release) => {
+			secondAcquired = true;
+			return release;
+		});
+
+		await Promise.resolve();
+		expect(secondAcquired).toBe(false);
+		expect(limiter.active()).toBe(1);
+		expect(limiter.queued()).toBe(1);
+
+		releaseFirst();
+		const releaseSecond = await second;
+		expect(secondAcquired).toBe(true);
+		expect(limiter.active()).toBe(1);
+		expect(limiter.queued()).toBe(0);
+
+		releaseSecond();
+		expect(limiter.active()).toBe(0);
+	});
+
+	it('times out queued page acquisition without leaking queue state', async () => {
+		const limiter = createPageConcurrencyLimiter();
+		const releaseFirst = await limiter.acquire(1, 1000);
+
+		await expect(limiter.acquire(1, 5)).rejects.toThrow(
+			'Timed out waiting for bridge browser page slot',
+		);
+
+		expect(limiter.active()).toBe(1);
+		expect(limiter.queued()).toBe(0);
+		releaseFirst();
+		expect(limiter.active()).toBe(0);
+	});
+});

--- a/src/shared/browser-service.ts
+++ b/src/shared/browser-service.ts
@@ -32,7 +32,16 @@ export interface BrowserConfig {
 	readonly executablePath?: string;
 	/** Additional chromium.launch() args (e.g., Lambda sandbox flags) */
 	readonly launchArgs?: readonly string[];
+	/** Maximum concurrent pages per Node process. Defaults to BRIDGE_MAX_CONCURRENT_PAGES or 3. */
+	readonly maxConcurrentPages: number;
+	/** Maximum time to wait for a page concurrency slot before failing. */
+	readonly pageAcquireTimeoutMs: number;
 }
+
+const positiveIntEnv = (name: string, fallback: number): number => {
+	const raw = Number(process.env[name]);
+	return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : fallback;
+};
 
 export const defaultBrowserConfig: BrowserConfig = {
 	baseUrl: 'https://MassageIthaca.as.me',
@@ -42,6 +51,8 @@ export const defaultBrowserConfig: BrowserConfig = {
 		'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
 	screenshotOnFailure: true,
 	screenshotDir: '/tmp/scheduling-kit-screenshots',
+	maxConcurrentPages: positiveIntEnv('BRIDGE_MAX_CONCURRENT_PAGES', 3),
+	pageAcquireTimeoutMs: positiveIntEnv('BRIDGE_PAGE_ACQUIRE_TIMEOUT_MS', 10_000),
 };
 
 // =============================================================================
@@ -71,6 +82,75 @@ export class BrowserProcess extends Context.Tag('scheduling-kit/BrowserProcess')
 	BrowserProcess,
 	BrowserProcessShape
 >() {}
+
+export interface PageConcurrencyLimiter {
+	readonly active: () => number;
+	readonly queued: () => number;
+	readonly acquire: (maxConcurrent: number, timeoutMs: number) => Promise<() => void>;
+}
+
+export const createPageConcurrencyLimiter = (): PageConcurrencyLimiter => {
+	let active = 0;
+	const queue: {
+		readonly resolve: (release: () => void) => void;
+		readonly reject: (error: Error) => void;
+		readonly maxConcurrent: number;
+		timeout: ReturnType<typeof setTimeout> | undefined;
+	}[] = [];
+
+	const releaseOne = () => {
+		active = Math.max(0, active - 1);
+		drain();
+	};
+
+	const grant = (resolve: (release: () => void) => void) => {
+		active += 1;
+		let released = false;
+		resolve(() => {
+			if (released) return;
+			released = true;
+			releaseOne();
+		});
+	};
+
+	const drain = () => {
+		while (queue.length > 0) {
+			const maxConcurrent = Math.max(1, queue[0]?.maxConcurrent ?? 1);
+			if (active >= maxConcurrent) return;
+			const next = queue.shift();
+			if (!next) return;
+			if (next.timeout) clearTimeout(next.timeout);
+			grant(next.resolve);
+		}
+	};
+
+	return {
+		active: () => active,
+		queued: () => queue.length,
+		acquire: (maxConcurrent, timeoutMs) =>
+			new Promise((resolve, reject) => {
+				const max = Math.max(1, Math.floor(maxConcurrent));
+				if (active < max) {
+					grant(resolve);
+					return;
+				}
+				const entry = {
+					resolve,
+					reject,
+					timeout: undefined as ReturnType<typeof setTimeout> | undefined,
+					maxConcurrent: max,
+				};
+				entry.timeout = setTimeout(() => {
+					const index = queue.indexOf(entry);
+					if (index >= 0) queue.splice(index, 1);
+					reject(new Error('Timed out waiting for bridge browser page slot'));
+				}, Math.max(1, timeoutMs));
+				queue.push(entry);
+			}),
+	};
+};
+
+const pageConcurrencyLimiter = createPageConcurrencyLimiter();
 
 // =============================================================================
 // LIVE IMPLEMENTATION
@@ -139,26 +219,40 @@ export const BrowserSessionLive = Layer.scoped(
 	Effect.gen(function* () {
 		const { browser, config } = yield* BrowserProcess;
 
-		// Track the active page as a Playwright "session" via acquire/release —
-		// `browserActiveSessions` is incremented when the page is created and
-		// decremented when the scope closes (including on interrupt / failure),
-		// so the gauge reflects the number of live contexts at any instant.
-		const page: Page = yield* Effect.acquireRelease(
+		// Track the active page as a Playwright "session" via acquire/release.
+		// The concurrency permit bounds K8s page fanout before Chromium is asked
+		// to allocate another page; it is released after the page closes.
+		const pageResource: { page: Page; releasePermit: () => void } = yield* Effect.acquireRelease(
 			Effect.tryPromise({
 				try: async () => {
-					const p = await browser.newPage({ userAgent: config.userAgent });
-					p.setDefaultTimeout(config.timeout);
-					metrics.browserActiveSessions.inc();
-					return p;
+					const releasePermit = await pageConcurrencyLimiter.acquire(
+						config.maxConcurrentPages,
+						config.pageAcquireTimeoutMs,
+					);
+					try {
+						const p = await browser.newPage({ userAgent: config.userAgent });
+						p.setDefaultTimeout(config.timeout);
+						metrics.browserActiveSessions.inc();
+						return { page: p, releasePermit };
+					} catch (error) {
+						releasePermit();
+						throw error;
+					}
 				},
 				catch: (e) => new BrowserError({ reason: 'PAGE_FAILED', cause: e }),
 			}),
-			(p) =>
-				Effect.promise(() => p.close()).pipe(
-					Effect.ensuring(Effect.sync(() => metrics.browserActiveSessions.dec())),
+			({ page, releasePermit }) =>
+				Effect.promise(() => page.close()).pipe(
+					Effect.ensuring(
+						Effect.sync(() => {
+							metrics.browserActiveSessions.dec();
+							releasePermit();
+						}),
+					),
 					Effect.ignoreLogged,
 				),
 		);
+		const page = pageResource.page;
 
 		const acquirePage = Effect.acquireRelease(
 			Effect.succeed(page),

--- a/src/shared/metrics.test.ts
+++ b/src/shared/metrics.test.ts
@@ -19,6 +19,9 @@ describe('metrics', () => {
 		expect(names).toContain('acuity_cache_hit_ratio');
 		expect(names).toContain('acuity_service_catalog_scrape_total');
 		expect(names).toContain('acuity_service_catalog_refresh_duration_seconds');
+		expect(names).toContain('acuity_bridge_read_cache_events_total');
+		expect(names).toContain('acuity_bridge_read_cache_wait_duration_seconds');
+		expect(names).toContain('acuity_bridge_read_duration_seconds');
 	});
 
 	it('renders Prometheus text format', async () => {
@@ -46,6 +49,68 @@ describe('metrics', () => {
 			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
 				(v) => v.labels.source === 'lock_winner',
 			)?.value ?? 0;
+		expect(after).toBe(before + 1);
+	});
+});
+
+describe('bridge read cache metrics wiring', () => {
+	const counterValue = async (
+		cacheKind: string,
+		event: string,
+	): Promise<number> => {
+		const snap = await metrics.bridgeReadCacheEventsTotal.get();
+		return snap.values.find(
+			(v) =>
+				v.labels.cache_kind === cacheKind &&
+				v.labels.event === event,
+		)?.value ?? 0;
+	};
+
+	const histogramCount = async (
+		metricName: string,
+		labels: Record<string, string>,
+	): Promise<number> => {
+		const metric = metrics.registry.getSingleMetric(metricName);
+		const snap = await metric?.get();
+		const countName = `${metricName}_count`;
+		return snap?.values.find((v) => {
+			if (v.metricName !== countName) return false;
+			return Object.entries(labels).every(
+				([key, value]) => v.labels[key] === value,
+			);
+		})?.value ?? 0;
+	};
+
+	it('increments fixed-label cache event counters', async () => {
+		const before = await counterValue('availability_slots', 'hit');
+		metrics.recordBridgeReadCacheEvent('availability_slots', 'hit');
+		const after = await counterValue('availability_slots', 'hit');
+		expect(after).toBe(before + 1);
+	});
+
+	it('records wait duration samples by outcome', async () => {
+		const before = await histogramCount(
+			'acuity_bridge_read_cache_wait_duration_seconds',
+			{ cache_kind: 'availability_slots', outcome: 'hit' },
+		);
+		metrics.recordBridgeReadCacheWait('availability_slots', 'hit', 250);
+		const after = await histogramCount(
+			'acuity_bridge_read_cache_wait_duration_seconds',
+			{ cache_kind: 'availability_slots', outcome: 'hit' },
+		);
+		expect(after).toBe(before + 1);
+	});
+
+	it('records uncached bridge read duration samples', async () => {
+		const before = await histogramCount(
+			'acuity_bridge_read_duration_seconds',
+			{ cache_kind: 'availability_dates' },
+		);
+		await metrics.observeBridgeRead('availability_dates', async () => 42);
+		const after = await histogramCount(
+			'acuity_bridge_read_duration_seconds',
+			{ cache_kind: 'availability_dates' },
+		);
 		expect(after).toBe(before + 1);
 	});
 });

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -55,6 +55,29 @@ const serviceCatalogRefreshDuration = new Histogram({
 	registers: [registry],
 });
 
+const bridgeReadCacheEventsTotal = new Counter({
+	name: 'acuity_bridge_read_cache_events_total',
+	help: 'Bridge availability read cache events by cache kind and event',
+	labelNames: ['cache_kind', 'event'],
+	registers: [registry],
+});
+
+const bridgeReadCacheWaitDuration = new Histogram({
+	name: 'acuity_bridge_read_cache_wait_duration_seconds',
+	help: 'Time spent waiting for another bridge reader to publish a cached value',
+	labelNames: ['cache_kind', 'outcome'],
+	buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60],
+	registers: [registry],
+});
+
+const bridgeReadDuration = new Histogram({
+	name: 'acuity_bridge_read_duration_seconds',
+	help: 'Wall time for uncached bridge availability reads',
+	labelNames: ['cache_kind'],
+	buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60],
+	registers: [registry],
+});
+
 // ─── Derived cache hit-ratio ─────────────────────────────────────────────────
 //
 // `cacheHitRatio` is a derived gauge — prom-client cannot compute it for us,
@@ -104,6 +127,36 @@ export const _resetCacheHitRatioForTests = (): void => {
 	cacheHitCount = 0;
 	cacheMissCount = 0;
 	cacheHitRatio.set(1);
+};
+
+export const recordBridgeReadCacheEvent = (
+	cacheKind: string,
+	event: string,
+): void => {
+	bridgeReadCacheEventsTotal.inc({ cache_kind: cacheKind, event });
+};
+
+export const recordBridgeReadCacheWait = (
+	cacheKind: string,
+	outcome: 'hit' | 'timeout',
+	waitMs: number,
+): void => {
+	bridgeReadCacheWaitDuration.observe(
+		{ cache_kind: cacheKind, outcome },
+		Math.max(0, waitMs) / 1000,
+	);
+};
+
+export const observeBridgeRead = async <A>(
+	cacheKind: string,
+	fn: () => Promise<A>,
+): Promise<A> => {
+	const end = bridgeReadDuration.startTimer({ cache_kind: cacheKind });
+	try {
+		return await fn();
+	} finally {
+		end();
+	}
 };
 
 // ─── Page-operation timer helper ─────────────────────────────────────────────
@@ -163,8 +216,14 @@ export const metrics = {
 	cacheHitRatio,
 	serviceCatalogScrapeTotal,
 	serviceCatalogRefreshDuration,
+	bridgeReadCacheEventsTotal,
+	bridgeReadCacheWaitDuration,
+	bridgeReadDuration,
 	recordCacheHit,
 	recordCacheMiss,
+	recordBridgeReadCacheEvent,
+	recordBridgeReadCacheWait,
+	observeBridgeRead,
 	observePageOp,
 	observePageOpEffect,
 	trackBrowserSession,


### PR DESCRIPTION
## Summary

- add bridge read-cache Prometheus metrics for events, single-flight wait duration, and uncached read duration
- wire `runBridgeReadCached` into the new metrics for dates and slots reads
- replace the fixed `2s` slot post-click wait with an early-exit DOM/network readiness wait capped by `ACUITY_POST_CLICK_SLOT_SETTLE_MS`
- add a per-process browser page concurrency limiter controlled by `BRIDGE_MAX_CONCURRENT_PAGES` and `BRIDGE_PAGE_ACQUIRE_TIMEOUT_MS`
- bump the bridge release edge to `@tummycrypt/scheduling-bridge@0.4.7` with package/Bazel metadata aligned

## Why

K8s bridge parity is functionally green, but we need durable visibility into cold bridge reads and cache state before tuning HPA/runtime policy. The slot path also still paid an unconditional fixed wait after date click.

## Validation

- `pnpm exec vitest run --reporter=verbose --config vitest.config.ts src/shared/metrics.test.ts src/shared/bridge-read-cache.test.ts src/shared/browser-service.test.ts tests/slot-read-profile.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm check:release-metadata`
- `pnpm docs:check`
- `pnpm build && pnpm check:package` after the `0.4.7` metadata bump
- `git diff --check`

## Notes

`pnpm build` materialized Bazel-derived `pkg/`/`dist/`; generated `pkg/` was removed afterward so the PR diff stays source-only.
