### PR TITLE
[codex] Bump scheduling-bridge to 0.4.9

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.8",
+    version = "0.4.9",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.8",
+    version = "0.4.9",
     compatibility_level = 1,
 )
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.4.8`
-- Bazel module version: `0.4.8`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.8`
+- package version: `0.4.9`
+- Bazel module version: `0.4.9`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.9`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

- bumps `@tummycrypt/scheduling-bridge` release metadata from `0.4.8` to `0.4.9`
- aligns `package.json`, `MODULE.bazel`, `BUILD.bazel`, and generated repo facts
- prepares a patch release for the merged booking write and availability cache hardening line

## Validation

- `pnpm check:release-metadata`
- `pnpm check:package`

## Release Boundary

This PR does not publish npm artifacts or apply Kubernetes changes. Publishing still requires the explicit tag/release workflow after merge. K8s deployment remains a separate Blahaj/OpenTofu action.