### PR TITLE
Harden payment booking service matching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,10 @@ As of `2026-04-25`, the active structural work here is:
 
 Operationally relevant truth:
 
-- current package metadata is `@tummycrypt/scheduling-bridge` `0.4.7`
-- `0.4.7` depends on `@tummycrypt/scheduling-kit ^0.7.5`
-- as of `2026-05-02`, npm `latest`, git tag `v0.4.6`, and the K8s bridge
-  shadow runtime are aligned on the previous `0.4.6` release edge
+- current package metadata is `@tummycrypt/scheduling-bridge` `0.4.8`
+- `0.4.8` depends on `@tummycrypt/scheduling-kit ^0.7.5`
+- as of `2026-05-03`, npm `latest`, git tag `v0.4.8`, and the K8s bridge
+  shadow runtime are aligned on the current `0.4.8` release edge
 - package metadata, git tags, npm dist-tags, GitHub releases, and deployed
   bridge runtime tuples remain separate authority surfaces and should be
   verified explicitly

--- a/src/adapters/acuity/steps/navigate.test.ts
+++ b/src/adapters/acuity/steps/navigate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+	normalizeServiceNameForMatch,
+	serviceNameMatches,
+} from './navigate.js';
+
+describe('serviceNameMatches', () => {
+	it('matches catalog service names with trailing whitespace against Acuity page text', () => {
+		expect(
+			serviceNameMatches(
+				'TMD 1st Consultation & Session',
+				'TMD 1st Consultation & Session ',
+			),
+		).toBe(true);
+	});
+
+	it('collapses repeated whitespace before comparing service names', () => {
+		expect(
+			serviceNameMatches(
+				'TMD 1st Consultation & Session',
+				'TMD   1st Consultation   &   Session',
+			),
+		).toBe(true);
+	});
+
+	it('does not match empty requested or candidate names', () => {
+		expect(serviceNameMatches('TMD 1st Consultation & Session', '   ')).toBe(false);
+		expect(serviceNameMatches('   ', 'TMD 1st Consultation & Session')).toBe(false);
+	});
+});
+
+describe('normalizeServiceNameForMatch', () => {
+	it('trims, lowercases, and normalizes inner whitespace', () => {
+		expect(normalizeServiceNameForMatch('  TMD   1st Consultation & Session  ')).toBe(
+			'tmd 1st consultation & session',
+		);
+	});
+});

--- a/src/adapters/acuity/steps/navigate.ts
+++ b/src/adapters/acuity/steps/navigate.ts
@@ -46,6 +46,15 @@ export interface NavigateResult {
 	readonly selectedTime: string;
 }
 
+export const normalizeServiceNameForMatch = (name: string): string =>
+	name.trim().replace(/\s+/g, ' ').toLowerCase();
+
+export const serviceNameMatches = (candidateName: string, requestedName: string): boolean => {
+	const candidate = normalizeServiceNameForMatch(candidateName);
+	const requested = normalizeServiceNameForMatch(requestedName);
+	return candidate.length > 0 && requested.length > 0 && candidate.includes(requested);
+};
+
 // =============================================================================
 // IMPLEMENTATION
 // =============================================================================
@@ -150,7 +159,7 @@ const selectService = (
 				for (const item of items) {
 					const nameEl = await item.$(Selectors.serviceName[0]);
 					const name = await nameEl?.textContent();
-					if (name && name.trim().toLowerCase().includes(serviceName.toLowerCase())) {
+					if (name && serviceNameMatches(name, serviceName)) {
 						return item;
 					}
 				}

--- a/src/server/__tests__/booking-create-with-payment.test.ts
+++ b/src/server/__tests__/booking-create-with-payment.test.ts
@@ -1,0 +1,223 @@
+import { type AddressInfo } from 'node:net';
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const stepMocks = vi.hoisted(() => ({
+	navigateToBooking: vi.fn(),
+	fillFormFields: vi.fn(),
+	bypassPayment: vi.fn(),
+	generateCouponCode: vi.fn(),
+	submitBooking: vi.fn(),
+	extractConfirmation: vi.fn(),
+	toBooking: vi.fn(),
+	readAvailableDates: vi.fn(),
+	readTimeSlots: vi.fn(),
+	fetchBusinessData: vi.fn(),
+	businessToServices: vi.fn(),
+}));
+
+vi.mock('../../adapters/acuity/steps/index.js', () => stepMocks);
+
+const service = {
+	id: '53178494',
+	name: 'TMD 1st Consultation & Session ',
+	duration: 90,
+	price: 15500,
+	currency: 'USD',
+	category: 'TMD',
+	description: 'Consultation and treatment',
+};
+
+const bookingRequest = {
+	serviceId: service.id,
+	datetime: '2026-05-30T18:00:00.000Z',
+	client: {
+		firstName: 'Jess',
+		lastName: 'Sullivan',
+		email: 'jess@example.com',
+		phone: '6075551212',
+		notes: 'test booking',
+		customFields: { pronouns: 'she/her' },
+	},
+};
+
+const listen = async () => {
+	const { server } = await import('../handler.js');
+	await new Promise<void>((resolve) => {
+		server.listen(0, '127.0.0.1', resolve);
+	});
+	const address = server.address() as AddressInfo;
+	return {
+		server,
+		baseUrl: `http://127.0.0.1:${address.port}`,
+	};
+};
+
+describe('POST /booking/create-with-payment', () => {
+	let activeServer: Awaited<ReturnType<typeof listen>>['server'] | null = null;
+
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		process.env.SERVICES_JSON = JSON.stringify([service]);
+		process.env.ACUITY_BYPASS_COUPON = 'TEST-100';
+		delete process.env.REDIS_URL;
+		delete process.env.AUTH_TOKEN;
+
+		stepMocks.navigateToBooking.mockReturnValue(
+			Effect.succeed({
+				url: 'https://massageithaca.as.me/schedule/mock/datetime/2026-05-30T18:00:00.000Z',
+				landingStep: 'client-form',
+				appointmentTypeId: service.id,
+				calendarId: '1234',
+				selectedDate: '2026-05-30',
+				selectedTime: '2:00 PM',
+			}),
+		);
+		stepMocks.fillFormFields.mockReturnValue(
+			Effect.succeed({ fieldsFilled: 3 }),
+		);
+		stepMocks.bypassPayment.mockReturnValue(Effect.succeed({ applied: true }));
+		stepMocks.submitBooking.mockReturnValue(
+			Effect.succeed({ submitted: true }),
+		);
+		stepMocks.extractConfirmation.mockReturnValue(
+			Effect.succeed({
+				appointmentId: 'apt_123',
+				confirmationCode: 'confirm_123',
+				serviceName: service.name.trim(),
+				datetime: bookingRequest.datetime,
+				providerName: null,
+				rawText: 'Booking confirmed',
+			}),
+		);
+		stepMocks.toBooking.mockReturnValue({
+			id: 'apt_123',
+			serviceId: service.id,
+			serviceName: service.name.trim(),
+			datetime: bookingRequest.datetime,
+			duration: service.duration,
+			price: service.price,
+			currency: service.currency,
+			client: bookingRequest.client,
+			status: 'confirmed',
+			confirmationCode: 'confirm_123',
+			paymentStatus: 'paid',
+			paymentRef: '[STRIPE] Transaction: pi_test_123',
+			createdAt: '2026-05-03T00:00:00.000Z',
+		});
+	});
+
+	afterEach(async () => {
+		if (activeServer?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				activeServer!.close((error) => (error ? reject(error) : resolve()));
+			});
+		}
+		activeServer = null;
+		delete process.env.SERVICES_JSON;
+		delete process.env.ACUITY_BYPASS_COUPON;
+	});
+
+	it('uses the static catalog service name, bypass coupon, and payment reference', async () => {
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await fetch(
+			`${running.baseUrl}/booking/create-with-payment`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					request: bookingRequest,
+					paymentRef: 'pi_test_123',
+					paymentProcessor: 'stripe',
+				}),
+			},
+		);
+
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({
+			success: true,
+			data: {
+				id: 'apt_123',
+				paymentRef: '[STRIPE] Transaction: pi_test_123',
+			},
+		});
+		expect(stepMocks.navigateToBooking).toHaveBeenCalledWith(
+			expect.objectContaining({
+				serviceName: service.name,
+				datetime: bookingRequest.datetime,
+				appointmentTypeId: service.id,
+			}),
+		);
+		expect(stepMocks.bypassPayment).toHaveBeenCalledWith('TEST-100');
+		expect(stepMocks.toBooking).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ serviceId: service.id }),
+			'pi_test_123',
+			'stripe',
+			expect.objectContaining({
+				name: service.name,
+				duration: service.duration,
+				price: service.price,
+				currency: service.currency,
+			}),
+		);
+	});
+
+	it('accepts a request-scoped coupon code override', async () => {
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await fetch(
+			`${running.baseUrl}/booking/create-with-payment`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					request: bookingRequest,
+					paymentRef: 'venmo_order_123',
+					paymentProcessor: 'venmo',
+					couponCode: 'REQUEST-100',
+				}),
+			},
+		);
+
+		expect(response.status).toBe(200);
+		expect(stepMocks.bypassPayment).toHaveBeenCalledWith('REQUEST-100');
+	});
+
+	it('rejects paid booking finalization before navigation when no bypass coupon is configured', async () => {
+		delete process.env.ACUITY_BYPASS_COUPON;
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await fetch(
+			`${running.baseUrl}/booking/create-with-payment`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					request: bookingRequest,
+					paymentRef: 'pi_test_123',
+					paymentProcessor: 'stripe',
+				}),
+			},
+		);
+
+		const body = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(body).toMatchObject({
+			success: false,
+			error: {
+				tag: 'ValidationError',
+				code: 'couponCode',
+			},
+		});
+		expect(stepMocks.navigateToBooking).not.toHaveBeenCalled();
+	});
+});

--- a/src/server/__tests__/booking-create-with-payment.test.ts
+++ b/src/server/__tests__/booking-create-with-payment.test.ts
@@ -42,7 +42,21 @@ const bookingRequest = {
 };
 
 const listen = async () => {
-	const { server } = await import('../handler.js');
+	const {
+		server,
+		__runEffectWithoutBrowserForTest,
+		__setAcuityStepOverridesForTest,
+		__setEffectRunnerForTest,
+	} = await import('../handler.js');
+	__setEffectRunnerForTest(__runEffectWithoutBrowserForTest);
+	__setAcuityStepOverridesForTest({
+		navigateToBooking: stepMocks.navigateToBooking,
+		fillFormFields: stepMocks.fillFormFields,
+		bypassPayment: stepMocks.bypassPayment,
+		submitBooking: stepMocks.submitBooking,
+		extractConfirmation: stepMocks.extractConfirmation,
+		toBooking: stepMocks.toBooking,
+	});
 	await new Promise<void>((resolve) => {
 		server.listen(0, '127.0.0.1', resolve);
 	});

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -790,7 +790,7 @@ const handleCreateBookingWithPayment = async (
 	const result = await runEffect(
 		Effect.gen(function* () {
 			yield* navigateToBooking({
-				serviceName,
+				serviceName: serviceName ?? request.serviceId,
 				datetime: request.datetime,
 				client: request.client,
 				appointmentTypeId: request.serviceId,

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -86,6 +86,26 @@ import type {
 } from '../core/types.js';
 import { Errors } from '../core/types.js';
 
+const acuitySteps = {
+	navigateToBooking,
+	fillFormFields,
+	bypassPayment,
+	generateCouponCode,
+	submitBooking,
+	extractConfirmation,
+	toBooking,
+	readAvailableDates,
+	readTimeSlots,
+	readDatesViaUrl,
+	readSlotsViaUrl,
+};
+
+export const __setAcuityStepOverridesForTest = (
+	overrides: Partial<typeof acuitySteps>,
+) => {
+	Object.assign(acuitySteps, overrides);
+};
+
 // =============================================================================
 // CONFIGURATION
 // =============================================================================
@@ -268,12 +288,9 @@ const browserRuntime = ManagedRuntime.make(BrowserProcessLive(browserConfig));
 
 type Result<A> = { ok: true; value: A } | { ok: false; error: SchedulingError };
 
-const runEffect = async <A>(
-	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
-): Promise<Result<A>> => {
-	const exit = await browserRuntime.runPromiseExit(
-		Effect.scoped(effect.pipe(Effect.provide(BrowserSessionLive))),
-	);
+const exitToResult = <A>(
+	exit: Exit.Exit<A, MiddlewareError | undefined>,
+): Result<A> => {
 	if (Exit.isSuccess(exit)) {
 		return { ok: true, value: exit.value };
 	}
@@ -282,6 +299,34 @@ const runEffect = async <A>(
 		return { ok: false, error: toSchedulingError(failure.value) };
 	}
 	return { ok: false, error: { _tag: 'InfrastructureError', code: 'UNKNOWN', message: Cause.pretty(exit.cause) } };
+};
+
+type RunEffect = <A>(
+	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
+) => Promise<Result<A>>;
+
+const runEffectWithBrowser: RunEffect = async <A>(
+	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
+): Promise<Result<A>> => {
+	const exit = await browserRuntime.runPromiseExit(
+		Effect.scoped(effect.pipe(Effect.provide(BrowserSessionLive))),
+	);
+	return exitToResult(exit);
+};
+
+let runEffect: RunEffect = runEffectWithBrowser;
+
+export const __runEffectWithoutBrowserForTest: RunEffect = async <A>(
+	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
+): Promise<Result<A>> => {
+	const exit = await Effect.runPromiseExit(
+		effect as Effect.Effect<A, MiddlewareError | undefined, never>,
+	);
+	return exitToResult(exit);
+};
+
+export const __setEffectRunnerForTest = (runner: RunEffect | null) => {
+	runEffect = runner ?? runEffectWithBrowser;
 };
 
 // =============================================================================
@@ -442,7 +487,7 @@ const scheduleSlotPrewarm = (
 			const cacheKey = buildAvailabilitySlotsCacheKey(ACUITY_BASE_URL, serviceId, date);
 			const result = await runCachedBridgeRead(context, 'availability_slots', cacheKey, () =>
 				runEffect(
-					readSlotsViaUrl(
+					acuitySteps.readSlotsViaUrl(
 						serviceId,
 						date,
 						createSlotReadTelemetryContext(context, 'availability_slots_prewarm'),
@@ -578,7 +623,7 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 	const cacheKey = `bridge-read:v2:dates:${ACUITY_BASE_URL}:${body.serviceId}:${targetMonth ?? 'current'}`;
 	const result = await runCachedBridgeRead(context, 'availability_dates', cacheKey, () =>
 		isAcuityAppointmentTypeId(body.serviceId)
-			? runEffect(readDatesViaUrl(body.serviceId, targetMonth))
+			? runEffect(acuitySteps.readDatesViaUrl(body.serviceId, targetMonth))
 			: (async () => {
 				const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
 				logRequestEvent('INFO', 'Availability dates resolved service name', context, {
@@ -588,7 +633,7 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 					startDate: body.startDate,
 				});
 				return runEffect(
-					readAvailableDates({
+					acuitySteps.readAvailableDates({
 						serviceName,
 						targetMonth,
 						monthsToScan: 2,
@@ -628,7 +673,7 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 	const result = await runCachedBridgeRead(context, 'availability_slots', cacheKey, () =>
 		isAcuityAppointmentTypeId(body.serviceId)
 			? runEffect(
-				readSlotsViaUrl(
+				acuitySteps.readSlotsViaUrl(
 					body.serviceId,
 					body.date,
 					createSlotReadTelemetryContext(context, 'availability_slots'),
@@ -643,7 +688,7 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 					date: body.date,
 				});
 				return runEffect(
-					readTimeSlots({
+					acuitySteps.readTimeSlots({
 						serviceName,
 						date: body.date,
 					}),
@@ -680,7 +725,7 @@ const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse, contex
 	});
 	const result = isAcuityAppointmentTypeId(body.serviceId)
 		? await runEffect(
-				readSlotsViaUrl(
+				acuitySteps.readSlotsViaUrl(
 					body.serviceId,
 					date,
 					createSlotReadTelemetryContext(context, 'availability_check'),
@@ -689,7 +734,7 @@ const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse, contex
 		: await (async () => {
 				const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
 				return runEffect(
-					readTimeSlots({
+					acuitySteps.readTimeSlots({
 						serviceName,
 						date,
 					}),
@@ -730,16 +775,16 @@ const handleCreateBooking = async (req: IncomingMessage, res: ServerResponse, co
 
 	const result = await runEffect(
 		Effect.gen(function* () {
-			yield* navigateToBooking({
+			yield* acuitySteps.navigateToBooking({
 				serviceName: serviceName ?? request.serviceId,
 				datetime: request.datetime,
 				client: request.client,
 				appointmentTypeId: request.serviceId,
 			});
-			yield* fillFormFields({ client: request.client, customFields: request.client.customFields });
-			yield* submitBooking();
-			const confirmation = yield* extractConfirmation();
-			return toBooking(confirmation, request, '', 'acuity');
+			yield* acuitySteps.fillFormFields({ client: request.client, customFields: request.client.customFields });
+			yield* acuitySteps.submitBooking();
+			const confirmation = yield* acuitySteps.extractConfirmation();
+			return acuitySteps.toBooking(confirmation, request, '', 'acuity');
 		}),
 	);
 
@@ -789,17 +834,17 @@ const handleCreateBookingWithPayment = async (
 
 	const result = await runEffect(
 		Effect.gen(function* () {
-			yield* navigateToBooking({
+			yield* acuitySteps.navigateToBooking({
 				serviceName: serviceName ?? request.serviceId,
 				datetime: request.datetime,
 				client: request.client,
 				appointmentTypeId: request.serviceId,
 			});
-			yield* fillFormFields({ client: request.client, customFields: request.client.customFields });
-			yield* bypassPayment(coupon);
-			yield* submitBooking();
-			const confirmation = yield* extractConfirmation();
-			return toBooking(
+			yield* acuitySteps.fillFormFields({ client: request.client, customFields: request.client.customFields });
+			yield* acuitySteps.bypassPayment(coupon);
+			yield* acuitySteps.submitBooking();
+			const confirmation = yield* acuitySteps.extractConfirmation();
+			return acuitySteps.toBooking(
 				confirmation,
 				request,
 				paymentRef,


### PR DESCRIPTION
## Summary
- normalize Acuity service-name matching so trailing/repeated whitespace in the service catalog cannot break booking navigation
- make `/booking/create-with-payment` fall back to `request.serviceId` when service-name resolution is unavailable, matching the standard booking path
- update AGENTS runtime truth to scheduling-bridge 0.4.8 / kit ^0.7.5 / K8s runtime edge
- add focused regression coverage for the service-name matcher
- add HTTP-level `/booking/create-with-payment` coverage for coupon handling, service metadata, and payment reference propagation

## Validation
- `pnpm test`
- `pnpm exec vitest run src/adapters/acuity/steps/navigate.test.ts`
- `pnpm exec vitest run src/server/__tests__/booking-create-with-payment.test.ts src/adapters/acuity/steps/navigate.test.ts`
- `pnpm typecheck`
- `git diff --check`

## Context
This targets the K8s failure where Stripe/card payment was captured but the external-payment booking write failed with `Wizard step navigate failed: Service "TMD 1st Consultation & Session " not found on the page`.