### PR TITLE
[codex] Prevent bridge read cache timeout fanout

### DIFF
--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -84,6 +84,7 @@ import type {
 	Service,
 	SchedulingError,
 } from '../core/types.js';
+import { Errors } from '../core/types.js';
 
 // =============================================================================
 // CONFIGURATION
@@ -104,6 +105,14 @@ const READ_CACHE_TTL_SECONDS = (() => {
 const EMPTY_READ_CACHE_TTL_SECONDS = (() => {
 	const parsed = Number(process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS ?? 2 * 60);
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : 2 * 60;
+})();
+const READ_CACHE_LOCK_TTL_MS = (() => {
+	const parsed = Number(process.env.ACUITY_READ_CACHE_LOCK_TTL_MS ?? 90_000);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 90_000;
+})();
+const READ_CACHE_WAIT_TIMEOUT_MS = (() => {
+	const parsed = Number(process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS ?? 55_000);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 55_000;
 })();
 const SLOT_PREWARM_LIMIT = getSlotPrewarmLimit();
 
@@ -366,6 +375,15 @@ const runCachedBridgeRead = async <A>(
 		cacheKey,
 		ttlSeconds: READ_CACHE_TTL_SECONDS,
 		emptyTtlSeconds: EMPTY_READ_CACHE_TTL_SECONDS,
+		lockTtlMs: READ_CACHE_LOCK_TTL_MS,
+		waitTimeoutMs: READ_CACHE_WAIT_TIMEOUT_MS,
+		waitTimeoutResult: (waitMs) => ({
+			ok: false,
+			error: Errors.infrastructure(
+				'TIMEOUT',
+				`Timed out after ${waitMs}ms waiting for ${cacheKind} cache fill`,
+			),
+		}),
 		read,
 		log: ({ event, cacheKind, waitMs, error }) => {
 			logRequestEvent(

--- a/src/shared/bridge-read-cache.test.ts
+++ b/src/shared/bridge-read-cache.test.ts
@@ -102,7 +102,7 @@ describe("runBridgeReadCached", () => {
 
   it("keeps the default wait budget above the observed Acuity cold-read envelope", () => {
     expect(BRIDGE_READ_CACHE_DEFAULTS.waitTimeoutMs).toBeGreaterThanOrEqual(
-      35_000,
+      55_000,
     );
     expect(BRIDGE_READ_CACHE_DEFAULTS.lockTtlMs).toBeGreaterThan(
       BRIDGE_READ_CACHE_DEFAULTS.waitTimeoutMs,
@@ -144,6 +144,34 @@ describe("runBridgeReadCached", () => {
       value: [{ datetime: "2026-05-04T15:00:00" }],
     });
     expect(read).toHaveBeenCalledTimes(1);
+    expect(events.map((event) => event.event)).toContain(
+      "bridge_read_cache_wait_timeout",
+    );
+  });
+
+  it("can return a timeout result instead of amplifying origin reads", async () => {
+    await mock.set("lock:busy-slot-key", "winner-token", "PX", 30_000, "NX");
+    const read = vi.fn(async () => ({
+      ok: true as const,
+      value: [{ datetime: "2026-05-04T15:00:00" }],
+    }));
+    const timeoutError = new Error("still waiting for winner");
+
+    const result = await runBridgeReadCached({
+      redisClient: mock as unknown as BridgeReadCacheClient,
+      cacheKind: "availability_slots",
+      cacheKey: "busy-slot-key",
+      ttlSeconds: 60,
+      emptyTtlSeconds: 10,
+      read,
+      log: (event) => events.push(event),
+      waitTimeoutMs: 30,
+      pollIntervalMs: 5,
+      waitTimeoutResult: () => ({ ok: false, error: timeoutError }),
+    });
+
+    expect(result).toEqual({ ok: false, error: timeoutError });
+    expect(read).not.toHaveBeenCalled();
     expect(events.map((event) => event.event)).toContain(
       "bridge_read_cache_wait_timeout",
     );

--- a/src/shared/bridge-read-cache.ts
+++ b/src/shared/bridge-read-cache.ts
@@ -40,11 +40,12 @@ export interface RunBridgeReadCachedOptions<A, E> {
   readonly lockTtlMs?: number;
   readonly waitTimeoutMs?: number;
   readonly pollIntervalMs?: number;
+  readonly waitTimeoutResult?: (waitMs: number) => BridgeReadResult<A, E>;
 }
 
 export const BRIDGE_READ_CACHE_DEFAULTS = {
-  lockTtlMs: 60_000,
-  waitTimeoutMs: 35_000,
+  lockTtlMs: 90_000,
+  waitTimeoutMs: 55_000,
   pollIntervalMs: 50,
 } as const;
 
@@ -95,6 +96,7 @@ export const runBridgeReadCached = async <A, E>({
   lockTtlMs = BRIDGE_READ_CACHE_DEFAULTS.lockTtlMs,
   waitTimeoutMs = BRIDGE_READ_CACHE_DEFAULTS.waitTimeoutMs,
   pollIntervalMs = BRIDGE_READ_CACHE_DEFAULTS.pollIntervalMs,
+  waitTimeoutResult,
 }: RunBridgeReadCachedOptions<A, E>): Promise<BridgeReadResult<A, E>> => {
   const record = (event: string): void => {
     metrics.recordBridgeReadCacheEvent(cacheKind, event);
@@ -194,5 +196,8 @@ export const runBridgeReadCached = async <A, E>({
     cacheKind,
     waitMs,
   });
+  const timeoutResult = waitTimeoutResult?.(waitMs);
+  if (timeoutResult) return timeoutResult;
+
   return observeRead();
 };


### PR DESCRIPTION
## Summary

- raise bridge read cache single-flight lock/wait defaults to cover observed K8s Acuity cold-read timing
- let HTTP bridge callers return a timeout result when another request is filling the cache, instead of falling through into a duplicate browser read
- add regression coverage proving wait-timeout losers do not amplify origin reads

## Root Cause

The three-pod K8s load proof showed cold month reads taking roughly 36-45s while duplicate requests timed out at the old 35s cache wait budget. Those timeout losers then started their own Acuity browser reads, increasing page pressure and producing request failures under cold traffic.

## Validation

- `pnpm exec vitest run src/shared/bridge-read-cache.test.ts --config vitest.config.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `git diff --check`
