### PR TITLE
[codex] Bump bridge scheduling-kit dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,11 @@ As of `2026-04-25`, the active structural work here is:
 
 Operationally relevant truth:
 
-- current package metadata is `@tummycrypt/scheduling-bridge` `0.4.8`
-- `0.4.8` depends on `@tummycrypt/scheduling-kit ^0.7.5`
-- as of `2026-05-03`, npm `latest`, git tag `v0.4.8`, and the K8s bridge
-  shadow runtime are aligned on the current `0.4.8` release edge
+- current package metadata is `@tummycrypt/scheduling-bridge` `0.4.10`
+- `0.4.10` depends on `@tummycrypt/scheduling-kit ^0.7.7`
+- as of `2026-05-06`, the package metadata is ahead of the last published
+  release so scheduling-kit dependency freshness can be validated before the
+  next tag/publish edge
 - package metadata, git tags, npm dist-tags, GitHub releases, and deployed
   bridge runtime tuples remain separate authority surfaces and should be
   verified explicitly

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.9",
+    version = "0.4.10",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.9",
+    version = "0.4.10",
     compatibility_level = 1,
 )
 
@@ -46,7 +46,7 @@ bazel_dep(name = "aspect_rules_swc", version = "2.6.1")
 # =============================================================================
 
 # Primary dependency: scheduling-kit (peer; bridge orchestrates over kit's adapters).
-bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.5")
+bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.7")
 
 # Auth surface (payment capability types come through tinyland-auth).
 bazel_dep(name = "tummycrypt_tinyland_auth", version = "0.3.0")

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.4.9`
-- Bazel module version: `0.4.9`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.9`
+- package version: `0.4.10`
+- Bazel module version: `0.4.10`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.10`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
@@ -50,7 +50,7 @@
     "paper:dev": "node docs/paper/watch.mjs"
   },
   "dependencies": {
-    "@tummycrypt/scheduling-kit": "^0.7.5",
+    "@tummycrypt/scheduling-kit": "^0.7.7",
     "effect": "^3.19.14",
     "ioredis": "^5",
     "playwright-core": "1.58.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@tummycrypt/scheduling-kit':
-        specifier: ^0.7.5
-        version: 0.7.5(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
+        specifier: ^0.7.7
+        version: 0.7.7(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
       effect:
         specifier: ^3.19.14
         version: 3.21.0
@@ -373,8 +373,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@tummycrypt/scheduling-kit@0.7.5':
-    resolution: {integrity: sha512-8bS4PME3Z29tWYKqsyRHadJcGaY1hQHjTbeJvezL2VT7lWEaPQ0GbRuErGgnGFEE7Tdzo5OICuQHIubtNtr5LQ==}
+  '@tummycrypt/scheduling-kit@0.7.7':
+    resolution: {integrity: sha512-ChnfRWS7Pb84iyCkDYY3PmD4xKTOKCp/yxjYY2rBJLNDn2+ZVwLDlt10QTaigHAH9YpoVL4BVTcPizqQeRIfQQ==}
     engines: {node: '>=20 <25'}
     peerDependencies:
       '@skeletonlabs/skeleton': ^4.0.0
@@ -1418,7 +1418,7 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tummycrypt/scheduling-kit@0.7.5(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
+  '@tummycrypt/scheduling-kit@0.7.7(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
     dependencies:
       '@tummycrypt/tinyland-auth-pg': 0.2.4(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)
       drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(pg@8.20.0)


### PR DESCRIPTION
## What changed

- Bumps `@tummycrypt/scheduling-bridge` metadata to `0.4.10`.
- Updates the npm dependency on `@tummycrypt/scheduling-kit` to `^0.7.7`.
- Updates the Bzlmod edge to `tummycrypt_scheduling_kit@0.7.7`.
- Refreshes generated repo facts and AGENTS operational truth.

## Why

`TIN-678` is no longer blocked on missing registry entries: the internal registry has `tummycrypt_scheduling_kit@0.7.7` and `tummycrypt_scheduling_bridge@0.4.9`. The remaining bridge drift was that the bridge package and Bzlmod metadata still pointed at scheduling-kit `0.7.5`. This PR makes the next bridge release line validate against the current kit release.

## Validation

- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- `pnpm docs:generate`
- `pnpm check:release-metadata`
- `pnpm docs:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm check:artifact-authority`
- `pnpm build`
- `pnpm check:package`
- `npx --yes @bazel/bazelisk mod graph`
- `git diff --check`

## Boundary

This is Bzlmod/package-authority cleanup. It is not RBE and does not add a remote executor path.