### PR TITLE
[codex] Bound empty date calendar settle

### DIFF
--- a/src/adapters/acuity/steps/read-via-url.test.ts
+++ b/src/adapters/acuity/steps/read-via-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { urlReadNetworkIdleTimeoutMs } from './read-via-url.js';
+import { dateEmptySettleTimeoutMs, urlReadNetworkIdleTimeoutMs } from './read-via-url.js';
 
 describe('URL read timing config', () => {
 	it('uses a short network-idle settle by default', () => {
@@ -18,5 +18,24 @@ describe('URL read timing config', () => {
 
 	it('falls back when the env value is invalid', () => {
 		expect(urlReadNetworkIdleTimeoutMs(30_000, { ACUITY_URL_READ_NETWORK_IDLE_MS: 'nope' })).toBe(1500);
+	});
+});
+
+describe('date empty settle timing config', () => {
+	it('waits briefly for enabled dates by default', () => {
+		expect(dateEmptySettleTimeoutMs(30_000, {})).toBe(2500);
+	});
+
+	it('honors explicit empty-date settle config including zero', () => {
+		expect(dateEmptySettleTimeoutMs(30_000, { ACUITY_EMPTY_DATE_SETTLE_MS: '1000' })).toBe(1000);
+		expect(dateEmptySettleTimeoutMs(30_000, { ACUITY_EMPTY_DATE_SETTLE_MS: '0' })).toBe(0);
+	});
+
+	it('never exceeds the caller operation timeout', () => {
+		expect(dateEmptySettleTimeoutMs(500, { ACUITY_EMPTY_DATE_SETTLE_MS: '2500' })).toBe(500);
+	});
+
+	it('falls back when the empty-date settle env value is invalid', () => {
+		expect(dateEmptySettleTimeoutMs(30_000, { ACUITY_EMPTY_DATE_SETTLE_MS: 'nope' })).toBe(2500);
 	});
 });

--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -41,6 +41,7 @@ export interface UrlSlotResult {
 }
 
 const DEFAULT_URL_READ_NETWORK_IDLE_MS = 1500;
+const DEFAULT_EMPTY_DATE_SETTLE_MS = 2500;
 
 export const urlReadNetworkIdleTimeoutMs = (
 	timeout: number,
@@ -50,6 +51,18 @@ export const urlReadNetworkIdleTimeoutMs = (
 	const parsed = raw === undefined || raw === '' ? DEFAULT_URL_READ_NETWORK_IDLE_MS : Number(raw);
 	if (!Number.isFinite(parsed) || parsed < 0) {
 		return Math.min(timeout, DEFAULT_URL_READ_NETWORK_IDLE_MS);
+	}
+	return Math.min(timeout, Math.floor(parsed));
+};
+
+export const dateEmptySettleTimeoutMs = (
+	timeout: number,
+	env: Record<string, string | undefined> = process.env,
+): number => {
+	const raw = env.ACUITY_EMPTY_DATE_SETTLE_MS;
+	const parsed = raw === undefined || raw === '' ? DEFAULT_EMPTY_DATE_SETTLE_MS : Number(raw);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		return Math.min(timeout, DEFAULT_EMPTY_DATE_SETTLE_MS);
 	}
 	return Math.min(timeout, Math.floor(parsed));
 };
@@ -124,6 +137,7 @@ const readEnabledCalendarDates = (
 			document.querySelectorAll(sel).forEach(tile => {
 				if ((tile as HTMLButtonElement).disabled) return;
 				if (tile.classList.contains(neighboringClass)) return;
+				if (tile.classList.contains('neighboringMonth')) return;
 
 				const abbr = tile.querySelector('abbr');
 				const label = abbr?.getAttribute('aria-label') || tile.getAttribute('data-date') || '';
@@ -138,6 +152,37 @@ const readEnabledCalendarDates = (
 		}, tileSelector),
 		catch: (e) => new WizardStepError({ step: 'read-availability', message: `Calendar read failed: ${e}` }),
 	});
+
+const waitForEnabledCalendarDate = (
+	page: Page,
+	tileSelector: string,
+	timeout: number,
+): Effect.Effect<void, never> =>
+	Effect.tryPromise({
+		try: async () => {
+			const waitMs = dateEmptySettleTimeoutMs(timeout);
+			if (waitMs <= 0) return;
+
+			await page.waitForFunction((sel) => {
+				const neighboringClasses = [
+					'react-calendar__tile--neighboringMonth',
+					'neighboringMonth',
+				];
+				return Array.from(document.querySelectorAll(sel)).some(tile => {
+					const button = tile as HTMLButtonElement;
+					if (button.disabled || button.getAttribute('aria-disabled') === 'true') return false;
+					if (neighboringClasses.some(className => tile.classList.contains(className))) return false;
+
+					const abbr = tile.querySelector('abbr');
+					const label = abbr?.getAttribute('aria-label') || tile.getAttribute('data-date') || '';
+					if (!label) return false;
+
+					return !Number.isNaN(new Date(label).getTime());
+				});
+			}, tileSelector, { timeout: waitMs }).catch(() => {});
+		},
+		catch: () => undefined,
+	}).pipe(Effect.ignore);
 
 // =============================================================================
 // READ DATES VIA URL PARAM
@@ -180,28 +225,9 @@ export const readDatesViaUrl = (
 		}
 
 		// Acuity occasionally paints the calendar shell before enabled dates are attached.
-		// Give the same page a short second chance before treating the month as empty.
-		yield* Effect.tryPromise({
-			try: () => page.waitForTimeout(750),
-			catch: () => null,
-		}).pipe(Effect.ignore);
-
-		dates = yield* readEnabledCalendarDates(page, tileSelector);
-		if (dates.length > 0) {
-			return dates;
-		}
-
-		// Final fallback: reload once and retry the DOM read. This is still cheaper
-		// than returning a false-empty month to the app and stranding the calendar.
-		yield* Effect.tryPromise({
-			try: () => navigateForUrlRead(page, url, config.timeout),
-			catch: (e) => new WizardStepError({ step: 'read-availability', message: `Retry navigation failed: ${e}` }),
-		});
-		yield* navigateToTargetMonth(page, targetMonth, 'read-availability');
-		yield* Effect.tryPromise({
-			try: () => page.waitForSelector(calendarSelector, { timeout: 10000 }),
-			catch: () => null,
-		}).pipe(Effect.ignore);
+		// Wait briefly for enabled tiles on the same page, but do not re-run a full
+		// deep-month navigation when the target month is legitimately empty.
+		yield* waitForEnabledCalendarDate(page, tileSelector, config.timeout);
 
 		return yield* readEnabledCalendarDates(page, tileSelector);
 	}));


### PR DESCRIPTION
## Summary

- replace the full reload-on-empty availability fallback with a bounded same-page settle for enabled date tiles
- skip neighboring-month tiles consistently when reading enabled calendar dates
- add timing config coverage for `ACUITY_EMPTY_DATE_SETTLE_MS`

## Root Cause

The live `sha-b799b40` load proof stopped cache-timeout fanout, but legitimately empty far-future months could still trigger the old fallback path: reload the service calendar and navigate the same deep month again. Under five cold month winners, that doubled the most expensive part of the read and pushed some requests past the 55-60s envelope.

## Validation

- `pnpm exec vitest run src/adapters/acuity/steps/read-via-url.test.ts --config vitest.config.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `git diff --check`
