### PR TITLE
[codex] Expose bridge page limiter metrics

### DIFF
--- a/src/shared/browser-service.test.ts
+++ b/src/shared/browser-service.test.ts
@@ -1,9 +1,33 @@
 import { describe, expect, it } from 'vitest';
 import { createPageConcurrencyLimiter } from './browser-service.js';
+import { metrics } from './metrics.js';
+
+const pageAcquireCount = async (outcome: string): Promise<number> => {
+	const snap = await metrics.browserPageAcquireDuration.get();
+	return (
+		snap.values.find(
+			(v) =>
+				v.metricName === 'acuity_browser_page_acquire_duration_seconds_count' &&
+				v.labels.outcome === outcome,
+		)?.value ?? 0
+	);
+};
+
+const timeoutCount = async (): Promise<number> => {
+	const snap = await metrics.browserPageAcquireTimeoutsTotal.get();
+	return (snap.values[0]?.value as number | undefined) ?? 0;
+};
+
+const limiterGauge = async (metricName: string): Promise<number> => {
+	const metric = metrics.registry.getSingleMetric(metricName);
+	const snap = await metric?.get();
+	return (snap?.values[0]?.value as number | undefined) ?? 0;
+};
 
 describe('createPageConcurrencyLimiter', () => {
 	it('queues page acquisition beyond the configured per-process cap', async () => {
 		const limiter = createPageConcurrencyLimiter();
+		const acquireBefore = await pageAcquireCount('success');
 		const releaseFirst = await limiter.acquire(1, 1000);
 		let secondAcquired = false;
 
@@ -16,6 +40,8 @@ describe('createPageConcurrencyLimiter', () => {
 		expect(secondAcquired).toBe(false);
 		expect(limiter.active()).toBe(1);
 		expect(limiter.queued()).toBe(1);
+		expect(await limiterGauge('acuity_browser_page_limiter_active')).toBe(1);
+		expect(await limiterGauge('acuity_browser_page_limiter_queued')).toBe(1);
 
 		releaseFirst();
 		const releaseSecond = await second;
@@ -25,10 +51,14 @@ describe('createPageConcurrencyLimiter', () => {
 
 		releaseSecond();
 		expect(limiter.active()).toBe(0);
+		expect(await limiterGauge('acuity_browser_page_limiter_active')).toBe(0);
+		expect(await limiterGauge('acuity_browser_page_limiter_queued')).toBe(0);
+		expect(await pageAcquireCount('success')).toBe(acquireBefore + 2);
 	});
 
 	it('times out queued page acquisition without leaking queue state', async () => {
 		const limiter = createPageConcurrencyLimiter();
+		const timeoutBefore = await timeoutCount();
 		const releaseFirst = await limiter.acquire(1, 1000);
 
 		await expect(limiter.acquire(1, 5)).rejects.toThrow(
@@ -37,7 +67,11 @@ describe('createPageConcurrencyLimiter', () => {
 
 		expect(limiter.active()).toBe(1);
 		expect(limiter.queued()).toBe(0);
+		expect(await limiterGauge('acuity_browser_page_limiter_active')).toBe(1);
+		expect(await limiterGauge('acuity_browser_page_limiter_queued')).toBe(0);
+		expect(await timeoutCount()).toBe(timeoutBefore + 1);
 		releaseFirst();
 		expect(limiter.active()).toBe(0);
+		expect(await limiterGauge('acuity_browser_page_limiter_active')).toBe(0);
 	});
 });

--- a/src/shared/browser-service.ts
+++ b/src/shared/browser-service.ts
@@ -95,16 +95,24 @@ export const createPageConcurrencyLimiter = (): PageConcurrencyLimiter => {
 		readonly resolve: (release: () => void) => void;
 		readonly reject: (error: Error) => void;
 		readonly maxConcurrent: number;
+		readonly startedAt: number;
 		timeout: ReturnType<typeof setTimeout> | undefined;
 	}[] = [];
 
+	const recordState = () => {
+		metrics.setBrowserPageLimiterState(active, queue.length);
+	};
+
 	const releaseOne = () => {
 		active = Math.max(0, active - 1);
+		recordState();
 		drain();
 	};
 
-	const grant = (resolve: (release: () => void) => void) => {
+	const grant = (resolve: (release: () => void) => void, startedAt: number) => {
 		active += 1;
+		recordState();
+		metrics.recordBrowserPageAcquire('success', Date.now() - startedAt);
 		let released = false;
 		resolve(() => {
 			if (released) return;
@@ -120,7 +128,8 @@ export const createPageConcurrencyLimiter = (): PageConcurrencyLimiter => {
 			const next = queue.shift();
 			if (!next) return;
 			if (next.timeout) clearTimeout(next.timeout);
-			grant(next.resolve);
+			recordState();
+			grant(next.resolve, next.startedAt);
 		}
 	};
 
@@ -130,8 +139,9 @@ export const createPageConcurrencyLimiter = (): PageConcurrencyLimiter => {
 		acquire: (maxConcurrent, timeoutMs) =>
 			new Promise((resolve, reject) => {
 				const max = Math.max(1, Math.floor(maxConcurrent));
+				const startedAt = Date.now();
 				if (active < max) {
-					grant(resolve);
+					grant(resolve, startedAt);
 					return;
 				}
 				const entry = {
@@ -139,13 +149,20 @@ export const createPageConcurrencyLimiter = (): PageConcurrencyLimiter => {
 					reject,
 					timeout: undefined as ReturnType<typeof setTimeout> | undefined,
 					maxConcurrent: max,
+					startedAt,
 				};
-				entry.timeout = setTimeout(() => {
-					const index = queue.indexOf(entry);
-					if (index >= 0) queue.splice(index, 1);
-					reject(new Error('Timed out waiting for bridge browser page slot'));
-				}, Math.max(1, timeoutMs));
+				entry.timeout = setTimeout(
+					() => {
+						const index = queue.indexOf(entry);
+						if (index >= 0) queue.splice(index, 1);
+						recordState();
+						metrics.recordBrowserPageAcquire('timeout', Date.now() - startedAt);
+						reject(new Error('Timed out waiting for bridge browser page slot'));
+					},
+					Math.max(1, timeoutMs),
+				);
 				queue.push(entry);
+				recordState();
 			}),
 	};
 };

--- a/src/shared/metrics.test.ts
+++ b/src/shared/metrics.test.ts
@@ -15,6 +15,10 @@ describe('metrics', () => {
 	it('exposes required SLIs from spec §6.1', () => {
 		const names = metrics.registry.getMetricsAsArray().map((m) => m.name);
 		expect(names).toContain('acuity_browser_active_sessions');
+		expect(names).toContain('acuity_browser_page_limiter_active');
+		expect(names).toContain('acuity_browser_page_limiter_queued');
+		expect(names).toContain('acuity_browser_page_acquire_duration_seconds');
+		expect(names).toContain('acuity_browser_page_acquire_timeouts_total');
 		expect(names).toContain('acuity_page_operations_duration_seconds');
 		expect(names).toContain('acuity_cache_hit_ratio');
 		expect(names).toContain('acuity_service_catalog_scrape_total');
@@ -31,6 +35,8 @@ describe('metrics', () => {
 		const text = await renderMetrics();
 		expect(text).toContain('# HELP acuity_browser_active_sessions');
 		expect(text).toContain('# TYPE acuity_browser_active_sessions gauge');
+		expect(text).toContain('# HELP acuity_browser_page_limiter_active');
+		expect(text).toContain('# TYPE acuity_browser_page_limiter_queued gauge');
 		// Histogram exposition: per-bucket cumulative, total sum, total count.
 		expect(text).toContain('acuity_page_operations_duration_seconds_bucket{');
 		expect(text).toContain('acuity_page_operations_duration_seconds_sum');
@@ -112,6 +118,54 @@ describe('bridge read cache metrics wiring', () => {
 			{ cache_kind: 'availability_dates' },
 		);
 		expect(after).toBe(before + 1);
+	});
+});
+
+describe('browser page limiter metrics wiring', () => {
+	const gaugeValue = async (metricName: string): Promise<number> => {
+		const metric = metrics.registry.getSingleMetric(metricName);
+		const snap = await metric?.get();
+		return (snap?.values[0]?.value as number | undefined) ?? 0;
+	};
+
+	const histogramCount = async (outcome: string): Promise<number> => {
+		const snap = await metrics.browserPageAcquireDuration.get();
+		return (
+			snap.values.find(
+				(v) =>
+					v.metricName ===
+						'acuity_browser_page_acquire_duration_seconds_count' &&
+					v.labels.outcome === outcome,
+			)?.value ?? 0
+		);
+	};
+
+	const timeoutCount = async (): Promise<number> => {
+		const snap = await metrics.browserPageAcquireTimeoutsTotal.get();
+		return (snap.values[0]?.value as number | undefined) ?? 0;
+	};
+
+	it('records limiter active and queued gauges', async () => {
+		metrics.setBrowserPageLimiterState(2, 1);
+		expect(await gaugeValue('acuity_browser_page_limiter_active')).toBe(2);
+		expect(await gaugeValue('acuity_browser_page_limiter_queued')).toBe(1);
+
+		metrics.setBrowserPageLimiterState(0, 0);
+		expect(await gaugeValue('acuity_browser_page_limiter_active')).toBe(0);
+		expect(await gaugeValue('acuity_browser_page_limiter_queued')).toBe(0);
+	});
+
+	it('records acquire duration and timeout counters', async () => {
+		const successBefore = await histogramCount('success');
+		const timeoutBefore = await histogramCount('timeout');
+		const timeoutCounterBefore = await timeoutCount();
+
+		metrics.recordBrowserPageAcquire('success', 25);
+		metrics.recordBrowserPageAcquire('timeout', 10000);
+
+		expect(await histogramCount('success')).toBe(successBefore + 1);
+		expect(await histogramCount('timeout')).toBe(timeoutBefore + 1);
+		expect(await timeoutCount()).toBe(timeoutCounterBefore + 1);
 	});
 });
 

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -11,7 +11,8 @@ import {
  * Prometheus metrics registry for the acuity-middleware bridge.
  *
  * Scope: Kubernetes phase 1.0 observability. SLIs are the canonical set
- * enumerated in spec §6.1 — do not extend this list without a spec update.
+ * enumerated in spec §6.1. TIN-92 adds page-limiter metrics so K8s HPA
+ * decisions can distinguish browser-slot contention from upstream Acuity cost.
  *
  * The `Registry` is a module-level singleton. In tests, a shared registry
  * means counters accumulate across files — assertions should be written as
@@ -24,6 +25,32 @@ collectDefaultMetrics({ register: registry, prefix: 'acuity_' });
 const browserActiveSessions = new Gauge({
 	name: 'acuity_browser_active_sessions',
 	help: 'Current number of open Playwright browser contexts',
+	registers: [registry],
+});
+
+const browserPageLimiterActive = new Gauge({
+	name: 'acuity_browser_page_limiter_active',
+	help: 'Current number of acquired browser page concurrency slots',
+	registers: [registry],
+});
+
+const browserPageLimiterQueued = new Gauge({
+	name: 'acuity_browser_page_limiter_queued',
+	help: 'Current number of requests waiting for a browser page concurrency slot',
+	registers: [registry],
+});
+
+const browserPageAcquireDuration = new Histogram({
+	name: 'acuity_browser_page_acquire_duration_seconds',
+	help: 'Time spent waiting to acquire a browser page concurrency slot',
+	labelNames: ['outcome'],
+	buckets: [0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+	registers: [registry],
+});
+
+const browserPageAcquireTimeoutsTotal = new Counter({
+	name: 'acuity_browser_page_acquire_timeouts_total',
+	help: 'Browser page concurrency slot acquisition timeouts',
 	registers: [registry],
 });
 
@@ -136,6 +163,24 @@ export const recordBridgeReadCacheEvent = (
 	bridgeReadCacheEventsTotal.inc({ cache_kind: cacheKind, event });
 };
 
+export const setBrowserPageLimiterState = (
+	active: number,
+	queued: number,
+): void => {
+	browserPageLimiterActive.set(Math.max(0, active));
+	browserPageLimiterQueued.set(Math.max(0, queued));
+};
+
+export const recordBrowserPageAcquire = (
+	outcome: 'success' | 'timeout',
+	waitMs: number,
+): void => {
+	browserPageAcquireDuration.observe({ outcome }, Math.max(0, waitMs) / 1000);
+	if (outcome === 'timeout') {
+		browserPageAcquireTimeoutsTotal.inc();
+	}
+};
+
 export const recordBridgeReadCacheWait = (
 	cacheKind: string,
 	outcome: 'hit' | 'timeout',
@@ -212,6 +257,10 @@ export const trackBrowserSession = <A, E, R>(
 export const metrics = {
 	registry,
 	browserActiveSessions,
+	browserPageLimiterActive,
+	browserPageLimiterQueued,
+	browserPageAcquireDuration,
+	browserPageAcquireTimeoutsTotal,
 	pageOperationsDuration,
 	cacheHitRatio,
 	serviceCatalogScrapeTotal,
@@ -221,6 +270,8 @@ export const metrics = {
 	bridgeReadDuration,
 	recordCacheHit,
 	recordCacheMiss,
+	setBrowserPageLimiterState,
+	recordBrowserPageAcquire,
 	recordBridgeReadCacheEvent,
 	recordBridgeReadCacheWait,
 	observeBridgeRead,


### PR DESCRIPTION
## Summary
- expose active and queued browser page limiter gauges
- record browser page acquire wait duration and timeout count
- wire limiter acquire/release/timeout paths into the new metrics

## Validation
- pnpm exec vitest run src/shared/metrics.test.ts src/shared/browser-service.test.ts --config vitest.config.ts
- pnpm typecheck
- pnpm test
- pnpm build

TIN-92 follow-up: this gives K8s load proof a direct signal for whether HPA should open above two bridge replicas.