### PR TITLE
Fix Acuity calendar month navigation depth

### DIFF
--- a/src/adapters/acuity/__tests__/wizard-calendar.test.ts
+++ b/src/adapters/acuity/__tests__/wizard-calendar.test.ts
@@ -1,5 +1,60 @@
 import { describe, it, expect } from 'vitest';
-import { MONTH_NAMES, parseYearMonthKey } from '../wizard-calendar.js';
+import { Effect } from 'effect';
+import type { Page } from 'playwright-core';
+import {
+	MAX_CALENDAR_NAVIGATION_STEPS,
+	MONTH_NAMES,
+	navigateToMonth,
+	parseYearMonthKey,
+	type CalendarMonth,
+} from '../wizard-calendar.js';
+
+const addMonths = (current: CalendarMonth, delta: number): CalendarMonth => {
+	const date = new Date(current.year, current.month + delta, 1);
+	return { year: date.getFullYear(), month: date.getMonth() };
+};
+
+const formatMonthLabel = (current: CalendarMonth): string => {
+	const month = MONTH_NAMES[current.month];
+	return `${month.charAt(0).toUpperCase()}${month.slice(1)} ${current.year}`;
+};
+
+const makeCalendarPage = (start: CalendarMonth) => {
+	let current = start;
+	let navClicks = 0;
+
+	const page = {
+		waitForSelector: async (selector: string) => {
+			if (selector.includes('prev-button')) {
+				return {
+					click: async () => {
+						navClicks += 1;
+						current = addMonths(current, -1);
+					},
+				};
+			}
+
+			if (selector.includes('next-button')) {
+				return {
+					click: async () => {
+						navClicks += 1;
+						current = addMonths(current, 1);
+					},
+				};
+			}
+
+			return {};
+		},
+		$eval: async () => formatMonthLabel(current),
+		waitForTimeout: async () => undefined,
+	} as unknown as Page;
+
+	return {
+		page,
+		getCurrent: () => current,
+		getNavClicks: () => navClicks,
+	};
+};
 
 describe('MONTH_NAMES', () => {
 	it('has 12 entries', () => {
@@ -37,5 +92,26 @@ describe('parseYearMonthKey', () => {
 		expect(parseYearMonthKey('2026-00')).toBeNull();
 		expect(parseYearMonthKey('2026-13')).toBeNull();
 		expect(parseYearMonthKey('july-2026')).toBeNull();
+	});
+});
+
+describe('navigateToMonth', () => {
+	it('can reach a future month beyond the old 12-step cap', async () => {
+		const calendar = makeCalendarPage({ year: 2026, month: 4 });
+
+		await Effect.runPromise(navigateToMonth(calendar.page, 6, 2027, 'read-availability'));
+
+		expect(calendar.getCurrent()).toEqual({ year: 2027, month: 6 });
+		expect(calendar.getNavClicks()).toBe(14);
+	});
+
+	it('fails clearly when the target exceeds the navigation budget', async () => {
+		const calendar = makeCalendarPage({ year: 2026, month: 4 });
+
+		await expect(
+			Effect.runPromise(navigateToMonth(calendar.page, 5, 2030, 'read-availability')),
+		).rejects.toThrow(`Could not navigate to june 2030 within ${MAX_CALENDAR_NAVIGATION_STEPS} steps`);
+
+		expect(calendar.getNavClicks()).toBe(MAX_CALENDAR_NAVIGATION_STEPS);
 	});
 });

--- a/src/adapters/acuity/wizard-calendar.ts
+++ b/src/adapters/acuity/wizard-calendar.ts
@@ -24,6 +24,8 @@ export interface CalendarMonth {
 	readonly year: number;
 }
 
+export const MAX_CALENDAR_NAVIGATION_STEPS = 36;
+
 export const parseYearMonthKey = (value: string): CalendarMonth | null => {
 	const match = value.match(/^(\d{4})-(\d{2})$/);
 	if (!match) return null;
@@ -146,7 +148,7 @@ export const clickCalendarNav = (
 
 /**
  * Navigate the calendar to a target month/year.
- * Clicks prev/next up to 12 times to reach the target.
+ * Clicks prev/next up to MAX_CALENDAR_NAVIGATION_STEPS times to reach the target.
  */
 export const navigateToMonth = (
 	page: Page,
@@ -165,7 +167,7 @@ export const navigateToMonth = (
 			),
 		);
 
-		for (let i = 0; i < 12; i++) {
+		for (let i = 0; i <= MAX_CALENDAR_NAVIGATION_STEPS; i++) {
 			const current = yield* getCurrentCalendarMonth(page);
 			if (!current) {
 				return yield* Effect.fail(new WizardStepError({
@@ -176,6 +178,8 @@ export const navigateToMonth = (
 
 			if (current.month === targetMonth && current.year === targetYear) return;
 
+			if (i === MAX_CALENDAR_NAVIGATION_STEPS) break;
+
 			const currentFirst = new Date(current.year, current.month, 1);
 			const targetFirst = new Date(targetYear, targetMonth, 1);
 			const direction = targetFirst > currentFirst ? 'next' : 'prev';
@@ -183,10 +187,10 @@ export const navigateToMonth = (
 			yield* clickCalendarNav(page, direction, step);
 		}
 
-		// If we exhausted 12 iterations, fail
+		// If we exhausted the navigation budget, fail.
 		return yield* Effect.fail(new WizardStepError({
 			step: step as WizardStepError['step'],
-			message: `Could not navigate to ${MONTH_NAMES[targetMonth]} ${targetYear} within 12 steps`,
+			message: `Could not navigate to ${MONTH_NAMES[targetMonth]} ${targetYear} within ${MAX_CALENDAR_NAVIGATION_STEPS} steps`,
 		}));
 	});
 


### PR DESCRIPTION
## Summary
- raise the shared Acuity calendar navigation budget from the old 12-step cap to a 36-step booking horizon
- check the target month after the final allowed click instead of failing immediately after the last navigation
- add unit coverage for the May 2026 to July 2027 path that failed during K8s load proof

## Validation
- pnpm exec vitest run src/adapters/acuity/__tests__/wizard-calendar.test.ts --config vitest.config.ts
- pnpm typecheck
- pnpm test
- pnpm build