### PR TITLE
Prewarm adjacent availability date months

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -173,7 +173,13 @@ vitest_bin.vitest_test(
         "tsconfig.json",
         ":node_modules/vitest",
         "vitest.config.ts",
-    ] + glob(["src/**/*.ts"]),
+    ] + glob([
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        "parity/**/*.ts",
+        "bench/**/*.ts",
+        "bench/**/*.js",
+    ]),
     args = [
         "run",
         "--reporter=verbose",

--- a/bench/README.md
+++ b/bench/README.md
@@ -8,11 +8,13 @@ Results feed `paper/data/phase1/` for the migration paper.
 ### 1. Install k6
 
 macOS:
+
 ```bash
 brew install k6
 ```
 
 Debian/Ubuntu:
+
 ```bash
 sudo apt install k6
 ```
@@ -26,6 +28,7 @@ Either:
 **Option A — Tailnet (recommended for K8s target):**
 The default `BASE_URL` resolves via MagicDNS. Verify your machine is on the
 tailnet and the service is reachable:
+
 ```bash
 tailscale status | grep ts-acuity-mw
 curl http://ts-acuity-mw.ts.net:3001/services
@@ -33,19 +36,22 @@ curl http://ts-acuity-mw.ts.net:3001/services
 
 **Option B — Direct URL (Modal or any reachable host):**
 Pass `--base-url` equivalent by setting `BASE_URL` in your environment:
+
 ```bash
 BASE_URL=https://your-modal-endpoint.modal.run TARGET=modal ./run.sh
 ```
 
 ## Environment Variables
 
-| Variable                  | Default                              | Description                                      |
-|---------------------------|--------------------------------------|--------------------------------------------------|
-| `BASE_URL`                | `http://ts-acuity-mw.ts.net:3001`   | Base URL of the middleware under test            |
-| `AUTH_TOKEN`              | *(empty)*                            | Bearer token for Authorization header            |
-| `TARGET`                  | `unknown`                            | Result tag: `modal` or `k8s`                     |
-| `SERVICE_IDS`             | `1,2,3,4,5`                          | Comma-separated IDs rotated for slot requests    |
-| `EXPECTED_CACHE_HIT_RATIO`| `0.8`                                | Expected fast-response ratio (10k test, informational) |
+| Variable                   | Default                           | Description                                                       |
+| -------------------------- | --------------------------------- | ----------------------------------------------------------------- |
+| `BASE_URL`                 | `http://ts-acuity-mw.ts.net:3001` | Base URL of the middleware under test                             |
+| `AUTH_TOKEN`               | _(empty)_                         | Bearer token for Authorization header                             |
+| `TARGET`                   | `unknown`                         | Result tag: `modal` or `k8s`                                      |
+| `SERVICE_IDS`              | `53178494`                        | Comma-separated Acuity appointment type IDs                       |
+| `DATE_MONTHS`              | current month,next month          | Comma-separated `YYYY-MM` months for `POST /availability/dates`   |
+| `SLOT_DATES`               | tomorrow                          | Comma-separated `YYYY-MM-DD` dates for `POST /availability/slots` |
+| `EXPECTED_CACHE_HIT_RATIO` | `0.8`                             | Expected fast-response ratio (10k test, informational)            |
 
 ## Running
 
@@ -60,6 +66,7 @@ BASE_URL=https://your-org--acuity-mw.modal.run AUTH_TOKEN=xxx TARGET=modal ./run
 ```
 
 `run.sh` runs all three scenarios in sequence and writes results to:
+
 ```
 results/<ISO8601_timestamp>-<TARGET>/
   smoke.json
@@ -69,16 +76,16 @@ results/<ISO8601_timestamp>-<TARGET>/
 
 ## Scenarios
 
-| Script            | VUs       | Requests | Endpoints                               |
-|-------------------|-----------|----------|-----------------------------------------|
-| `k6-smoke.js`     | 1         | 100      | `GET /services`                         |
-| `k6-load-1k.js`   | 10 (ramped)| ~1000   | `GET /services`, `GET /availability/slots` |
-| `k6-load-10k.js`  | 20 (sustained 8min) | ~10000 | same as 1k              |
+| Script           | VUs                 | Requests | Endpoints                                                               |
+| ---------------- | ------------------- | -------- | ----------------------------------------------------------------------- |
+| `k6-smoke.js`    | 1                   | 100      | `GET /services`                                                         |
+| `k6-load-1k.js`  | 10 (ramped)         | ~1000    | `GET /services`, `POST /availability/dates`, `POST /availability/slots` |
+| `k6-load-10k.js` | 20 (sustained 8min) | ~10000   | same as 1k                                                              |
 
 ## Thresholds
 
 | Scenario | `http_req_failed` | `http_req_duration p(99)` |
-|----------|-------------------|---------------------------|
+| -------- | ----------------- | ------------------------- |
 | smoke    | < 1%              | < 8 s                     |
 | load-1k  | < 2%              | < 10 s                    |
 | load-10k | < 5%              | < 15 s                    |
@@ -86,9 +93,17 @@ results/<ISO8601_timestamp>-<TARGET>/
 ## Interpreting Results
 
 The `--summary-export` JSON files contain aggregated metrics including
-`http_req_duration`, `http_req_failed`, and (for 10k) `cache_hint_fast_response`.
+`http_req_duration`, `http_req_failed`, and (for 10k)
+`cache_hint_fast_response`, `cache_hint_fast_services`,
+`cache_hint_fast_dates`, and `cache_hint_fast_slots`.
+
+The load scenarios intentionally use the same JSON `POST` protocol as the
+application and parity harness. Do not convert availability reads back to query
+string `GET` requests; those do not exercise the deployed bridge routes or the
+Redis read-cache keys used by `MassageIthaca`.
 
 Copy result directories into `paper/data/phase1/` to feed the comparison analysis:
+
 ```bash
 cp -r results/<run>/ ../paper/data/phase1/<run>/
 ```

--- a/bench/k6-load-10k.js
+++ b/bench/k6-load-10k.js
@@ -4,76 +4,142 @@ import { check, sleep } from 'k6';
 import { Rate } from 'k6/metrics';
 
 export const options = {
-  stages: [
-    { duration: '8m', target: 20 }, // 20 VUs sustained for 8 min
-    { duration: '30s', target: 0 }, // ramp down
-  ],
-  thresholds: {
-    http_req_failed: ['rate<0.05'],
-    http_req_duration: ['p(99)<15000'],
-  },
+	stages: [
+		{ duration: '8m', target: 20 }, // 20 VUs sustained for 8 min
+		{ duration: '30s', target: 0 }, // ramp down
+	],
+	thresholds: {
+		http_req_failed: ['rate<0.05'],
+		http_req_duration: ['p(99)<15000'],
+	},
 };
 
 const BASE_URL = __ENV.BASE_URL || 'http://ts-acuity-mw.ts.net:3001';
 const AUTH_TOKEN = __ENV.AUTH_TOKEN || '';
 const EXPECTED_CACHE_HIT_RATIO = parseFloat(
-  __ENV.EXPECTED_CACHE_HIT_RATIO || '0.8'
+	__ENV.EXPECTED_CACHE_HIT_RATIO || '0.8',
 );
 
-// Service IDs to rotate through for /availability/slots requests
-const RAW_IDS = __ENV.SERVICE_IDS || '1,2,3,4,5';
-const SERVICE_IDS = RAW_IDS.split(',').map((s) => s.trim());
+const parseList = (value) =>
+	value
+		.split(',')
+		.map((s) => s.trim())
+		.filter(Boolean);
+
+// Massage Ithaca's TMD consultation appointment type. Override for other tenants.
+const SERVICE_IDS = parseList(__ENV.SERVICE_IDS || '53178494');
 
 // Custom metric: track cache-hit-indicative fast responses (<200ms)
 const fastResponses = new Rate('cache_hint_fast_response');
+const fastServices = new Rate('cache_hint_fast_services');
+const fastDates = new Rate('cache_hint_fast_dates');
+const fastSlots = new Rate('cache_hint_fast_slots');
 
 // Simple date helper: YYYY-MM-DD for tomorrow
 const tomorrow = () => {
-  const d = new Date();
-  d.setDate(d.getDate() + 1);
-  return d.toISOString().slice(0, 10);
+	const d = new Date();
+	d.setDate(d.getDate() + 1);
+	return d.toISOString().slice(0, 10);
 };
 
+const monthOffset = (offset) => {
+	const d = new Date();
+	d.setUTCDate(1);
+	d.setUTCMonth(d.getUTCMonth() + offset);
+	return d.toISOString().slice(0, 7);
+};
+
+const DATE_MONTHS = parseList(
+	__ENV.DATE_MONTHS || `${monthOffset(0)},${monthOffset(1)}`,
+);
+const SLOT_DATES = parseList(__ENV.SLOT_DATES || tomorrow());
+
+const authHeaders = () =>
+	AUTH_TOKEN ? { Authorization: `Bearer ${AUTH_TOKEN}` } : {};
+
+const jsonHeaders = () => ({
+	...authHeaders(),
+	'Content-Type': 'application/json',
+});
+
+const hasArrayPayload = (r) =>
+	Array.isArray(r.json('data')) ||
+	Array.isArray(r.json('services')) ||
+	Array.isArray(r.json());
+
+const serviceIdFor = (iterationGroup) =>
+	SERVICE_IDS[iterationGroup % SERVICE_IDS.length];
+const monthFor = (iterationGroup) =>
+	DATE_MONTHS[iterationGroup % DATE_MONTHS.length];
+const slotDateFor = (iterationGroup) =>
+	SLOT_DATES[iterationGroup % SLOT_DATES.length];
+
 export default function () {
-  const headers = { Authorization: `Bearer ${AUTH_TOKEN}` };
-  const tag = { target: __ENV.TARGET || 'unknown' };
+	const target = __ENV.TARGET || 'unknown';
 
-  // Alternate between /services and /availability/slots
-  const iteration = __ITER % 2;
-  if (iteration === 0) {
-    const res = http.get(`${BASE_URL}/services`, { headers, tags: tag });
-    check(res, {
-      'status 200': (r) => r.status === 200,
-      'services array present': (r) =>
-        Array.isArray(r.json('services')) || Array.isArray(r.json()),
-    });
-    fastResponses.add(res.timings.duration < 200);
-  } else {
-    // __ITER is always odd in this branch; using `__ITER % length` skips
-    // half the services when `SERVICE_IDS.length` is even. `Math.floor(__ITER / 2)`
-    // gives a dense 0,0,1,1,2,2,... index that rotates through every entry.
-    const serviceId = SERVICE_IDS[Math.floor(__ITER / 2) % SERVICE_IDS.length];
-    const date = tomorrow();
-    const res = http.get(
-      `${BASE_URL}/availability/slots?serviceId=${serviceId}&date=${date}`,
-      { headers, tags: tag }
-    );
-    check(res, {
-      'status 200': (r) => r.status === 200,
-    });
-    fastResponses.add(res.timings.duration < 200);
-  }
+	// Alternate across service catalog, date cache, and slot cache paths.
+	const iteration = __ITER % 3;
+	const group = Math.floor(__ITER / 3);
+	if (iteration === 0) {
+		const res = http.get(`${BASE_URL}/services`, {
+			headers: authHeaders(),
+			tags: { target, endpoint: 'services' },
+		});
+		check(res, {
+			'status 200': (r) => r.status === 200,
+			'services array present': hasArrayPayload,
+		});
+		const isFast = res.timings.duration < 200;
+		fastResponses.add(isFast);
+		fastServices.add(isFast);
+	} else if (iteration === 1) {
+		const serviceId = serviceIdFor(group);
+		const month = monthFor(group);
+		const res = http.post(
+			`${BASE_URL}/availability/dates`,
+			JSON.stringify({ serviceId, startDate: month }),
+			{
+				headers: jsonHeaders(),
+				tags: { target, endpoint: 'availability_dates' },
+			},
+		);
+		check(res, {
+			'status 200': (r) => r.status === 200,
+			'dates array present': hasArrayPayload,
+		});
+		const isFast = res.timings.duration < 200;
+		fastResponses.add(isFast);
+		fastDates.add(isFast);
+	} else {
+		const serviceId = serviceIdFor(group);
+		const date = slotDateFor(group);
+		const res = http.post(
+			`${BASE_URL}/availability/slots`,
+			JSON.stringify({ serviceId, date }),
+			{
+				headers: jsonHeaders(),
+				tags: { target, endpoint: 'availability_slots' },
+			},
+		);
+		check(res, {
+			'status 200': (r) => r.status === 200,
+			'slots array present': hasArrayPayload,
+		});
+		const isFast = res.timings.duration < 200;
+		fastResponses.add(isFast);
+		fastSlots.add(isFast);
+	}
 
-  sleep(0.05);
+	sleep(0.05);
 }
 
 export function teardown() {
-  // Log expected vs observed cache-hit proxy at teardown.
-  // k6 does not expose aggregated custom metric values in teardown,
-  // so this is a reminder note only — inspect cache_hint_fast_response
-  // in the summary JSON to compare against EXPECTED_CACHE_HIT_RATIO.
-  console.log(
-    `Expected cache-hit ratio proxy: ${EXPECTED_CACHE_HIT_RATIO}. ` +
-      `Check 'cache_hint_fast_response' in summary JSON for observed value.`
-  );
+	// Log expected vs observed cache-hit proxy at teardown.
+	// k6 does not expose aggregated custom metric values in teardown,
+	// so this is a reminder note only — inspect cache_hint_fast_response
+	// in the summary JSON to compare against EXPECTED_CACHE_HIT_RATIO.
+	console.log(
+		`Expected cache-hit ratio proxy: ${EXPECTED_CACHE_HIT_RATIO}. ` +
+			`Check 'cache_hint_fast_response' in summary JSON for observed value.`,
+	);
 }

--- a/bench/k6-load-1k.js
+++ b/bench/k6-load-1k.js
@@ -3,58 +3,114 @@ import http from 'k6/http';
 import { check, sleep } from 'k6';
 
 export const options = {
-  stages: [
-    { duration: '30s', target: 10 }, // ramp up to 10 VUs
-    { duration: '2m', target: 10 },  // hold at 10 VUs
-    { duration: '30s', target: 0 },  // ramp down
-  ],
-  thresholds: {
-    http_req_failed: ['rate<0.02'],
-    http_req_duration: ['p(99)<10000'],
-  },
+	stages: [
+		{ duration: '30s', target: 10 }, // ramp up to 10 VUs
+		{ duration: '2m', target: 10 }, // hold at 10 VUs
+		{ duration: '30s', target: 0 }, // ramp down
+	],
+	thresholds: {
+		http_req_failed: ['rate<0.02'],
+		http_req_duration: ['p(99)<10000'],
+	},
 };
 
 const BASE_URL = __ENV.BASE_URL || 'http://ts-acuity-mw.ts.net:3001';
 const AUTH_TOKEN = __ENV.AUTH_TOKEN || '';
 
-// Service IDs to rotate through for /availability/slots requests
-const RAW_IDS = __ENV.SERVICE_IDS || '1,2,3,4,5';
-const SERVICE_IDS = RAW_IDS.split(',').map((s) => s.trim());
+const parseList = (value) =>
+	value
+		.split(',')
+		.map((s) => s.trim())
+		.filter(Boolean);
+
+// Massage Ithaca's TMD consultation appointment type. Override for other tenants.
+const SERVICE_IDS = parseList(__ENV.SERVICE_IDS || '53178494');
 
 // Simple date helper: YYYY-MM-DD for tomorrow
 const tomorrow = () => {
-  const d = new Date();
-  d.setDate(d.getDate() + 1);
-  return d.toISOString().slice(0, 10);
+	const d = new Date();
+	d.setDate(d.getDate() + 1);
+	return d.toISOString().slice(0, 10);
 };
 
+const monthOffset = (offset) => {
+	const d = new Date();
+	d.setUTCDate(1);
+	d.setUTCMonth(d.getUTCMonth() + offset);
+	return d.toISOString().slice(0, 7);
+};
+
+const DATE_MONTHS = parseList(
+	__ENV.DATE_MONTHS || `${monthOffset(0)},${monthOffset(1)}`,
+);
+const SLOT_DATES = parseList(__ENV.SLOT_DATES || tomorrow());
+
+const authHeaders = () =>
+	AUTH_TOKEN ? { Authorization: `Bearer ${AUTH_TOKEN}` } : {};
+
+const jsonHeaders = () => ({
+	...authHeaders(),
+	'Content-Type': 'application/json',
+});
+
+const hasArrayPayload = (r) =>
+	Array.isArray(r.json('data')) ||
+	Array.isArray(r.json('services')) ||
+	Array.isArray(r.json());
+
+const serviceIdFor = (iterationGroup) =>
+	SERVICE_IDS[iterationGroup % SERVICE_IDS.length];
+const monthFor = (iterationGroup) =>
+	DATE_MONTHS[iterationGroup % DATE_MONTHS.length];
+const slotDateFor = (iterationGroup) =>
+	SLOT_DATES[iterationGroup % SLOT_DATES.length];
+
 export default function () {
-  const headers = { Authorization: `Bearer ${AUTH_TOKEN}` };
-  const tag = { target: __ENV.TARGET || 'unknown' };
+	const target = __ENV.TARGET || 'unknown';
 
-  // Alternate between /services and /availability/slots
-  const iteration = __ITER % 2;
-  if (iteration === 0) {
-    const res = http.get(`${BASE_URL}/services`, { headers, tags: tag });
-    check(res, {
-      'status 200': (r) => r.status === 200,
-      'services array present': (r) =>
-        Array.isArray(r.json('services')) || Array.isArray(r.json()),
-    });
-  } else {
-    // __ITER is always odd in this branch; using `__ITER % length` skips
-    // half the services when `SERVICE_IDS.length` is even. `Math.floor(__ITER / 2)`
-    // gives a dense 0,0,1,1,2,2,... index that rotates through every entry.
-    const serviceId = SERVICE_IDS[Math.floor(__ITER / 2) % SERVICE_IDS.length];
-    const date = tomorrow();
-    const res = http.get(
-      `${BASE_URL}/availability/slots?serviceId=${serviceId}&date=${date}`,
-      { headers, tags: tag }
-    );
-    check(res, {
-      'status 200': (r) => r.status === 200,
-    });
-  }
+	// Alternate across service catalog, date cache, and slot cache paths.
+	const iteration = __ITER % 3;
+	const group = Math.floor(__ITER / 3);
+	if (iteration === 0) {
+		const res = http.get(`${BASE_URL}/services`, {
+			headers: authHeaders(),
+			tags: { target, endpoint: 'services' },
+		});
+		check(res, {
+			'status 200': (r) => r.status === 200,
+			'services array present': hasArrayPayload,
+		});
+	} else if (iteration === 1) {
+		const serviceId = serviceIdFor(group);
+		const month = monthFor(group);
+		const res = http.post(
+			`${BASE_URL}/availability/dates`,
+			JSON.stringify({ serviceId, startDate: month }),
+			{
+				headers: jsonHeaders(),
+				tags: { target, endpoint: 'availability_dates' },
+			},
+		);
+		check(res, {
+			'status 200': (r) => r.status === 200,
+			'dates array present': hasArrayPayload,
+		});
+	} else {
+		const serviceId = serviceIdFor(group);
+		const date = slotDateFor(group);
+		const res = http.post(
+			`${BASE_URL}/availability/slots`,
+			JSON.stringify({ serviceId, date }),
+			{
+				headers: jsonHeaders(),
+				tags: { target, endpoint: 'availability_slots' },
+			},
+		);
+		check(res, {
+			'status 200': (r) => r.status === 200,
+			'slots array present': hasArrayPayload,
+		});
+	}
 
-  sleep(0.1);
+	sleep(0.1);
 }

--- a/bench/k6-protocol.test.ts
+++ b/bench/k6-protocol.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const readBenchFile = (name: string): string =>
+	readFileSync(new URL(`./${name}`, import.meta.url), 'utf8');
+
+describe('k6 benchmark protocol', () => {
+	it.each(['k6-load-1k.js', 'k6-load-10k.js'])(
+		'%s uses the deployed POST availability protocol',
+		(fileName) => {
+			const source = readBenchFile(fileName);
+
+			expect(source).toContain('http.post');
+			expect(source).toContain('`${BASE_URL}/availability/dates`');
+			expect(source).toContain('`${BASE_URL}/availability/slots`');
+			expect(source).toContain(
+				'JSON.stringify({ serviceId, startDate: month })',
+			);
+			expect(source).toContain('JSON.stringify({ serviceId, date })');
+			expect(source).toContain("'Content-Type': 'application/json'");
+			expect(source).not.toContain('/availability/slots?');
+			expect(source).not.toContain('/availability/dates?');
+		},
+	);
+});

--- a/bench/k6-smoke.js
+++ b/bench/k6-smoke.js
@@ -3,26 +3,33 @@ import http from 'k6/http';
 import { check, sleep } from 'k6';
 
 export const options = {
-  vus: 1,
-  iterations: 100,
-  thresholds: {
-    http_req_failed: ['rate<0.01'],
-    http_req_duration: ['p(99)<8000'],
-  },
+	vus: 1,
+	iterations: 100,
+	thresholds: {
+		http_req_failed: ['rate<0.01'],
+		http_req_duration: ['p(99)<8000'],
+	},
 };
 
 const BASE_URL = __ENV.BASE_URL || 'http://ts-acuity-mw.ts.net:3001';
 const AUTH_TOKEN = __ENV.AUTH_TOKEN || '';
 
+const authHeaders = () =>
+	AUTH_TOKEN ? { Authorization: `Bearer ${AUTH_TOKEN}` } : {};
+
+const hasArrayPayload = (r) =>
+	Array.isArray(r.json('data')) ||
+	Array.isArray(r.json('services')) ||
+	Array.isArray(r.json());
+
 export default function () {
-  const res = http.get(`${BASE_URL}/services`, {
-    headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
-    tags: { target: __ENV.TARGET || 'unknown' },
-  });
-  check(res, {
-    'status 200': (r) => r.status === 200,
-    'services array present': (r) =>
-      Array.isArray(r.json('services')) || Array.isArray(r.json()),
-  });
-  sleep(0.1);
+	const res = http.get(`${BASE_URL}/services`, {
+		headers: authHeaders(),
+		tags: { target: __ENV.TARGET || 'unknown', endpoint: 'services' },
+	});
+	check(res, {
+		'status 200': (r) => r.status === 200,
+		'services array present': hasArrayPayload,
+	});
+	sleep(0.1);
 }

--- a/src/adapters/acuity/steps/read-via-url.test.ts
+++ b/src/adapters/acuity/steps/read-via-url.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { Effect } from 'effect';
+import type { Page } from 'playwright-core';
+import { describe, expect, it, vi } from 'vitest';
 
-import { dateEmptySettleTimeoutMs, urlReadNetworkIdleTimeoutMs } from './read-via-url.js';
+import {
+	BrowserService,
+	defaultBrowserConfig,
+} from '../../../shared/browser-service.js';
+import {
+	dateEmptySettleTimeoutMs,
+	readDatesViaUrl,
+	urlReadNetworkIdleTimeoutMs,
+} from './read-via-url.js';
 
 describe('URL read timing config', () => {
 	it('uses a short network-idle settle by default', () => {
@@ -8,16 +18,32 @@ describe('URL read timing config', () => {
 	});
 
 	it('honors explicit network-idle settle config including zero', () => {
-		expect(urlReadNetworkIdleTimeoutMs(30_000, { ACUITY_URL_READ_NETWORK_IDLE_MS: '750' })).toBe(750);
-		expect(urlReadNetworkIdleTimeoutMs(30_000, { ACUITY_URL_READ_NETWORK_IDLE_MS: '0' })).toBe(0);
+		expect(
+			urlReadNetworkIdleTimeoutMs(30_000, {
+				ACUITY_URL_READ_NETWORK_IDLE_MS: '750',
+			}),
+		).toBe(750);
+		expect(
+			urlReadNetworkIdleTimeoutMs(30_000, {
+				ACUITY_URL_READ_NETWORK_IDLE_MS: '0',
+			}),
+		).toBe(0);
 	});
 
 	it('never exceeds the caller operation timeout', () => {
-		expect(urlReadNetworkIdleTimeoutMs(500, { ACUITY_URL_READ_NETWORK_IDLE_MS: '2000' })).toBe(500);
+		expect(
+			urlReadNetworkIdleTimeoutMs(500, {
+				ACUITY_URL_READ_NETWORK_IDLE_MS: '2000',
+			}),
+		).toBe(500);
 	});
 
 	it('falls back when the env value is invalid', () => {
-		expect(urlReadNetworkIdleTimeoutMs(30_000, { ACUITY_URL_READ_NETWORK_IDLE_MS: 'nope' })).toBe(1500);
+		expect(
+			urlReadNetworkIdleTimeoutMs(30_000, {
+				ACUITY_URL_READ_NETWORK_IDLE_MS: 'nope',
+			}),
+		).toBe(1500);
 	});
 });
 
@@ -27,15 +53,137 @@ describe('date empty settle timing config', () => {
 	});
 
 	it('honors explicit empty-date settle config including zero', () => {
-		expect(dateEmptySettleTimeoutMs(30_000, { ACUITY_EMPTY_DATE_SETTLE_MS: '1000' })).toBe(1000);
-		expect(dateEmptySettleTimeoutMs(30_000, { ACUITY_EMPTY_DATE_SETTLE_MS: '0' })).toBe(0);
+		expect(
+			dateEmptySettleTimeoutMs(30_000, { ACUITY_EMPTY_DATE_SETTLE_MS: '1000' }),
+		).toBe(1000);
+		expect(
+			dateEmptySettleTimeoutMs(30_000, { ACUITY_EMPTY_DATE_SETTLE_MS: '0' }),
+		).toBe(0);
 	});
 
 	it('never exceeds the caller operation timeout', () => {
-		expect(dateEmptySettleTimeoutMs(500, { ACUITY_EMPTY_DATE_SETTLE_MS: '2500' })).toBe(500);
+		expect(
+			dateEmptySettleTimeoutMs(500, { ACUITY_EMPTY_DATE_SETTLE_MS: '2500' }),
+		).toBe(500);
 	});
 
 	it('falls back when the empty-date settle env value is invalid', () => {
-		expect(dateEmptySettleTimeoutMs(30_000, { ACUITY_EMPTY_DATE_SETTLE_MS: 'nope' })).toBe(2500);
+		expect(
+			dateEmptySettleTimeoutMs(30_000, { ACUITY_EMPTY_DATE_SETTLE_MS: 'nope' }),
+		).toBe(2500);
+	});
+});
+
+const monthNames = [
+	'January',
+	'February',
+	'March',
+	'April',
+	'May',
+	'June',
+	'July',
+	'August',
+	'September',
+	'October',
+	'November',
+	'December',
+] as const;
+
+const formatMonthKey = (date: Date): string =>
+	`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+
+const makeUrlDateReadPage = (
+	initialMonth: string,
+	datesByMonth: Map<string, string[]>,
+	onWaitForFunction?: () => void,
+) => {
+	const [year, month] = initialMonth.split('-').map(Number);
+	const current = new Date(year, month - 1, 1);
+	const navClicks: string[] = [];
+	const gotoUrls: string[] = [];
+
+	const navHandle = (direction: 'prev' | 'next') => ({
+		click: vi.fn(async () => {
+			current.setMonth(current.getMonth() + (direction === 'next' ? 1 : -1));
+			navClicks.push(direction);
+		}),
+	});
+
+	const page = {
+		goto: vi.fn(async (url: string) => {
+			gotoUrls.push(url);
+		}),
+		waitForLoadState: vi.fn(async () => undefined),
+		waitForSelector: vi.fn(async (selector: string) => {
+			if (selector.includes('prev-button')) return navHandle('prev');
+			if (selector.includes('next-button')) return navHandle('next');
+			return {};
+		}),
+		waitForTimeout: vi.fn(async () => undefined),
+		waitForFunction: vi.fn(async () => {
+			onWaitForFunction?.();
+		}),
+		$eval: vi.fn(async () => {
+			const label = `${monthNames[current.getMonth()]} ${current.getFullYear()}`;
+			return label;
+		}),
+		evaluate: vi.fn(async () => {
+			const dates = datesByMonth.get(formatMonthKey(current)) ?? [];
+			return dates.map((date) => ({ date, slots: 1 }));
+		}),
+	} as unknown as Page;
+
+	return {
+		page,
+		gotoUrls,
+		navClicks,
+	};
+};
+
+const runDateRead = (page: Page, targetMonth?: string) =>
+	Effect.runPromise(
+		Effect.scoped(
+			readDatesViaUrl('53178494', targetMonth).pipe(
+				Effect.provideService(BrowserService, {
+					acquirePage: Effect.succeed(page),
+					screenshot: () => Effect.succeed(Buffer.from('')),
+					config: {
+						...defaultBrowserConfig,
+						baseUrl: 'https://MassageIthaca.as.me',
+						timeout: 1_000,
+					},
+				}),
+			),
+		),
+	);
+
+describe('readDatesViaUrl DOM behavior', () => {
+	it('waits for enabled dates before returning an empty month', async () => {
+		const datesByMonth = new Map<string, string[]>([['2026-07', []]]);
+		const fake = makeUrlDateReadPage('2026-07', datesByMonth, () => {
+			datesByMonth.set('2026-07', ['2026-07-15']);
+		});
+
+		const dates = await runDateRead(fake.page);
+
+		expect(dates).toEqual([{ date: '2026-07-15', slots: 1 }]);
+		expect(fake.page.evaluate).toHaveBeenCalledTimes(2);
+		expect(fake.page.waitForFunction).toHaveBeenCalledTimes(1);
+	});
+
+	it('navigates to the requested target month before reading enabled dates', async () => {
+		const datesByMonth = new Map<string, string[]>([
+			['2026-07', ['2026-07-15']],
+			['2026-09', ['2026-09-12']],
+		]);
+		const fake = makeUrlDateReadPage('2026-07', datesByMonth);
+
+		const dates = await runDateRead(fake.page, '2026-09');
+
+		expect(dates).toEqual([{ date: '2026-09-12', slots: 1 }]);
+		expect(fake.navClicks).toEqual(['next', 'next']);
+		expect(fake.gotoUrls[0]).toBe(
+			'https://massageithaca.as.me/?appointmentType=53178494',
+		);
 	});
 });

--- a/src/server/__tests__/availability-dates-cache.test.ts
+++ b/src/server/__tests__/availability-dates-cache.test.ts
@@ -86,8 +86,25 @@ vi.mock('ioredis', () => {
 const serviceId = '53178494';
 const baseUrl = 'https://MassageIthaca.as.me';
 
+const mockAcuityModules = () => {
+	vi.doMock('../../adapters/acuity/steps/read-via-url.js', () => readViaUrlMocks);
+	vi.doMock('../../adapters/acuity/steps/index.js', () => stepMocks);
+};
+
 const listen = async () => {
-	const { server } = await import('../handler.js');
+	const {
+		server,
+		__runEffectWithoutBrowserForTest,
+		__setEffectRunnerForTest,
+		__setAcuityStepOverridesForTest,
+	} = await import('../handler.js');
+	__setEffectRunnerForTest(__runEffectWithoutBrowserForTest);
+	__setAcuityStepOverridesForTest({
+		readDatesViaUrl: readViaUrlMocks.readDatesViaUrl,
+		readSlotsViaUrl: readViaUrlMocks.readSlotsViaUrl,
+		readAvailableDates: stepMocks.readAvailableDates,
+		readTimeSlots: stepMocks.readTimeSlots,
+	});
 	await new Promise<void>((resolve) => {
 		server.listen(0, '127.0.0.1', resolve);
 	});
@@ -114,6 +131,7 @@ describe('POST /availability/dates cache prewarm', () => {
 
 	beforeEach(() => {
 		vi.resetModules();
+		mockAcuityModules();
 		vi.clearAllMocks();
 		redisState.values.clear();
 		redisState.instances.length = 0;

--- a/src/server/__tests__/availability-dates-cache.test.ts
+++ b/src/server/__tests__/availability-dates-cache.test.ts
@@ -1,0 +1,215 @@
+import { type AddressInfo } from 'node:net';
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readViaUrlMocks = vi.hoisted(() => ({
+	readDatesViaUrl: vi.fn(),
+	readSlotsViaUrl: vi.fn(),
+}));
+
+const stepMocks = vi.hoisted(() => ({
+	navigateToBooking: vi.fn(),
+	fillFormFields: vi.fn(),
+	bypassPayment: vi.fn(),
+	generateCouponCode: vi.fn(),
+	submitBooking: vi.fn(),
+	extractConfirmation: vi.fn(),
+	toBooking: vi.fn(),
+	readAvailableDates: vi.fn(),
+	readTimeSlots: vi.fn(),
+	fetchBusinessData: vi.fn(),
+	businessToServices: vi.fn(),
+}));
+
+const redisState = vi.hoisted(() => ({
+	values: new Map<string, string>(),
+	instances: [] as Array<{
+		get: ReturnType<typeof vi.fn>;
+		set: ReturnType<typeof vi.fn>;
+		eval: ReturnType<typeof vi.fn>;
+		exists: ReturnType<typeof vi.fn>;
+		ping: ReturnType<typeof vi.fn>;
+		quit: ReturnType<typeof vi.fn>;
+		on: ReturnType<typeof vi.fn>;
+	}>,
+}));
+
+vi.mock('../../adapters/acuity/steps/read-via-url.js', () => readViaUrlMocks);
+vi.mock('../../adapters/acuity/steps/index.js', () => stepMocks);
+
+vi.mock('ioredis', () => {
+	class Redis {
+		get = vi.fn(async (key: string) => redisState.values.get(key) ?? null);
+
+		set = vi.fn(
+			async (
+				key: string,
+				value: string,
+				...args: Array<string | number>
+			): Promise<'OK' | null> => {
+				const flags = args.map((arg) => String(arg).toUpperCase());
+				if (flags.includes('NX') && redisState.values.has(key)) {
+					return null;
+				}
+				redisState.values.set(key, value);
+				return 'OK';
+			},
+		);
+
+		eval = vi.fn(
+			async (
+				_script: string,
+				_numKeys: number,
+				key: string,
+				token: string,
+			): Promise<number> => {
+				if (redisState.values.get(key) !== token) return 0;
+				redisState.values.delete(key);
+				return 1;
+			},
+		);
+
+		exists = vi.fn(async (key: string) => (redisState.values.has(key) ? 1 : 0));
+		ping = vi.fn(async () => 'PONG');
+		quit = vi.fn(async () => 'OK');
+		on = vi.fn(() => this);
+
+		constructor() {
+			redisState.instances.push(this);
+		}
+	}
+
+	return { Redis };
+});
+
+const serviceId = '53178494';
+const baseUrl = 'https://MassageIthaca.as.me';
+
+const listen = async () => {
+	const { server } = await import('../handler.js');
+	await new Promise<void>((resolve) => {
+		server.listen(0, '127.0.0.1', resolve);
+	});
+	const address = server.address() as AddressInfo;
+	return {
+		server,
+		baseUrl: `http://127.0.0.1:${address.port}`,
+	};
+};
+
+const postAvailabilityDates = async (
+	url: string,
+	startDate: string,
+): Promise<Response> =>
+	fetch(`${url}/availability/dates`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ serviceId, startDate }),
+	});
+
+describe('POST /availability/dates cache prewarm', () => {
+	let activeServer: Awaited<ReturnType<typeof listen>>['server'] | null = null;
+
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		redisState.values.clear();
+		redisState.instances.length = 0;
+
+		process.env.ACUITY_BASE_URL = baseUrl;
+		process.env.ACUITY_DATE_PREWARM_MONTHS = '1';
+		process.env.ACUITY_SLOT_PREWARM_LIMIT = '0';
+		process.env.REDIS_URL = 'redis://unit.test:6379';
+		delete process.env.REDIS_PASSWORD;
+		delete process.env.AUTH_TOKEN;
+
+		readViaUrlMocks.readDatesViaUrl.mockImplementation(
+			(_serviceId: string, targetMonth: string | undefined) =>
+				Effect.succeed([{ date: `${targetMonth ?? 'current'}-15` }]),
+		);
+	});
+
+	afterEach(async () => {
+		if (activeServer?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				activeServer!.close((error) => (error ? reject(error) : resolve()));
+			});
+		}
+		activeServer = null;
+		delete process.env.ACUITY_BASE_URL;
+		delete process.env.ACUITY_DATE_PREWARM_MONTHS;
+		delete process.env.ACUITY_SLOT_PREWARM_LIMIT;
+		delete process.env.REDIS_URL;
+		delete process.env.REDIS_PASSWORD;
+		delete process.env.AUTH_TOKEN;
+	});
+
+	it('warms the next month after a successful date request', async () => {
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await postAvailabilityDates(running.baseUrl, '2026-07-01');
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			success: true,
+			data: [{ date: '2026-07-15' }],
+		});
+
+		await vi.waitFor(
+			() => {
+				expect(readViaUrlMocks.readDatesViaUrl).toHaveBeenCalledWith(
+					serviceId,
+					'2026-08',
+				);
+				expect(
+					redisState.values.get(
+						`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
+					),
+				).toBe(JSON.stringify([{ date: '2026-08-15' }]));
+			},
+			{ timeout: 5_000 },
+		);
+	});
+
+	it('serves a prewarmed month from Redis without rereading Acuity for that month', async () => {
+		const running = await listen();
+		activeServer = running.server;
+
+		await postAvailabilityDates(running.baseUrl, '2026-07-01');
+		await vi.waitFor(
+			() => {
+				expect(
+					redisState.values.get(
+						`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
+					),
+				).toBe(JSON.stringify([{ date: '2026-08-15' }]));
+			},
+			{ timeout: 5_000 },
+		);
+
+		readViaUrlMocks.readDatesViaUrl.mockClear();
+
+		const response = await postAvailabilityDates(running.baseUrl, '2026-08-01');
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			success: true,
+			data: [{ date: '2026-08-15' }],
+		});
+		expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalledWith(
+			serviceId,
+			'2026-08',
+		);
+		await vi.waitFor(
+			() => {
+				expect(
+					redisState.values.get(
+						`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-09`,
+					),
+				).toBe(JSON.stringify([{ date: '2026-09-15' }]));
+			},
+			{ timeout: 5_000 },
+		);
+	});
+});

--- a/src/server/__tests__/availability-dates-cache.test.ts
+++ b/src/server/__tests__/availability-dates-cache.test.ts
@@ -1,6 +1,7 @@
 import { type AddressInfo } from 'node:net';
 import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrowserError } from '../../adapters/acuity/errors.js';
 
 const readViaUrlMocks = vi.hoisted(() => ({
 	readDatesViaUrl: vi.fn(),
@@ -233,5 +234,29 @@ describe('POST /availability/dates cache prewarm', () => {
 			},
 		});
 		expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalled();
+	});
+
+	it('surfaces Acuity date-read failures without caching them as empty results', async () => {
+		readViaUrlMocks.readDatesViaUrl.mockImplementationOnce(() =>
+			Effect.fail(new BrowserError({ reason: 'PAGE_FAILED' })),
+		);
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await postAvailabilityDates(running.baseUrl, '2026-07-01');
+
+		expect(response.status).toBe(500);
+		await expect(response.json()).resolves.toMatchObject({
+			success: false,
+			error: {
+				tag: 'InfrastructureError',
+				code: 'NETWORK',
+			},
+		});
+		expect(
+			redisState.values.get(
+				`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-07`,
+			),
+		).toBeUndefined();
 	});
 });

--- a/src/server/__tests__/availability-dates-cache.test.ts
+++ b/src/server/__tests__/availability-dates-cache.test.ts
@@ -100,11 +100,12 @@ const listen = async () => {
 const postAvailabilityDates = async (
 	url: string,
 	startDate: string,
+	body: unknown = { serviceId, startDate },
 ): Promise<Response> =>
 	fetch(`${url}/availability/dates`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ serviceId, startDate }),
+		body: JSON.stringify(body),
 	});
 
 describe('POST /availability/dates cache prewarm', () => {
@@ -211,5 +212,26 @@ describe('POST /availability/dates cache prewarm', () => {
 			},
 			{ timeout: 5_000 },
 		);
+	});
+
+	it('rejects missing service id before cache lookup or Acuity reads', async () => {
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await postAvailabilityDates(
+			running.baseUrl,
+			'2026-07-01',
+			{ startDate: '2026-07-01' },
+		);
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toMatchObject({
+			success: false,
+			error: {
+				tag: 'ValidationError',
+				code: 'serviceId',
+			},
+		});
+		expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalled();
 	});
 });

--- a/src/server/__tests__/availability-slots-cache.test.ts
+++ b/src/server/__tests__/availability-slots-cache.test.ts
@@ -240,4 +240,41 @@ describe('POST /availability/slots read cache', () => {
 		});
 		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
 	});
+
+	it('rejects unauthenticated slot requests before cache lookup or Acuity reads', async () => {
+		process.env.AUTH_TOKEN = 'bridge-secret';
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await postAvailabilitySlots(running.baseUrl);
+
+		expect(response.status).toBe(401);
+		await expect(response.json()).resolves.toMatchObject({
+			success: false,
+			error: {
+				tag: 'InfrastructureError',
+				code: 'UNAUTHORIZED',
+			},
+		});
+		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
+	});
+
+	it('does not run slot reads for unsupported methods', async () => {
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await fetch(`${running.baseUrl}/availability/slots`, {
+			method: 'GET',
+		});
+
+		expect(response.status).toBe(404);
+		await expect(response.json()).resolves.toMatchObject({
+			success: false,
+			error: {
+				tag: 'InfrastructureError',
+				code: 'NOT_FOUND',
+			},
+		});
+		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
+	});
 });

--- a/src/server/__tests__/availability-slots-cache.test.ts
+++ b/src/server/__tests__/availability-slots-cache.test.ts
@@ -1,0 +1,201 @@
+import { type AddressInfo } from 'node:net';
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readViaUrlMocks = vi.hoisted(() => ({
+	readDatesViaUrl: vi.fn(),
+	readSlotsViaUrl: vi.fn(),
+}));
+
+const stepMocks = vi.hoisted(() => ({
+	navigateToBooking: vi.fn(),
+	fillFormFields: vi.fn(),
+	bypassPayment: vi.fn(),
+	generateCouponCode: vi.fn(),
+	submitBooking: vi.fn(),
+	extractConfirmation: vi.fn(),
+	toBooking: vi.fn(),
+	readAvailableDates: vi.fn(),
+	readTimeSlots: vi.fn(),
+	fetchBusinessData: vi.fn(),
+	businessToServices: vi.fn(),
+}));
+
+const redisState = vi.hoisted(() => ({
+	values: new Map<string, string>(),
+	instances: [] as Array<{
+		get: ReturnType<typeof vi.fn>;
+		set: ReturnType<typeof vi.fn>;
+		eval: ReturnType<typeof vi.fn>;
+		exists: ReturnType<typeof vi.fn>;
+		ping: ReturnType<typeof vi.fn>;
+		quit: ReturnType<typeof vi.fn>;
+		on: ReturnType<typeof vi.fn>;
+	}>,
+}));
+
+vi.mock('../../adapters/acuity/steps/read-via-url.js', () => readViaUrlMocks);
+vi.mock('../../adapters/acuity/steps/index.js', () => stepMocks);
+
+vi.mock('ioredis', () => {
+	class Redis {
+		get = vi.fn(async (key: string) => redisState.values.get(key) ?? null);
+
+		set = vi.fn(
+			async (
+				key: string,
+				value: string,
+				...args: Array<string | number>
+			): Promise<'OK' | null> => {
+				const flags = args.map((arg) => String(arg).toUpperCase());
+				if (flags.includes('NX') && redisState.values.has(key)) {
+					return null;
+				}
+				redisState.values.set(key, value);
+				return 'OK';
+			},
+		);
+
+		eval = vi.fn(
+			async (
+				_script: string,
+				_numKeys: number,
+				key: string,
+				token: string,
+			): Promise<number> => {
+				if (redisState.values.get(key) !== token) return 0;
+				redisState.values.delete(key);
+				return 1;
+			},
+		);
+
+		exists = vi.fn(async (key: string) => (redisState.values.has(key) ? 1 : 0));
+		ping = vi.fn(async () => 'PONG');
+		quit = vi.fn(async () => 'OK');
+		on = vi.fn(() => this);
+
+		constructor() {
+			redisState.instances.push(this);
+		}
+	}
+
+	return { Redis };
+});
+
+const serviceId = '53178494';
+const baseUrl = 'https://MassageIthaca.as.me';
+const slotDate = '2026-08-15';
+const slotCacheKey = `bridge-read:v2:slots:${baseUrl}:${serviceId}:${slotDate}`;
+
+const listen = async () => {
+	const { server } = await import('../handler.js');
+	await new Promise<void>((resolve) => {
+		server.listen(0, '127.0.0.1', resolve);
+	});
+	const address = server.address() as AddressInfo;
+	return {
+		server,
+		baseUrl: `http://127.0.0.1:${address.port}`,
+	};
+};
+
+const postAvailabilitySlots = async (url: string): Promise<Response> =>
+	fetch(`${url}/availability/slots`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ serviceId, date: slotDate }),
+	});
+
+describe('POST /availability/slots read cache', () => {
+	let activeServer: Awaited<ReturnType<typeof listen>>['server'] | null = null;
+
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		redisState.values.clear();
+		redisState.instances.length = 0;
+
+		process.env.ACUITY_BASE_URL = baseUrl;
+		process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS = '7';
+		process.env.ACUITY_READ_CACHE_TTL_SECONDS = '60';
+		process.env.REDIS_URL = 'redis://unit.test:6379';
+		delete process.env.REDIS_PASSWORD;
+		delete process.env.AUTH_TOKEN;
+
+		readViaUrlMocks.readSlotsViaUrl.mockImplementation(
+			(_serviceId: string, date: string) =>
+				Effect.succeed([
+					{
+						datetime: `${date}T18:00:00.000Z`,
+						available: true,
+					},
+				]),
+		);
+	});
+
+	afterEach(async () => {
+		if (activeServer?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				activeServer!.close((error) => (error ? reject(error) : resolve()));
+			});
+		}
+		activeServer = null;
+		delete process.env.ACUITY_BASE_URL;
+		delete process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS;
+		delete process.env.ACUITY_READ_CACHE_TTL_SECONDS;
+		delete process.env.REDIS_URL;
+		delete process.env.REDIS_PASSWORD;
+		delete process.env.AUTH_TOKEN;
+	});
+
+	it('serves repeated slot requests from Redis without rereading Acuity', async () => {
+		const running = await listen();
+		activeServer = running.server;
+
+		const first = await postAvailabilitySlots(running.baseUrl);
+
+		expect(first.status).toBe(200);
+		await expect(first.json()).resolves.toMatchObject({
+			success: true,
+			data: [{ datetime: `${slotDate}T18:00:00.000Z`, available: true }],
+		});
+		expect(redisState.values.get(slotCacheKey)).toBe(
+			JSON.stringify([
+				{ datetime: `${slotDate}T18:00:00.000Z`, available: true },
+			]),
+		);
+
+		readViaUrlMocks.readSlotsViaUrl.mockClear();
+
+		const second = await postAvailabilitySlots(running.baseUrl);
+
+		expect(second.status).toBe(200);
+		await expect(second.json()).resolves.toMatchObject({
+			success: true,
+			data: [{ datetime: `${slotDate}T18:00:00.000Z`, available: true }],
+		});
+		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
+	});
+
+	it('uses the empty-read TTL for empty slot arrays', async () => {
+		readViaUrlMocks.readSlotsViaUrl.mockImplementationOnce(() =>
+			Effect.succeed([]),
+		);
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await postAvailabilitySlots(running.baseUrl);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			success: true,
+			data: [],
+		});
+		expect(redisState.instances[0]?.set).toHaveBeenCalledWith(
+			slotCacheKey,
+			JSON.stringify([]),
+			'EX',
+			7,
+		);
+	});
+});

--- a/src/server/__tests__/availability-slots-cache.test.ts
+++ b/src/server/__tests__/availability-slots-cache.test.ts
@@ -87,8 +87,25 @@ const baseUrl = 'https://MassageIthaca.as.me';
 const slotDate = '2026-08-15';
 const slotCacheKey = `bridge-read:v2:slots:${baseUrl}:${serviceId}:${slotDate}`;
 
+const mockAcuityModules = () => {
+	vi.doMock('../../adapters/acuity/steps/read-via-url.js', () => readViaUrlMocks);
+	vi.doMock('../../adapters/acuity/steps/index.js', () => stepMocks);
+};
+
 const listen = async () => {
-	const { server } = await import('../handler.js');
+	const {
+		server,
+		__runEffectWithoutBrowserForTest,
+		__setEffectRunnerForTest,
+		__setAcuityStepOverridesForTest,
+	} = await import('../handler.js');
+	__setEffectRunnerForTest(__runEffectWithoutBrowserForTest);
+	__setAcuityStepOverridesForTest({
+		readDatesViaUrl: readViaUrlMocks.readDatesViaUrl,
+		readSlotsViaUrl: readViaUrlMocks.readSlotsViaUrl,
+		readAvailableDates: stepMocks.readAvailableDates,
+		readTimeSlots: stepMocks.readTimeSlots,
+	});
 	await new Promise<void>((resolve) => {
 		server.listen(0, '127.0.0.1', resolve);
 	});
@@ -114,6 +131,7 @@ describe('POST /availability/slots read cache', () => {
 
 	beforeEach(() => {
 		vi.resetModules();
+		mockAcuityModules();
 		vi.clearAllMocks();
 		redisState.values.clear();
 		redisState.instances.length = 0;

--- a/src/server/__tests__/availability-slots-cache.test.ts
+++ b/src/server/__tests__/availability-slots-cache.test.ts
@@ -99,11 +99,14 @@ const listen = async () => {
 	};
 };
 
-const postAvailabilitySlots = async (url: string): Promise<Response> =>
+const postAvailabilitySlots = async (
+	url: string,
+	body: unknown = { serviceId, date: slotDate },
+): Promise<Response> =>
 	fetch(`${url}/availability/slots`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ serviceId, date: slotDate }),
+		body: JSON.stringify(body),
 	});
 
 describe('POST /availability/slots read cache', () => {
@@ -118,6 +121,7 @@ describe('POST /availability/slots read cache', () => {
 		process.env.ACUITY_BASE_URL = baseUrl;
 		process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS = '7';
 		process.env.ACUITY_READ_CACHE_TTL_SECONDS = '60';
+		process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS = '10';
 		process.env.REDIS_URL = 'redis://unit.test:6379';
 		delete process.env.REDIS_PASSWORD;
 		delete process.env.AUTH_TOKEN;
@@ -143,6 +147,7 @@ describe('POST /availability/slots read cache', () => {
 		delete process.env.ACUITY_BASE_URL;
 		delete process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS;
 		delete process.env.ACUITY_READ_CACHE_TTL_SECONDS;
+		delete process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS;
 		delete process.env.REDIS_URL;
 		delete process.env.REDIS_PASSWORD;
 		delete process.env.AUTH_TOKEN;
@@ -197,5 +202,42 @@ describe('POST /availability/slots read cache', () => {
 			'EX',
 			7,
 		);
+	});
+
+	it('returns timeout instead of rereading Acuity when another caller owns the cache fill', async () => {
+		redisState.values.set(`lock:${slotCacheKey}`, 'winner-token');
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await postAvailabilitySlots(running.baseUrl);
+
+		expect(response.status).toBe(500);
+		await expect(response.json()).resolves.toMatchObject({
+			success: false,
+			error: {
+				tag: 'InfrastructureError',
+				code: 'TIMEOUT',
+			},
+		});
+		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
+	});
+
+	it('rejects missing service id before cache lookup or Acuity reads', async () => {
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await postAvailabilitySlots(running.baseUrl, {
+			date: slotDate,
+		});
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toMatchObject({
+			success: false,
+			error: {
+				tag: 'ValidationError',
+				code: 'serviceId',
+			},
+		});
+		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
 	});
 });

--- a/src/server/date-prewarm.test.ts
+++ b/src/server/date-prewarm.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildAvailabilityDatesCacheKey,
+	getDatePrewarmMonths,
+	selectDatePrewarmMonths,
+} from './date-prewarm.js';
+
+describe('date prewarm helpers', () => {
+	it('defaults to one month and caps aggressive env values', () => {
+		expect(getDatePrewarmMonths({})).toBe(1);
+		expect(getDatePrewarmMonths({ ACUITY_DATE_PREWARM_MONTHS: '2' })).toBe(2);
+		expect(getDatePrewarmMonths({ ACUITY_DATE_PREWARM_MONTHS: '99' })).toBe(2);
+	});
+
+	it('allows disabling date prewarm with zero or negative env values', () => {
+		expect(getDatePrewarmMonths({ ACUITY_DATE_PREWARM_MONTHS: '0' })).toBe(0);
+		expect(getDatePrewarmMonths({ ACUITY_DATE_PREWARM_MONTHS: '-1' })).toBe(0);
+	});
+
+	it('selects months after the requested target month', () => {
+		expect(selectDatePrewarmMonths('2026-07', 2)).toEqual([
+			'2026-08',
+			'2026-09',
+		]);
+	});
+
+	it('accepts route startDate values when selecting prewarm months', () => {
+		expect(selectDatePrewarmMonths('2026-12-01', 2)).toEqual([
+			'2027-01',
+			'2027-02',
+		]);
+	});
+
+	it('falls back to the current month when no route month is provided', () => {
+		expect(
+			selectDatePrewarmMonths(undefined, 1, new Date(2026, 4, 15)),
+		).toEqual(['2026-06']);
+	});
+
+	it('builds the same date cache key used by the public dates route', () => {
+		expect(
+			buildAvailabilityDatesCacheKey(
+				'https://MassageIthaca.as.me',
+				'53178494',
+				'2026-08',
+			),
+		).toBe('bridge-read:v2:dates:https://MassageIthaca.as.me:53178494:2026-08');
+	});
+});

--- a/src/server/date-prewarm.ts
+++ b/src/server/date-prewarm.ts
@@ -1,0 +1,72 @@
+const YEAR_MONTH_RE = /^\d{4}-\d{2}$/;
+const DATE_RE = /^(\d{4})-(\d{2})-\d{2}$/;
+const DEFAULT_DATE_PREWARM_MONTHS = 1;
+const MAX_DATE_PREWARM_MONTHS = 2;
+
+export const getDatePrewarmMonths = (
+	env: Record<string, string | undefined> = process.env,
+): number => {
+	const raw = env.ACUITY_DATE_PREWARM_MONTHS;
+	if (raw === undefined || raw === '') {
+		return DEFAULT_DATE_PREWARM_MONTHS;
+	}
+
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_DATE_PREWARM_MONTHS;
+	}
+	if (parsed <= 0) {
+		return 0;
+	}
+
+	return Math.min(Math.floor(parsed), MAX_DATE_PREWARM_MONTHS);
+};
+
+export const buildAvailabilityDatesCacheKey = (
+	baseUrl: string,
+	serviceId: string,
+	targetMonth: string,
+): string => `bridge-read:v2:dates:${baseUrl}:${serviceId}:${targetMonth}`;
+
+const parseYearMonth = (
+	value: string | undefined,
+	now = new Date(),
+): { year: number; month: number } => {
+	if (value && YEAR_MONTH_RE.test(value)) {
+		return {
+			year: Number.parseInt(value.slice(0, 4), 10),
+			month: Number.parseInt(value.slice(5, 7), 10),
+		};
+	}
+
+	const dateMatch = value?.match(DATE_RE);
+	if (dateMatch) {
+		return {
+			year: Number.parseInt(dateMatch[1], 10),
+			month: Number.parseInt(dateMatch[2], 10),
+		};
+	}
+
+	return {
+		year: now.getFullYear(),
+		month: now.getMonth() + 1,
+	};
+};
+
+const formatYearMonth = (year: number, month: number): string => {
+	const normalized = new Date(Date.UTC(year, month - 1, 1));
+	return `${normalized.getUTCFullYear()}-${String(normalized.getUTCMonth() + 1).padStart(2, '0')}`;
+};
+
+export const selectDatePrewarmMonths = (
+	currentMonth: string | undefined,
+	limit: number,
+	now = new Date(),
+): string[] => {
+	if (limit <= 0) return [];
+
+	const base = parseYearMonth(currentMonth, now);
+	return Array.from({ length: limit }, (_, index) =>
+		formatYearMonth(base.year, base.month + index + 1),
+	);
+};

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -91,6 +91,26 @@ import type {
 } from '../core/types.js';
 import { Errors } from '../core/types.js';
 
+const acuitySteps = {
+	navigateToBooking,
+	fillFormFields,
+	bypassPayment,
+	generateCouponCode,
+	submitBooking,
+	extractConfirmation,
+	toBooking,
+	readAvailableDates,
+	readTimeSlots,
+	readDatesViaUrl,
+	readSlotsViaUrl,
+};
+
+export const __setAcuityStepOverridesForTest = (
+	overrides: Partial<typeof acuitySteps>,
+) => {
+	Object.assign(acuitySteps, overrides);
+};
+
 // =============================================================================
 // CONFIGURATION
 // =============================================================================
@@ -284,12 +304,9 @@ const browserRuntime = ManagedRuntime.make(BrowserProcessLive(browserConfig));
 
 type Result<A> = { ok: true; value: A } | { ok: false; error: SchedulingError };
 
-const runEffect = async <A>(
-	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
-): Promise<Result<A>> => {
-	const exit = await browserRuntime.runPromiseExit(
-		Effect.scoped(effect.pipe(Effect.provide(BrowserSessionLive))),
-	);
+const exitToResult = <A>(
+	exit: Exit.Exit<A, MiddlewareError | undefined>,
+): Result<A> => {
 	if (Exit.isSuccess(exit)) {
 		return { ok: true, value: exit.value };
 	}
@@ -298,6 +315,34 @@ const runEffect = async <A>(
 		return { ok: false, error: toSchedulingError(failure.value) };
 	}
 	return { ok: false, error: { _tag: 'InfrastructureError', code: 'UNKNOWN', message: Cause.pretty(exit.cause) } };
+};
+
+type RunEffect = <A>(
+	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
+) => Promise<Result<A>>;
+
+const runEffectWithBrowser: RunEffect = async <A>(
+	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
+): Promise<Result<A>> => {
+	const exit = await browserRuntime.runPromiseExit(
+		Effect.scoped(effect.pipe(Effect.provide(BrowserSessionLive))),
+	);
+	return exitToResult(exit);
+};
+
+let runEffect: RunEffect = runEffectWithBrowser;
+
+export const __runEffectWithoutBrowserForTest: RunEffect = async <A>(
+	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
+): Promise<Result<A>> => {
+	const exit = await Effect.runPromiseExit(
+		effect as Effect.Effect<A, MiddlewareError | undefined, never>,
+	);
+	return exitToResult(exit);
+};
+
+export const __setEffectRunnerForTest = (runner: RunEffect | null) => {
+	runEffect = runner ?? runEffectWithBrowser;
 };
 
 // =============================================================================
@@ -456,7 +501,7 @@ const scheduleDatePrewarm = (
 	for (const month of selectDatePrewarmMonths(currentMonth, DATE_PREWARM_MONTHS)) {
 		const cacheKey = buildAvailabilityDatesCacheKey(ACUITY_BASE_URL, serviceId, month);
 		void runCachedBridgeRead(context, 'availability_dates', cacheKey, () =>
-			runEffect(readDatesViaUrl(serviceId, month)),
+			runEffect(acuitySteps.readDatesViaUrl(serviceId, month)),
 		).then((result) => {
 			if (!result.ok) {
 				logRequestEvent('WARN', 'Availability dates prewarm failed', context, {
@@ -505,7 +550,7 @@ const scheduleSlotPrewarm = (
 			const cacheKey = buildAvailabilitySlotsCacheKey(ACUITY_BASE_URL, serviceId, date);
 			const result = await runCachedBridgeRead(context, 'availability_slots', cacheKey, () =>
 				runEffect(
-					readSlotsViaUrl(
+					acuitySteps.readSlotsViaUrl(
 						serviceId,
 						date,
 						createSlotReadTelemetryContext(context, 'availability_slots_prewarm'),
@@ -657,7 +702,7 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 	);
 	const result = await runCachedBridgeRead(context, 'availability_dates', cacheKey, () =>
 		isAcuityAppointmentTypeId(body.serviceId)
-			? runEffect(readDatesViaUrl(body.serviceId, targetMonth))
+			? runEffect(acuitySteps.readDatesViaUrl(body.serviceId, targetMonth))
 			: (async () => {
 				const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
 				logRequestEvent('INFO', 'Availability dates resolved service name', context, {
@@ -667,7 +712,7 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 					startDate: body.startDate,
 				});
 				return runEffect(
-					readAvailableDates({
+					acuitySteps.readAvailableDates({
 						serviceName,
 						targetMonth,
 						monthsToScan: 2,
@@ -719,7 +764,7 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 	const result = await runCachedBridgeRead(context, 'availability_slots', cacheKey, () =>
 		isAcuityAppointmentTypeId(body.serviceId)
 			? runEffect(
-				readSlotsViaUrl(
+				acuitySteps.readSlotsViaUrl(
 					body.serviceId,
 					body.date,
 					createSlotReadTelemetryContext(context, 'availability_slots'),
@@ -734,7 +779,7 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 					date: body.date,
 				});
 				return runEffect(
-					readTimeSlots({
+					acuitySteps.readTimeSlots({
 						serviceName,
 						date: body.date,
 					}),
@@ -771,7 +816,7 @@ const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse, contex
 	});
 	const result = isAcuityAppointmentTypeId(body.serviceId)
 		? await runEffect(
-				readSlotsViaUrl(
+				acuitySteps.readSlotsViaUrl(
 					body.serviceId,
 					date,
 					createSlotReadTelemetryContext(context, 'availability_check'),
@@ -780,7 +825,7 @@ const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse, contex
 		: await (async () => {
 				const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
 				return runEffect(
-					readTimeSlots({
+					acuitySteps.readTimeSlots({
 						serviceName,
 						date,
 					}),
@@ -821,16 +866,16 @@ const handleCreateBooking = async (req: IncomingMessage, res: ServerResponse, co
 
 	const result = await runEffect(
 		Effect.gen(function* () {
-			yield* navigateToBooking({
+			yield* acuitySteps.navigateToBooking({
 				serviceName: serviceName ?? request.serviceId,
 				datetime: request.datetime,
 				client: request.client,
 				appointmentTypeId: request.serviceId,
 			});
-			yield* fillFormFields({ client: request.client, customFields: request.client.customFields });
-			yield* submitBooking();
-			const confirmation = yield* extractConfirmation();
-			return toBooking(confirmation, request, '', 'acuity');
+			yield* acuitySteps.fillFormFields({ client: request.client, customFields: request.client.customFields });
+			yield* acuitySteps.submitBooking();
+			const confirmation = yield* acuitySteps.extractConfirmation();
+			return acuitySteps.toBooking(confirmation, request, '', 'acuity');
 		}),
 	);
 
@@ -880,17 +925,17 @@ const handleCreateBookingWithPayment = async (
 
 	const result = await runEffect(
 		Effect.gen(function* () {
-			yield* navigateToBooking({
+			yield* acuitySteps.navigateToBooking({
 				serviceName,
 				datetime: request.datetime,
 				client: request.client,
 				appointmentTypeId: request.serviceId,
 			});
-			yield* fillFormFields({ client: request.client, customFields: request.client.customFields });
-			yield* bypassPayment(coupon);
-			yield* submitBooking();
-			const confirmation = yield* extractConfirmation();
-			return toBooking(
+			yield* acuitySteps.fillFormFields({ client: request.client, customFields: request.client.customFields });
+			yield* acuitySteps.bypassPayment(coupon);
+			yield* acuitySteps.submitBooking();
+			const confirmation = yield* acuitySteps.extractConfirmation();
+			return acuitySteps.toBooking(
 				confirmation,
 				request,
 				paymentRef,

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -176,6 +176,16 @@ const sendError = (res: ServerResponse, status: number, err: SchedulingError) =>
 		},
 	});
 
+const sendValidationError = (res: ServerResponse, code: string, message: string) =>
+	sendJson(res, 400, {
+		success: false,
+		error: {
+			tag: 'ValidationError',
+			code,
+			message,
+		},
+	});
+
 const parseBody = async (req: IncomingMessage): Promise<unknown> => {
 	const chunks: Buffer[] = [];
 	for await (const chunk of req) {
@@ -368,6 +378,17 @@ const serviceCatalog = createAcuityServiceCatalog({
 
 const isSchedulingError = (error: unknown): error is SchedulingError =>
 	typeof error === 'object' && error !== null && '_tag' in error;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isNonEmptyString = (value: unknown): value is string =>
+	typeof value === 'string' && value.trim().length > 0;
+
+const optionalString = (value: unknown): string | undefined | null => {
+	if (value === undefined) return undefined;
+	return typeof value === 'string' ? value : null;
+};
 
 const runCachedBridgeRead = async <A>(
 	context: RequestContext,
@@ -609,7 +630,19 @@ const handleGetService = async (serviceId: string, res: ServerResponse) => {
 };
 
 const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, context: RequestContext) => {
-	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; startDate?: string };
+	const rawBody = await parseBody(req);
+	if (!isRecord(rawBody) || !isNonEmptyString(rawBody.serviceId)) {
+		return sendValidationError(res, 'serviceId', 'serviceId is required');
+	}
+	const serviceName = optionalString(rawBody.serviceName);
+	if (serviceName === null) {
+		return sendValidationError(res, 'serviceName', 'serviceName must be a string');
+	}
+	const startDate = optionalString(rawBody.startDate);
+	if (startDate === null) {
+		return sendValidationError(res, 'startDate', 'startDate must be a string');
+	}
+	const body = { serviceId: rawBody.serviceId, serviceName, startDate };
 	const targetMonth = body.startDate?.slice(0, 7);
 	logRequestEvent('INFO', 'Availability dates requested', context, {
 		event: 'availability_dates_requested',
@@ -664,7 +697,18 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 };
 
 const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, context: RequestContext) => {
-	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; date: string };
+	const rawBody = await parseBody(req);
+	if (!isRecord(rawBody) || !isNonEmptyString(rawBody.serviceId)) {
+		return sendValidationError(res, 'serviceId', 'serviceId is required');
+	}
+	if (!isNonEmptyString(rawBody.date)) {
+		return sendValidationError(res, 'date', 'date is required');
+	}
+	const serviceName = optionalString(rawBody.serviceName);
+	if (serviceName === null) {
+		return sendValidationError(res, 'serviceName', 'serviceName must be a string');
+	}
+	const body = { serviceId: rawBody.serviceId, serviceName, date: rawBody.date };
 	logRequestEvent('INFO', 'Availability slots requested', context, {
 		event: 'availability_slots_requested',
 		serviceId: body.serviceId,

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -73,6 +73,11 @@ import {
 import { buildHealthPayload } from './health.js';
 import { handleReady as _handleReady } from './ready.js';
 import {
+	buildAvailabilityDatesCacheKey,
+	getDatePrewarmMonths,
+	selectDatePrewarmMonths,
+} from './date-prewarm.js';
+import {
 	buildAvailabilitySlotsCacheKey,
 	getSlotPrewarmLimit,
 	selectSlotPrewarmDates,
@@ -114,6 +119,7 @@ const READ_CACHE_WAIT_TIMEOUT_MS = (() => {
 	const parsed = Number(process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS ?? 55_000);
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : 55_000;
 })();
+const DATE_PREWARM_MONTHS = getDatePrewarmMonths();
 const SLOT_PREWARM_LIMIT = getSlotPrewarmLimit();
 
 const browserConfig: BrowserConfig = {
@@ -417,6 +423,42 @@ const resolveServiceName = async (serviceId: string, serviceName?: string): Prom
 
 const isAcuityAppointmentTypeId = (serviceId: string): boolean => /^\d+$/.test(serviceId);
 
+const scheduleDatePrewarm = (
+	context: RequestContext,
+	serviceId: string,
+	currentMonth: string | undefined,
+): void => {
+	if (!redisClient || DATE_PREWARM_MONTHS <= 0 || !isAcuityAppointmentTypeId(serviceId)) {
+		return;
+	}
+
+	for (const month of selectDatePrewarmMonths(currentMonth, DATE_PREWARM_MONTHS)) {
+		const cacheKey = buildAvailabilityDatesCacheKey(ACUITY_BASE_URL, serviceId, month);
+		void runCachedBridgeRead(context, 'availability_dates', cacheKey, () =>
+			runEffect(readDatesViaUrl(serviceId, month)),
+		).then((result) => {
+			if (!result.ok) {
+				logRequestEvent('WARN', 'Availability dates prewarm failed', context, {
+					event: 'availability_dates_prewarm_failed',
+					serviceId,
+					targetMonth: month,
+					errorTag: result.error._tag,
+					errorCode: 'code' in result.error ? result.error.code : 'UNKNOWN',
+					errorMessage: 'message' in result.error ? result.error.message : 'Date prewarm failed',
+				});
+				return;
+			}
+
+			logRequestEvent('INFO', 'Availability dates prewarm completed', context, {
+				event: 'availability_dates_prewarm_completed',
+				serviceId,
+				targetMonth: month,
+				dateCount: Array.isArray(result.value) ? result.value.length : undefined,
+			});
+		});
+	}
+};
+
 const scheduleSlotPrewarm = (
 	context: RequestContext,
 	serviceId: string,
@@ -575,7 +617,11 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 		serviceName: body.serviceName,
 		startDate: body.startDate,
 	});
-	const cacheKey = `bridge-read:v2:dates:${ACUITY_BASE_URL}:${body.serviceId}:${targetMonth ?? 'current'}`;
+	const cacheKey = buildAvailabilityDatesCacheKey(
+		ACUITY_BASE_URL,
+		body.serviceId,
+		targetMonth ?? 'current',
+	);
 	const result = await runCachedBridgeRead(context, 'availability_dates', cacheKey, () =>
 		isAcuityAppointmentTypeId(body.serviceId)
 			? runEffect(readDatesViaUrl(body.serviceId, targetMonth))
@@ -612,6 +658,7 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Availability lookup failed' },
 		});
 	}
+	scheduleDatePrewarm(context, body.serviceId, targetMonth);
 	scheduleSlotPrewarm(context, body.serviceId, result.value);
 	sendSuccess(res, result.value);
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 			'src/**/__tests__/**/*.test.ts',
 			'tests/**/*.test.ts',
 			'parity/**/*.test.ts',
+			'bench/**/*.test.ts',
 		],
 		environment: 'node',
 		globals: true,


### PR DESCRIPTION
## Summary
- add bounded `ACUITY_DATE_PREWARM_MONTHS` support for adjacent availability date months
- prewarm next-month date cache after successful `/availability/dates` reads when Redis is configured and the service id is an Acuity appointment id
- reuse the existing bridge read cache single-flight path so concurrent pods do not duplicate Acuity reads
- add focused helper coverage for env parsing, month rollover, and date cache key construction
- add HTTP route coverage proving a July dates request warms August and an August month advance is served from Redis without rereading Acuity for August
- add HTTP route coverage proving repeated slot requests are served from Redis and empty slot arrays use the short empty-read TTL
- validate date/slot route bodies before cache lookup or Acuity reads
- add route-level timeout coverage proving cache losers return `TIMEOUT` without becoming duplicate Acuity reads
- add route-edge coverage for auth rejection, unsupported methods, and Acuity read failures
- add fake-Page URL date-reader coverage for false-empty settling and target-month navigation correctness
- update the k6 benchmark harness to exercise the deployed JSON `POST /availability/dates` and `POST /availability/slots` protocol, with endpoint tags and fast-response cache proxy metrics
- add a benchmark protocol test so load scripts cannot silently drift back to query-string `GET` availability reads

## Validation
- `pnpm exec vitest run bench/k6-protocol.test.ts --config vitest.config.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm exec prettier --single-quote --use-tabs --check bench/k6-smoke.js bench/k6-load-1k.js bench/k6-load-10k.js bench/README.md bench/k6-protocol.test.ts vitest.config.ts`
- `pnpm exec vitest run src/adapters/acuity/steps/read-via-url.test.ts src/server/__tests__/availability-slots-cache.test.ts src/server/__tests__/availability-dates-cache.test.ts src/server/date-prewarm.test.ts src/server/slot-prewarm.test.ts src/shared/bridge-read-cache.test.ts`
- `pnpm exec prettier --single-quote --use-tabs --check src/adapters/acuity/steps/read-via-url.test.ts src/server/__tests__/availability-slots-cache.test.ts src/server/__tests__/availability-dates-cache.test.ts`
- `git diff --check`

## Context
Live K8s evidence showed repeated app cache hits returning in 1-2ms, but month-advance date reads and hour-slot reads still paid 7s-15s cold bridge reads. This makes the likely next month warm, proves slot cache hits/empty-result TTL behavior, hardens cache-loser/body/auth/method/error behavior, and fixes the benchmark harness so future perf artifacts measure the same POST routes the app actually calls. No deployment is performed from this PR.