### PR TITLE
[codex] Harden bridge cold slot reads

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.7",
+    version = "0.4.8",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.7",
+    version = "0.4.8",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ dashboard state when `/health` is available.
 | `CHROMIUM_LAUNCH_ARGS` | No | -- | Comma-separated Chromium args |
 | `SERVICES_JSON` | No | -- | Optional static service catalog to bypass live Acuity reads |
 | `ACUITY_SERVICE_CACHE_TTL_MS` | No | `300000` | TTL for cached live service catalogs before BUSINESS/scraper refresh |
+| `ACUITY_URL_READ_NETWORK_IDLE_MS` | No | `1500` | Bounded post-navigation network-idle settle for direct URL availability reads; set `0` to skip |
+| `ACUITY_SLOT_PREWARM_LIMIT` | No | `1` | Number of first available dates to warm in the slots cache after a successful Acuity dates read; max `3`, set `0` to disable |
 | `SCHEDULING_BRIDGE_SLOT_PROFILE_THRESHOLD_MS` | No | `1500` | Threshold in ms for logging long-tail slot-read profile events |
 | `SCHEDULING_BRIDGE_PROFILE_SLOT_READS` | No | `false` | Force logging of slot-read profile events even when under threshold |
 | `MIDDLEWARE_RELEASE_SHA` | No | -- | Release commit SHA exposed via `/health` |

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.4.7`
-- Bazel module version: `0.4.7`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.7`
+- package version: `0.4.8`
+- Bazel module version: `0.4.8`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.8`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/adapters/acuity/steps/read-via-url.test.ts
+++ b/src/adapters/acuity/steps/read-via-url.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { urlReadNetworkIdleTimeoutMs } from './read-via-url.js';
+
+describe('URL read timing config', () => {
+	it('uses a short network-idle settle by default', () => {
+		expect(urlReadNetworkIdleTimeoutMs(30_000, {})).toBe(1500);
+	});
+
+	it('honors explicit network-idle settle config including zero', () => {
+		expect(urlReadNetworkIdleTimeoutMs(30_000, { ACUITY_URL_READ_NETWORK_IDLE_MS: '750' })).toBe(750);
+		expect(urlReadNetworkIdleTimeoutMs(30_000, { ACUITY_URL_READ_NETWORK_IDLE_MS: '0' })).toBe(0);
+	});
+
+	it('never exceeds the caller operation timeout', () => {
+		expect(urlReadNetworkIdleTimeoutMs(500, { ACUITY_URL_READ_NETWORK_IDLE_MS: '2000' })).toBe(500);
+	});
+
+	it('falls back when the env value is invalid', () => {
+		expect(urlReadNetworkIdleTimeoutMs(30_000, { ACUITY_URL_READ_NETWORK_IDLE_MS: 'nope' })).toBe(1500);
+	});
+});

--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -40,11 +40,28 @@ export interface UrlSlotResult {
 	readonly available: boolean;
 }
 
+const DEFAULT_URL_READ_NETWORK_IDLE_MS = 1500;
+
+export const urlReadNetworkIdleTimeoutMs = (
+	timeout: number,
+	env: Record<string, string | undefined> = process.env,
+): number => {
+	const raw = env.ACUITY_URL_READ_NETWORK_IDLE_MS;
+	const parsed = raw === undefined || raw === '' ? DEFAULT_URL_READ_NETWORK_IDLE_MS : Number(raw);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		return Math.min(timeout, DEFAULT_URL_READ_NETWORK_IDLE_MS);
+	}
+	return Math.min(timeout, Math.floor(parsed));
+};
+
 const navigateForUrlRead = async (page: Page, url: URL, timeout: number): Promise<void> => {
 	// Acuity can leave background requests open long after the calendar DOM is
 	// useful. Bound the network-idle wait so empty days do not become 30s 500s.
 	await page.goto(url.toString(), { waitUntil: 'domcontentloaded', timeout });
-	await page.waitForLoadState('networkidle', { timeout: Math.min(timeout, 5000) }).catch(() => {});
+	const networkIdleTimeout = urlReadNetworkIdleTimeoutMs(timeout);
+	if (networkIdleTimeout > 0) {
+		await page.waitForLoadState('networkidle', { timeout: networkIdleTimeout }).catch(() => {});
+	}
 };
 
 const postClickSlotSettleMs = (): number => {

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -72,6 +72,11 @@ import {
 } from '../adapters/acuity/steps/read-via-url.js';
 import { buildHealthPayload } from './health.js';
 import { handleReady as _handleReady } from './ready.js';
+import {
+	buildAvailabilitySlotsCacheKey,
+	getSlotPrewarmLimit,
+	selectSlotPrewarmDates,
+} from './slot-prewarm.js';
 import { ndjsonLog } from '../shared/logger.js';
 import type {
 	Booking,
@@ -100,6 +105,7 @@ const EMPTY_READ_CACHE_TTL_SECONDS = (() => {
 	const parsed = Number(process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS ?? 2 * 60);
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : 2 * 60;
 })();
+const SLOT_PREWARM_LIMIT = getSlotPrewarmLimit();
 
 const browserConfig: BrowserConfig = {
 	...defaultBrowserConfig,
@@ -393,6 +399,60 @@ const resolveServiceName = async (serviceId: string, serviceName?: string): Prom
 
 const isAcuityAppointmentTypeId = (serviceId: string): boolean => /^\d+$/.test(serviceId);
 
+const scheduleSlotPrewarm = (
+	context: RequestContext,
+	serviceId: string,
+	dates: readonly { date?: unknown }[],
+): void => {
+	if (!redisClient || SLOT_PREWARM_LIMIT <= 0 || !isAcuityAppointmentTypeId(serviceId)) {
+		return;
+	}
+
+	const prewarmDates = selectSlotPrewarmDates(dates, SLOT_PREWARM_LIMIT);
+	if (prewarmDates.length === 0) return;
+
+	logRequestEvent('INFO', 'Availability slot prewarm queued', context, {
+		event: 'availability_slot_prewarm_queued',
+		serviceId,
+		dates: prewarmDates,
+		limit: SLOT_PREWARM_LIMIT,
+	});
+
+	void (async () => {
+		for (const date of prewarmDates) {
+			const startedAt = Date.now();
+			const cacheKey = buildAvailabilitySlotsCacheKey(ACUITY_BASE_URL, serviceId, date);
+			const result = await runCachedBridgeRead(context, 'availability_slots', cacheKey, () =>
+				runEffect(
+					readSlotsViaUrl(
+						serviceId,
+						date,
+						createSlotReadTelemetryContext(context, 'availability_slots_prewarm'),
+					),
+				),
+			);
+
+			logRequestEvent(result.ok ? 'INFO' : 'WARN', 'Availability slot prewarm completed', context, {
+				event: 'availability_slot_prewarm_completed',
+				serviceId,
+				date,
+				durationMs: Date.now() - startedAt,
+				ok: result.ok,
+				...(result.ok
+					? { slots: Array.isArray(result.value) ? result.value.length : undefined }
+					: { error: describeLogValue(result.error) }),
+			});
+		}
+	})().catch((error) => {
+		logRequestEvent('ERROR', 'Availability slot prewarm failed', context, {
+			event: 'availability_slot_prewarm_failed',
+			serviceId,
+			dates: prewarmDates,
+			error: describeLogValue(error),
+		});
+	});
+};
+
 // =============================================================================
 // ROUTE HANDLERS
 // =============================================================================
@@ -534,6 +594,7 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Availability lookup failed' },
 		});
 	}
+	scheduleSlotPrewarm(context, body.serviceId, result.value);
 	sendSuccess(res, result.value);
 };
 
@@ -545,7 +606,7 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 		serviceName: body.serviceName,
 		date: body.date,
 	});
-	const cacheKey = `bridge-read:v2:slots:${ACUITY_BASE_URL}:${body.serviceId}:${body.date}`;
+	const cacheKey = buildAvailabilitySlotsCacheKey(ACUITY_BASE_URL, body.serviceId, body.date);
 	const result = await runCachedBridgeRead(context, 'availability_slots', cacheKey, () =>
 		isAcuityAppointmentTypeId(body.serviceId)
 			? runEffect(

--- a/src/server/slot-prewarm.test.ts
+++ b/src/server/slot-prewarm.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildAvailabilitySlotsCacheKey,
+	getSlotPrewarmLimit,
+	selectSlotPrewarmDates,
+} from './slot-prewarm.js';
+
+describe('slot prewarm helpers', () => {
+	it('defaults to one slot prewarm and caps aggressive env values', () => {
+		expect(getSlotPrewarmLimit({})).toBe(1);
+		expect(getSlotPrewarmLimit({ ACUITY_SLOT_PREWARM_LIMIT: '2' })).toBe(2);
+		expect(getSlotPrewarmLimit({ ACUITY_SLOT_PREWARM_LIMIT: '99' })).toBe(3);
+	});
+
+	it('allows disabling slot prewarm with zero or negative env values', () => {
+		expect(getSlotPrewarmLimit({ ACUITY_SLOT_PREWARM_LIMIT: '0' })).toBe(0);
+		expect(getSlotPrewarmLimit({ ACUITY_SLOT_PREWARM_LIMIT: '-1' })).toBe(0);
+	});
+
+	it('selects unique valid dates up to the configured limit', () => {
+		const selected = selectSlotPrewarmDates(
+			[
+				{ date: '2026-08-02' },
+				{ date: 'not-a-date' },
+				{ date: '2026-08-02' },
+				{ date: '2026-08-03' },
+				{ date: '2026-08-04' },
+			],
+			2,
+		);
+
+		expect(selected).toEqual(['2026-08-02', '2026-08-03']);
+	});
+
+	it('builds the same slot cache key used by the public slot route', () => {
+		expect(
+			buildAvailabilitySlotsCacheKey(
+				'https://MassageIthaca.as.me',
+				'53178494',
+				'2026-08-02',
+			),
+		).toBe('bridge-read:v2:slots:https://MassageIthaca.as.me:53178494:2026-08-02');
+	});
+});

--- a/src/server/slot-prewarm.ts
+++ b/src/server/slot-prewarm.ts
@@ -1,0 +1,53 @@
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DEFAULT_SLOT_PREWARM_LIMIT = 1;
+const MAX_SLOT_PREWARM_LIMIT = 3;
+
+export interface DateLike {
+	readonly date?: unknown;
+}
+
+export const getSlotPrewarmLimit = (
+	env: Record<string, string | undefined> = process.env,
+): number => {
+	const raw = env.ACUITY_SLOT_PREWARM_LIMIT;
+	if (raw === undefined || raw === '') {
+		return DEFAULT_SLOT_PREWARM_LIMIT;
+	}
+
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_SLOT_PREWARM_LIMIT;
+	}
+	if (parsed <= 0) {
+		return 0;
+	}
+
+	return Math.min(Math.floor(parsed), MAX_SLOT_PREWARM_LIMIT);
+};
+
+export const selectSlotPrewarmDates = (
+	dates: readonly DateLike[],
+	limit: number,
+): string[] => {
+	if (limit <= 0) return [];
+
+	const selected: string[] = [];
+	const seen = new Set<string>();
+	for (const candidate of dates) {
+		if (typeof candidate.date !== 'string') continue;
+		if (!DATE_RE.test(candidate.date)) continue;
+		if (seen.has(candidate.date)) continue;
+
+		seen.add(candidate.date);
+		selected.push(candidate.date);
+		if (selected.length >= limit) break;
+	}
+
+	return selected;
+};
+
+export const buildAvailabilitySlotsCacheKey = (
+	baseUrl: string,
+	serviceId: string,
+	date: string,
+): string => `bridge-read:v2:slots:${baseUrl}:${serviceId}:${date}`;


### PR DESCRIPTION
## Summary
- reduce direct URL read network-idle settling from the previous hard cap to a configurable 1500ms default
- add Redis-backed slot prewarm after successful Acuity date reads so the first selected available date can share the cache/single-flight path
- bump bridge package/Bazel metadata to 0.4.8 and document the new cold-path knobs

## Why
Live K8s slot profiles showed the remaining 13s cold path was dominated by URL navigation/network-idle time, not slot DOM parsing. This keeps the existing calendar readiness checks while reducing the fixed wait and warming the first available slot read opportunistically.

## Validation
- pnpm exec vitest run src/server/slot-prewarm.test.ts src/adapters/acuity/steps/read-via-url.test.ts tests/slot-read-profile.test.ts src/shared/bridge-read-cache.test.ts --config vitest.config.ts
- pnpm exec tsc --noEmit
- pnpm typecheck
- pnpm test
- pnpm check:release-metadata
- pnpm check:artifact-authority
- pnpm docs:check
- pnpm build
- pnpm check:package
- git diff --check
