### PR TITLE
Add async bridge queue runtime

### DIFF
--- a/.github/workflows/deploy-modal.yml
+++ b/.github/workflows/deploy-modal.yml
@@ -1,23 +1,12 @@
 name: Deploy Modal
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'modal-app.py'
-      - 'src/**'
-      - 'BUILD.bazel'
-      - 'MODULE.bazel'
-      - '.bazelversion'
-      - '.npmrc'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'scripts/build-derived-artifacts.mjs'
-      - 'scripts/bazel-helpers.mjs'
-      - 'tsconfig.json'
-      - '.github/workflows/deploy-modal.yml'
   workflow_dispatch:
     inputs:
+      acknowledge_legacy_modal:
+        description: 'Type legacy-modal to acknowledge this path is decommissioning-only'
+        required: true
+        type: string
       modal_environment:
         description: 'Modal environment name (optional)'
         required: false
@@ -38,6 +27,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ github.event.inputs.acknowledge_legacy_modal == 'legacy-modal' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -98,6 +98,7 @@ ts_project(
     name = "server",
     srcs = [
         "src/server/handler.ts",
+        "src/server/worker.ts",
         "src/server.ts",
     ],
     declaration = True,
@@ -110,6 +111,8 @@ ts_project(
         ":shared",
         ":node_modules",
         ":node_modules/effect",
+        ":node_modules/pg",
+        ":node_modules/@types/pg",
         ":node_modules/@tummycrypt/scheduling-kit",
     ],
     visibility = ["//visibility:public"],
@@ -138,6 +141,8 @@ ts_project(
         ":node_modules",
         ":node_modules/effect",
         ":node_modules/playwright-core",
+        ":node_modules/pg",
+        ":node_modules/@types/pg",
         ":node_modules/@tummycrypt/scheduling-kit",
     ],
     visibility = ["//visibility:public"],
@@ -157,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.4.10",
+    version = "0.5.0",
     visibility = ["//visibility:public"],
 )
 
@@ -206,6 +211,8 @@ ts_project(
         ":node_modules",
         ":node_modules/effect",
         ":node_modules/playwright-core",
+        ":node_modules/pg",
+        ":node_modules/@types/pg",
         ":node_modules/@tummycrypt/scheduling-kit",
     ],
     visibility = ["//visibility:public"],

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #   docker build -t scheduling-bridge .
 #   docker run -p 3001:3001 \
 #     -e AUTH_TOKEN=... \
-#     -e ACUITY_BASE_URL=https://MassageIthaca.as.me \
+#     -e ACUITY_BASE_URL=https://example.as.me \
 #     -e ACUITY_BYPASS_COUPON=... \
 #     scheduling-bridge
 #

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.4.10",
+    version = "0.5.0",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ HTTP Request
 | POST | `/availability/dates` | Available dates for a service |
 | POST | `/availability/slots` | Time slots for a specific date |
 | POST | `/availability/check` | Check if a slot is available |
+| POST | `/availability/refresh` | Enqueue async availability refresh |
+| GET | `/availability/snapshot` | Read latest durable availability snapshot |
 | POST | `/booking/create` | Create a booking (standard) |
-| POST | `/booking/create-with-payment` | Create booking with payment bypass (coupon) |
+| POST | `/booking/create-with-payment` | Deprecated sync paid booking endpoint; returns `410 ASYNC_REQUIRED` |
+| POST | `/booking/jobs` | Enqueue async paid booking job |
+| GET | `/jobs/:operationId` | Read async job status |
 
 ### Health Contract
 
@@ -77,7 +81,12 @@ dashboard state when `/health` is available.
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `PORT` | No | `3001` | Server port |
-| `ACUITY_BASE_URL` | No | `https://MassageIthaca.as.me` | Acuity scheduling page URL |
+| `ACUITY_BASE_URL` | No | `https://example.as.me` | Acuity scheduling page URL |
+| `BRIDGE_DATABASE_URL` | For async K8s runtime | -- | Postgres queue/snapshot store for async jobs |
+| `BRIDGE_DATABASE_SSL` | No | `false` | Enable SSL for `BRIDGE_DATABASE_URL` |
+| `BRIDGE_DATABASE_MIGRATE` | No | `true` | Run async queue/snapshot schema creation at startup |
+| `BRIDGE_WORKER_POLL_MS` | No | `1000` | Worker queue poll interval |
+| `BRIDGE_WORKER_BATCH_SIZE` | No | `5` | Maximum jobs drained per worker poll |
 | `AUTH_TOKEN` | Recommended | -- | Bearer token for all endpoints (except /health) |
 | `ACUITY_BYPASS_COUPON` | For payment bypass | -- | 100% gift certificate code |
 | `PLAYWRIGHT_HEADLESS` | No | `true` | Run browser headless |
@@ -115,8 +124,9 @@ contract.
 
 - Accepted next-production route: K8s/container runtime managed from
   infrastructure.
-- Current fallback/proofing provider: Modal, retained until remaining stable
-  consumer traffic is deliberately moved.
+- Legacy proofing provider: Modal. Automatic Modal deploys are disabled; the
+  manual workflow is retained only for deliberate decommissioning or
+  forensic fallback while TIN-981 closes the surface.
 - Compatibility target: Docker image with the same `dist/server/handler.js`
   entrypoint.
 - Consumer apps should configure the remote bridge with
@@ -128,9 +138,9 @@ contract.
 The npm package supports active downstream consumer runtimes on Node 22 and
 Node 24. CI validates the host test suite on both majors.
 
-The bridge-owned Bazel toolchain, Nix dev shell, Docker image, Modal image, and
-publish workflow intentionally stay on Node 24. Downstream apps should not infer
-that they must also run Node 24 unless they deploy the bridge runtime itself.
+The bridge-owned Bazel toolchain, Nix dev shell, Docker/K8s image, and publish
+workflow intentionally stay on Node 24. Downstream apps should not infer that
+they must also run Node 24 unless they deploy the bridge runtime itself.
 
 ### Standalone Node.js
 
@@ -152,29 +162,29 @@ docker run -p 3001:3001 \
   scheduling-bridge
 ```
 
-### Modal Labs
+### Legacy Modal Labs
 
 ```bash
-# Set secrets in Modal dashboard first:
-#   AUTH_TOKEN, ACUITY_BASE_URL, ACUITY_BYPASS_COUPON
+# Automatic Modal deploys are disabled. The manual workflow requires an
+# explicit legacy-modal acknowledgement and should only be used for
+# decommissioning or forensic fallback while TIN-981 is open.
 # The Modal workflow materializes the Bazel-derived pkg/ before deploy.
 modal deploy modal-app.py
 ```
 
 #### Supported fallback deployment path
 
-The Modal deployment path remains available for fallback/proofing traffic:
+The Modal deployment path is legacy-only:
 
-1. merge to `main`
-2. let `.github/workflows/deploy-modal.yml` deploy `modal-app.py`
+1. manually dispatch `.github/workflows/deploy-modal.yml`
+2. type `legacy-modal` in `acknowledge_legacy_modal`
 3. inject `MIDDLEWARE_RELEASE_SHA`, `MIDDLEWARE_RELEASE_REF`,
    `MIDDLEWARE_RELEASE_VERSION`, and `MIDDLEWARE_RELEASE_BUILT_AT`
 4. verify the resulting bridge tuple via `GET /health`
 
 Operationally, this means:
 
-- Modal deployment can be part of release truth when it is the selected
-  provider, not a side channel
+- Modal deployment is not automatic release truth
 - the live bridge should be identified by the `/health` release + protocol tuple
 - downstream apps should validate the tuple they expect before making rollout claims
 
@@ -202,10 +212,9 @@ The current publish + deploy shape is:
 2. Bazel validates/builds the publishable artifact
 3. CI dry-runs the extracted Bazel package surface before release
 4. GitHub Actions publishes that extracted artifact
-5. GitHub Actions can deploy the Modal fallback runtime from `main`
-6. infrastructure can deploy the K8s/container runtime from the same package
+5. infrastructure can deploy the K8s/container runtime from the same package
    artifact and image entrypoint
-7. downstream apps consume the published package and verify the live runtime
+6. downstream apps consume the published package and verify the live runtime
    tuple via `/health`
 
 This repo is the sole owner of Acuity automation concerns. App repos and shared

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -7,8 +7,8 @@ The release path is artifact-first.
 3. Build the package with `bazel build //:pkg`.
 4. Use `pnpm build` when local `pkg/` and `dist/` materialization is needed.
 5. Publish from `./bazel-bin/pkg`.
-6. Deploy Modal, Docker, and K8s/container runtimes from the same materialized
-   package surface.
+6. Deploy Docker and K8s/container runtimes from the same materialized package
+   surface.
 
 ## Commands
 
@@ -44,7 +44,6 @@ Bridge-owned runtime and artifact authority remains Node 24:
 - Bazel Node toolchain
 - Nix development shell
 - Docker runtime image
-- Modal runtime image
 - K8s/container runtime image
 - npm/GitHub Packages publish runner
 
@@ -54,11 +53,11 @@ runtime image, and package CI must prove both supported consumer majors.
 ## Runtime Provider Policy
 
 K8s/container execution is the accepted next-production bridge route. Modal
-remains legacy proofing/fallback context, and may still serve stable live
-consumer traffic until that traffic is deliberately moved. Every provider must
-consume the same materialized package and launch the same
-`dist/server/handler.js` entrypoint. Provider-specific deployment mechanics
-must not fork the bridge protocol or package artifact.
+is legacy proofing context with automatic deploys disabled and manual dispatch
+guarded by explicit acknowledgement. Every provider must consume the same
+materialized package and launch the same `dist/server/handler.js` entrypoint.
+Provider-specific deployment mechanics must not fork the bridge protocol or
+package artifact.
 
 ## Bazel Cache Contract
 
@@ -84,8 +83,8 @@ Before cutting a bridge release, verify these surfaces together:
 - GitHub Packages package: `@jesssullivan/scheduling-bridge`
 - tag and GitHub release for the package version
 - Bazel package artifact from `./bazel-bin/pkg`
-- Docker, K8s/container, and Modal fallback runtime images built from the
-  materialized `pkg/` surface
+- Docker and K8s/container runtime images built from the materialized `pkg/`
+  surface
 - `/health` release tuple for the deployed bridge
 
 The shared `js-bazel-package` workflow owns npm provenance when running on

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.4.10`
-- Bazel module version: `0.4.10`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.4.10`
+- package version: `0.5.0`
+- Bazel module version: `0.5.0`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.0`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains
@@ -42,7 +42,7 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 - provider-agnostic contract: Node HTTP server plus `/health` tuple
 - accepted next-production provider: K8s/container runtime from infrastructure
-- fallback/proofing provider: Modal, until remaining live traffic moves
+- legacy proofing provider: Modal, automatic deploys disabled during TIN-981
 - forward consumer env names: `SCHEDULING_BRIDGE_URL` and
   `SCHEDULING_BRIDGE_AUTH_TOKEN`
 
@@ -55,7 +55,7 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 ## Protocol Surface
 
-- protocol version: `1.0.0`
+- protocol version: `1.1.0`
 - flow owner: `scheduling-bridge`
 - transport: `http-json`
 - backend: `acuity`
@@ -70,8 +70,12 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 | `availabilityDates` | `/availability/dates` |
 | `availabilitySlots` | `/availability/slots` |
 | `availabilityCheck` | `/availability/check` |
+| `availabilityRefresh` | `/availability/refresh` |
+| `availabilitySnapshot` | `/availability/snapshot` |
 | `bookingCreate` | `/booking/create` |
 | `bookingCreateWithPayment` | `/booking/create-with-payment` |
+| `bookingJobs` | `/booking/jobs` |
+| `jobStatus` | `/jobs/:operationId` |
 
 ### Capabilities
 
@@ -80,8 +84,12 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 - `availability:dates`
 - `availability:slots`
 - `availability:check`
+- `availability:refresh-async`
+- `availability:snapshot`
 - `booking:create`
-- `booking:create-with-payment`
+- `booking:create-with-payment:deprecated`
+- `booking:create-with-payment-async`
+- `booking:job-status`
 - `service-catalog:static-fallback`
 - `service-catalog:business-extract`
 - `service-catalog:scraper-fallback`

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@
 `@tummycrypt/scheduling-bridge`.
 
 The repo owns browser automation, HTTP bridge endpoints, Docker and
-K8s/container runtime packaging, Modal fallback/proofing runtime support, and
-the bridge runtime truth exposed by `/health`.
+K8s/container runtime packaging, and the bridge runtime truth exposed by
+`/health`.
 
 It does not own app deployment, business-specific UI, or reusable
 backend-agnostic checkout components. It also does not own cluster state or
@@ -17,9 +17,9 @@ public-edge routing. Those are consumer app, infrastructure, and
 - Bazel `//:pkg` builds the publishable package artifact.
 - `pnpm build` materializes local `pkg/` and `dist/` from `bazel-bin/pkg`.
 - CI and publish workflows extract `./bazel-bin/pkg`.
-- Docker, K8s/container, and Modal fallback runtimes consume the materialized
-  `pkg/` artifact rather than rebuilding from source inside runtime images.
+- Docker and K8s/container runtimes consume the materialized `pkg/` artifact
+  rather than rebuilding from source inside runtime images.
 - K8s/container execution is the accepted next-production bridge route; Modal
-  remains legacy proofing/fallback context until remaining live consumer traffic
-  is deliberately moved.
+  is legacy proofing context with automatic deploys disabled while TIN-981
+  closes the surface.
 - Generated facts live in `docs/generated/repo-facts.md`.

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -22,8 +22,9 @@ protocol endpoints and `/health` tuple.
 
 - K8s/container execution is the accepted next-production bridge route and is
   the current MassageIthaca K8s shadow runtime.
-- Modal remains legacy proofing/fallback context, and may still serve stable
-  live consumer traffic until that traffic is deliberately moved.
+- Modal is legacy proofing context. Automatic Modal deploys are disabled; the
+  manual workflow requires explicit acknowledgement while TIN-981 closes the
+  surface.
 - Provider state, tailnet exposure, and public-edge routing are managed by the
   infrastructure repo.
 - Docker is the local/container compatibility target and must mirror the same

--- a/llms.txt
+++ b/llms.txt
@@ -13,7 +13,7 @@ Authority:
 - runtime start command is `node dist/server/handler.js`
 - provider-agnostic runtime contract is the Node HTTP server plus `/health` tuple
 - K8s/container execution is the accepted next-production provider from infrastructure
-- Modal remains fallback/proofing context until remaining live traffic moves
+- Modal is legacy proofing context with automatic deploys disabled during TIN-981
 - consumer apps should use `SCHEDULING_BRIDGE_URL` and `SCHEDULING_BRIDGE_AUTH_TOKEN`
 
 Toolchains:
@@ -27,7 +27,7 @@ Toolchains:
 - CI publish node: `24`
 
 Protocol:
-- version: `1.0.0`
+- version: `1.1.0`
 - flow owner: `scheduling-bridge`
 - backend: `acuity`
 - transport: `http-json`
@@ -39,8 +39,12 @@ Endpoints:
 - `availabilityDates` -> `/availability/dates`
 - `availabilitySlots` -> `/availability/slots`
 - `availabilityCheck` -> `/availability/check`
+- `availabilityRefresh` -> `/availability/refresh`
+- `availabilitySnapshot` -> `/availability/snapshot`
 - `bookingCreate` -> `/booking/create`
 - `bookingCreateWithPayment` -> `/booking/create-with-payment`
+- `bookingJobs` -> `/booking/jobs`
+- `jobStatus` -> `/jobs/:operationId`
 
 Capabilities:
 - `services:list`
@@ -48,8 +52,12 @@ Capabilities:
 - `availability:dates`
 - `availability:slots`
 - `availability:check`
+- `availability:refresh-async`
+- `availability:snapshot`
 - `booking:create`
-- `booking:create-with-payment`
+- `booking:create-with-payment:deprecated`
+- `booking:create-with-payment-async`
+- `booking:job-status`
 - `service-catalog:static-fallback`
 - `service-catalog:business-extract`
 - `service-catalog:scraper-fallback`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.4.10",
+  "version": "0.5.0",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
@@ -53,11 +53,13 @@
     "@tummycrypt/scheduling-kit": "^0.7.7",
     "effect": "^3.19.14",
     "ioredis": "^5",
+    "pg": "8.20.0",
     "playwright-core": "1.58.1",
     "prom-client": "^15"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/pg": "8.11.6",
     "ioredis-mock": "^8.13.1",
     "publint": "^0.3.18",
     "tsx": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       ioredis:
         specifier: ^5
         version: 5.10.1
+      pg:
+        specifier: 8.20.0
+        version: 8.20.0
       playwright-core:
         specifier: 1.58.1
         version: 1.58.1
@@ -30,6 +33,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      '@types/pg':
+        specifier: 8.11.6
+        version: 8.11.6
       ioredis-mock:
         specifier: ^8.13.1
         version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.10.1))(ioredis@5.10.1)

--- a/scripts/generate-doc-surfaces.mjs
+++ b/scripts/generate-doc-surfaces.mjs
@@ -186,7 +186,7 @@ This page is generated from \`package.json\`, \`MODULE.bazel\`, \`BUILD.bazel\`,
 
 - provider-agnostic contract: Node HTTP server plus \`/health\` tuple
 - accepted next-production provider: K8s/container runtime from infrastructure
-- fallback/proofing provider: Modal, until remaining live traffic moves
+- legacy proofing provider: Modal, automatic deploys disabled during TIN-981
 - forward consumer env names: \`SCHEDULING_BRIDGE_URL\` and
   \`SCHEDULING_BRIDGE_AUTH_TOKEN\`
 
@@ -230,7 +230,7 @@ const llms = [
   `- runtime start command is \`${pkg.scripts.start}\``,
   '- provider-agnostic runtime contract is the Node HTTP server plus `/health` tuple',
   '- K8s/container execution is the accepted next-production provider from infrastructure',
-  '- Modal remains fallback/proofing context until remaining live traffic moves',
+  '- Modal is legacy proofing context with automatic deploys disabled during TIN-981',
   '- consumer apps should use `SCHEDULING_BRIDGE_URL` and `SCHEDULING_BRIDGE_AUTH_TOKEN`',
   '',
   'Toolchains:',

--- a/src/adapters/acuity/selectors.ts
+++ b/src/adapters/acuity/selectors.ts
@@ -21,7 +21,7 @@ import { SelectorError } from './errors.js';
  * Uses Emotion CSS-in-JS (css-* hashes are UNSTABLE — prefer semantic classes)
  *
  * Wizard flow:
- *   1. Service page: massageithaca.as.me → <li.select-item> list with "Book" buttons
+ *   1. Service page: <tenant>.as.me → <li.select-item> list with "Book" buttons
  *   2. Calendar page: /schedule/<hash>/appointment/<aptId>/calendar/<calId>
  *      - react-calendar month grid + available-times-container
  *   3. Client form: (after selecting time slot) → input fields

--- a/src/adapters/acuity/steps/navigate.ts
+++ b/src/adapters/acuity/steps/navigate.ts
@@ -3,7 +3,7 @@
  *
  * Acuity's React SPA (2026) does NOT support deep-linking via query params.
  * Instead, we click through the 5-step wizard:
- *   1. Service page (massageithaca.as.me) → find service → click "Book"
+ *   1. Service page (<tenant>.as.me) → find service → click "Book"
  *   2. Calendar page → navigate to target month → click target day
  *   3. Time slots → click matching slot → "Select and continue"
  *   4. Land on client form (fields empty — filling is a separate step)

--- a/src/async/postgres-store.ts
+++ b/src/async/postgres-store.ts
@@ -1,0 +1,342 @@
+import { randomUUID } from 'node:crypto';
+import pg from 'pg';
+import type { QueryResultRow } from 'pg';
+import type {
+	AvailabilitySnapshot,
+	AvailabilitySnapshotQuery,
+	BridgeJobCommand,
+	BridgeJobFailure,
+	BridgeJobRecord,
+	BridgeJobResult,
+	BridgeJobStatus,
+	EnqueueBridgeJobOptions,
+} from './types.js';
+import type { BridgeAsyncStore } from './store.js';
+
+const { Pool } = pg;
+
+export const BRIDGE_ASYNC_SCHEMA_SQL = `
+create table if not exists bridge_jobs (
+  operation_id uuid primary key,
+  kind text not null,
+  status text not null,
+  command jsonb not null,
+  idempotency_key text unique,
+  attempts integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  leased_by text,
+  leased_until timestamptz,
+  result jsonb,
+  failure jsonb
+);
+
+create index if not exists bridge_jobs_ready_idx
+  on bridge_jobs (status, created_at);
+
+create table if not exists bridge_availability_snapshots (
+  snapshot_id uuid primary key,
+  kind text not null,
+  service_id text not null,
+  scope text not null,
+  base_url text not null,
+  adapter_profile jsonb not null,
+  value jsonb not null,
+  observed_at timestamptz not null,
+  stale_at timestamptz not null,
+  expires_at timestamptz not null,
+  version integer not null default 1,
+  source_job_id uuid references bridge_jobs(operation_id) on delete set null,
+  updated_at timestamptz not null default now(),
+  unique (kind, service_id, scope, base_url)
+);
+
+create index if not exists bridge_availability_snapshots_freshness_idx
+  on bridge_availability_snapshots (kind, service_id, scope, stale_at, expires_at);
+`;
+
+interface BridgeJobRow {
+	operation_id: string;
+	kind: BridgeJobRecord['kind'];
+	status: BridgeJobStatus;
+	command: BridgeJobRecord['command'];
+	idempotency_key: string | null;
+	attempts: number;
+	created_at: Date | string;
+	updated_at: Date | string;
+	leased_by: string | null;
+	leased_until: Date | string | null;
+	result: BridgeJobResult | null;
+	failure: BridgeJobFailure | null;
+}
+
+interface AvailabilitySnapshotRow {
+	snapshot_id: string;
+	kind: AvailabilitySnapshot['kind'];
+	service_id: string;
+	scope: string;
+	adapter_profile: AvailabilitySnapshot['adapterProfile'];
+	value: AvailabilitySnapshot['value'];
+	observed_at: Date | string;
+	stale_at: Date | string;
+	expires_at: Date | string;
+	version: number;
+	source_job_id: string | null;
+}
+
+const iso = (value: Date | string): string =>
+	value instanceof Date ? value.toISOString() : value;
+
+const jobFromRow = (row: BridgeJobRow): BridgeJobRecord => ({
+	operationId: row.operation_id,
+	kind: row.kind,
+	status: row.status,
+	command: row.command,
+	idempotencyKey: row.idempotency_key ?? undefined,
+	attempts: row.attempts,
+	createdAt: iso(row.created_at),
+	updatedAt: iso(row.updated_at),
+	leasedBy: row.leased_by ?? undefined,
+	leasedUntil: row.leased_until ? iso(row.leased_until) : undefined,
+	result: row.result ?? undefined,
+	failure: row.failure ?? undefined,
+});
+
+const snapshotFromRow = (row: AvailabilitySnapshotRow): AvailabilitySnapshot => ({
+	snapshotId: row.snapshot_id,
+	kind: row.kind,
+	serviceId: row.service_id,
+	scope: row.scope,
+	adapterProfile: row.adapter_profile,
+	value: row.value,
+	observedAt: iso(row.observed_at),
+	staleAt: iso(row.stale_at),
+	expiresAt: iso(row.expires_at),
+	version: row.version,
+	sourceJobId: row.source_job_id ?? undefined,
+});
+
+export interface PostgresBridgeAsyncStoreOptions {
+	readonly connectionString: string;
+	readonly ssl?: boolean | pg.PoolConfig['ssl'];
+	readonly migrate?: boolean;
+}
+
+export const ensureBridgeAsyncSchema = async (
+	pool: pg.Pool,
+): Promise<void> => {
+	await pool.query(BRIDGE_ASYNC_SCHEMA_SQL);
+};
+
+export const createPostgresBridgeAsyncStore = (
+	options: PostgresBridgeAsyncStoreOptions,
+): BridgeAsyncStore & { close: () => Promise<void>; ready: () => Promise<void> } => {
+	const pool = new Pool({
+		connectionString: options.connectionString,
+		ssl: options.ssl,
+	});
+	const ready = options.migrate === false
+		? Promise.resolve()
+		: ensureBridgeAsyncSchema(pool);
+	const query = async <T extends QueryResultRow = QueryResultRow>(
+		text: string,
+		values?: unknown[],
+	) => {
+		await ready;
+		return pool.query<T>(text, values);
+	};
+
+	return {
+		async enqueueJob(job: BridgeJobCommand, options?: EnqueueBridgeJobOptions) {
+			const operationId = randomUUID();
+			const inserted = await query<BridgeJobRow>(
+				`
+				insert into bridge_jobs (
+					operation_id,
+					kind,
+					status,
+					command,
+					idempotency_key
+				)
+				values ($1, $2, 'queued', $3::jsonb, $4)
+				on conflict (idempotency_key)
+				do update set updated_at = bridge_jobs.updated_at
+				returning *
+				`,
+				[
+					operationId,
+					job.kind,
+					JSON.stringify(job.command),
+					options?.idempotencyKey ?? null,
+				],
+			);
+			return jobFromRow(inserted.rows[0]!);
+		},
+
+		async getJob(operationId) {
+			const found = await query<BridgeJobRow>(
+				'select * from bridge_jobs where operation_id = $1',
+				[operationId],
+			);
+			return found.rows[0] ? jobFromRow(found.rows[0]) : null;
+		},
+
+		async listReadyJobs(limit, now = new Date()) {
+			const found = await query<BridgeJobRow>(
+				`
+				select *
+				from bridge_jobs
+				where status = 'queued'
+				   or (status in ('leased', 'running') and leased_until <= $1)
+				order by created_at asc
+				limit $2
+				`,
+				[now, limit],
+			);
+			return found.rows.map(jobFromRow);
+		},
+
+		async markJobRunning(operationId, lease) {
+			const updated = await query<BridgeJobRow>(
+				`
+				update bridge_jobs
+				set status = 'running',
+				    attempts = attempts + 1,
+				    leased_by = $2,
+				    leased_until = $3,
+				    updated_at = now()
+				where operation_id = $1
+				  and status in ('queued', 'leased', 'running')
+				returning *
+				`,
+				[operationId, lease.workerId, lease.leasedUntil],
+			);
+			return updated.rows[0] ? jobFromRow(updated.rows[0]) : null;
+		},
+
+		async completeJob(operationId, result) {
+			const updated = await query<BridgeJobRow>(
+				`
+				update bridge_jobs
+				set status = 'succeeded',
+				    result = $2::jsonb,
+				    failure = null,
+				    updated_at = now()
+				where operation_id = $1
+				returning *
+				`,
+				[operationId, JSON.stringify(result)],
+			);
+			return updated.rows[0] ? jobFromRow(updated.rows[0]) : null;
+		},
+
+		async failJob(operationId, failure) {
+			const updated = await query<BridgeJobRow>(
+				`
+				update bridge_jobs
+				set status = $2,
+				    failure = $3::jsonb,
+				    updated_at = now()
+				where operation_id = $1
+				returning *
+				`,
+				[operationId, failure.status, JSON.stringify(failure)],
+			);
+			return updated.rows[0] ? jobFromRow(updated.rows[0]) : null;
+		},
+
+		async requeueJob(operationId, failure) {
+			const updated = await query<BridgeJobRow>(
+				`
+				update bridge_jobs
+				set status = 'queued',
+				    failure = coalesce($2::jsonb, failure),
+				    leased_by = null,
+				    leased_until = null,
+				    updated_at = now()
+				where operation_id = $1
+				returning *
+				`,
+				[
+					operationId,
+					failure ? JSON.stringify(failure) : null,
+				],
+			);
+			return updated.rows[0] ? jobFromRow(updated.rows[0]) : null;
+		},
+
+		async upsertAvailabilitySnapshot(snapshot) {
+			const inserted = await query<AvailabilitySnapshotRow>(
+				`
+				insert into bridge_availability_snapshots (
+					snapshot_id,
+					kind,
+					service_id,
+					scope,
+					base_url,
+					adapter_profile,
+					value,
+					observed_at,
+					stale_at,
+					expires_at,
+					source_job_id
+				)
+				values ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9, $10, $11)
+				on conflict (kind, service_id, scope, base_url)
+				do update set
+					adapter_profile = excluded.adapter_profile,
+					value = excluded.value,
+					observed_at = excluded.observed_at,
+					stale_at = excluded.stale_at,
+					expires_at = excluded.expires_at,
+					source_job_id = excluded.source_job_id,
+					version = bridge_availability_snapshots.version + 1,
+					updated_at = now()
+				returning *
+				`,
+				[
+					randomUUID(),
+					snapshot.kind,
+					snapshot.serviceId,
+					snapshot.scope,
+					snapshot.adapterProfile.baseUrl,
+					JSON.stringify(snapshot.adapterProfile),
+					JSON.stringify(snapshot.value),
+					snapshot.observedAt,
+					snapshot.staleAt,
+					snapshot.expiresAt,
+					snapshot.sourceJobId ?? null,
+				],
+			);
+			return snapshotFromRow(inserted.rows[0]!);
+		},
+
+		async getAvailabilitySnapshot(snapshotQuery: AvailabilitySnapshotQuery) {
+			const found = await query<AvailabilitySnapshotRow>(
+				`
+				select *
+				from bridge_availability_snapshots
+				where kind = $1
+				  and service_id = $2
+				  and scope = $3
+				  and base_url = $4
+				`,
+				[
+					snapshotQuery.kind,
+					snapshotQuery.serviceId,
+					snapshotQuery.scope,
+					snapshotQuery.baseUrl,
+				],
+			);
+			return found.rows[0] ? snapshotFromRow(found.rows[0]) : null;
+		},
+
+		async close() {
+			await pool.end();
+		},
+
+		async ready() {
+			await ready;
+		},
+	};
+};

--- a/src/async/store.test.ts
+++ b/src/async/store.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { createInMemoryBridgeAsyncStore } from './store.js';
+import type { BridgeJobCommand } from './types.js';
+
+const profile = {
+	backend: 'acuity' as const,
+	baseUrl: 'https://example.as.me',
+};
+
+const datesJob: BridgeJobCommand = {
+	kind: 'availability_dates_refresh',
+	command: {
+		serviceId: '53178494',
+		month: '2026-06',
+		adapterProfile: profile,
+	},
+};
+
+describe('BridgeAsyncStore in-memory contract', () => {
+	it('deduplicates enqueue by idempotency key', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+
+		const first = await store.enqueueJob(datesJob, {
+			idempotencyKey: 'dates:53178494:2026-06',
+		});
+		const second = await store.enqueueJob(datesJob, {
+			idempotencyKey: 'dates:53178494:2026-06',
+		});
+
+		expect(second.operationId).toBe(first.operationId);
+		expect(second.status).toBe('queued');
+	});
+
+	it('returns expired leased jobs as ready work', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		const job = await store.enqueueJob(datesJob);
+		await store.markJobRunning(job.operationId, {
+			workerId: 'worker-a',
+			leasedUntil: new Date('2026-05-08T12:00:00.000Z'),
+		});
+
+		const notReady = await store.listReadyJobs(10, new Date('2026-05-08T11:59:00.000Z'));
+		const ready = await store.listReadyJobs(10, new Date('2026-05-08T12:00:01.000Z'));
+
+		expect(notReady).toHaveLength(0);
+		expect(ready).toHaveLength(1);
+		expect(ready[0]?.operationId).toBe(job.operationId);
+	});
+
+	it('versions availability snapshots per service and scope', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+
+		const first = await store.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: '53178494',
+			scope: '2026-06',
+			adapterProfile: profile,
+			value: [{ date: '2026-06-15' }],
+			observedAt: '2026-05-08T12:00:00.000Z',
+			staleAt: '2026-05-08T12:05:00.000Z',
+			expiresAt: '2026-05-08T12:30:00.000Z',
+		});
+		const second = await store.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: '53178494',
+			scope: '2026-06',
+			adapterProfile: profile,
+			value: [{ date: '2026-06-16' }],
+			observedAt: '2026-05-08T12:01:00.000Z',
+			staleAt: '2026-05-08T12:06:00.000Z',
+			expiresAt: '2026-05-08T12:31:00.000Z',
+		});
+
+		expect(second.snapshotId).toBe(first.snapshotId);
+		expect(second.version).toBe(2);
+		await expect(store.getAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: '53178494',
+			scope: '2026-06',
+			baseUrl: profile.baseUrl,
+		})).resolves.toMatchObject({
+			version: 2,
+			value: [{ date: '2026-06-16' }],
+		});
+	});
+});

--- a/src/async/store.ts
+++ b/src/async/store.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from 'node:crypto';
+import type {
+	AvailabilitySnapshot,
+	AvailabilitySnapshotQuery,
+	BridgeJobCommand,
+	BridgeJobFailure,
+	BridgeJobRecord,
+	BridgeJobResult,
+	EnqueueBridgeJobOptions,
+} from './types.js';
+
+export interface BridgeAsyncStore {
+	enqueueJob(
+		job: BridgeJobCommand,
+		options?: EnqueueBridgeJobOptions,
+	): Promise<BridgeJobRecord>;
+	getJob(operationId: string): Promise<BridgeJobRecord | null>;
+	listReadyJobs(limit: number, now?: Date): Promise<readonly BridgeJobRecord[]>;
+	markJobRunning(
+		operationId: string,
+		lease: { workerId: string; leasedUntil: Date },
+	): Promise<BridgeJobRecord | null>;
+	completeJob(
+		operationId: string,
+		result: BridgeJobResult,
+	): Promise<BridgeJobRecord | null>;
+	failJob(
+		operationId: string,
+		failure: BridgeJobFailure,
+	): Promise<BridgeJobRecord | null>;
+	requeueJob(
+		operationId: string,
+		failure?: BridgeJobFailure,
+	): Promise<BridgeJobRecord | null>;
+	upsertAvailabilitySnapshot(
+		snapshot: Omit<AvailabilitySnapshot, 'snapshotId' | 'version'>,
+	): Promise<AvailabilitySnapshot>;
+	getAvailabilitySnapshot(
+		query: AvailabilitySnapshotQuery,
+	): Promise<AvailabilitySnapshot | null>;
+	clear?(): Promise<void>;
+}
+
+const snapshotKey = (query: AvailabilitySnapshotQuery): string =>
+	[
+		query.baseUrl,
+		query.kind,
+		query.serviceId,
+		query.scope,
+	].join('::');
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const nowIso = (now = new Date()): string => now.toISOString();
+
+export const createInMemoryBridgeAsyncStore = (): BridgeAsyncStore => {
+	const jobs = new Map<string, BridgeJobRecord>();
+	const idempotencyKeys = new Map<string, string>();
+	const snapshots = new Map<string, AvailabilitySnapshot>();
+
+	const getByOperationId = (operationId: string): BridgeJobRecord | null => {
+		const found = jobs.get(operationId);
+		return found ? clone(found) : null;
+	};
+
+	return {
+		async enqueueJob(job, options) {
+			const idempotencyKey = options?.idempotencyKey;
+			if (idempotencyKey) {
+				const existingOperationId = idempotencyKeys.get(idempotencyKey);
+				if (existingOperationId) {
+					const existing = getByOperationId(existingOperationId);
+					if (existing) return existing;
+				}
+			}
+
+			const operationId = randomUUID();
+			const timestamp = nowIso();
+			const record: BridgeJobRecord = {
+				operationId,
+				kind: job.kind,
+				status: 'queued',
+				command: clone(job.command),
+				idempotencyKey,
+				attempts: 0,
+				createdAt: timestamp,
+				updatedAt: timestamp,
+			};
+			jobs.set(operationId, record);
+			if (idempotencyKey) idempotencyKeys.set(idempotencyKey, operationId);
+			return clone(record);
+		},
+
+		async getJob(operationId) {
+			return getByOperationId(operationId);
+		},
+
+		async listReadyJobs(limit, now = new Date()) {
+			const cutoff = now.getTime();
+			return [...jobs.values()]
+				.filter((job) => {
+					if (job.status === 'queued') return true;
+					if (
+						(job.status !== 'leased' && job.status !== 'running') ||
+						!job.leasedUntil
+					) {
+						return false;
+					}
+					return Date.parse(job.leasedUntil) <= cutoff;
+				})
+				.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+				.slice(0, limit)
+				.map(clone);
+		},
+
+		async markJobRunning(operationId, lease) {
+			const found = jobs.get(operationId);
+			if (!found) return null;
+			const next: BridgeJobRecord = {
+				...found,
+				status: 'running',
+				attempts: found.attempts + 1,
+				leasedBy: lease.workerId,
+				leasedUntil: lease.leasedUntil.toISOString(),
+				updatedAt: nowIso(),
+			};
+			jobs.set(operationId, next);
+			return clone(next);
+		},
+
+		async completeJob(operationId, result) {
+			const found = jobs.get(operationId);
+			if (!found) return null;
+			const next: BridgeJobRecord = {
+				...found,
+				status: 'succeeded',
+				result: clone(result),
+				failure: undefined,
+				updatedAt: nowIso(),
+			};
+			jobs.set(operationId, next);
+			return clone(next);
+		},
+
+		async failJob(operationId, failure) {
+			const found = jobs.get(operationId);
+			if (!found) return null;
+			const next: BridgeJobRecord = {
+				...found,
+				status: failure.status,
+				failure: clone(failure),
+				updatedAt: nowIso(),
+			};
+			jobs.set(operationId, next);
+			return clone(next);
+		},
+
+		async requeueJob(operationId, failure) {
+			const found = jobs.get(operationId);
+			if (!found) return null;
+			const next: BridgeJobRecord = {
+				...found,
+				status: 'queued',
+				failure: failure ? clone(failure) : found.failure,
+				leasedBy: undefined,
+				leasedUntil: undefined,
+				updatedAt: nowIso(),
+			};
+			jobs.set(operationId, next);
+			return clone(next);
+		},
+
+		async upsertAvailabilitySnapshot(snapshot) {
+			const key = snapshotKey({
+				kind: snapshot.kind,
+				serviceId: snapshot.serviceId,
+				scope: snapshot.scope,
+				baseUrl: snapshot.adapterProfile.baseUrl,
+			});
+			const previous = snapshots.get(key);
+			const next: AvailabilitySnapshot = {
+				...clone(snapshot),
+				snapshotId: previous?.snapshotId ?? randomUUID(),
+				version: (previous?.version ?? 0) + 1,
+			};
+			snapshots.set(key, next);
+			return clone(next);
+		},
+
+		async getAvailabilitySnapshot(query) {
+			const found = snapshots.get(snapshotKey(query));
+			return found ? clone(found) : null;
+		},
+
+		async clear() {
+			jobs.clear();
+			idempotencyKeys.clear();
+			snapshots.clear();
+		},
+	};
+};

--- a/src/async/types.ts
+++ b/src/async/types.ts
@@ -1,0 +1,164 @@
+import type {
+	AvailableDate,
+	Booking,
+	BookingRequest,
+	TimeSlot,
+} from '../core/types.js';
+
+export type BridgeJobKind =
+	| 'availability_dates_refresh'
+	| 'availability_slots_refresh'
+	| 'booking_create_with_payment';
+
+export type BridgeJobStatus =
+	| 'queued'
+	| 'leased'
+	| 'running'
+	| 'succeeded'
+	| 'failed_pre_submit'
+	| 'reconcile_required'
+	| 'cancelled';
+
+export type AvailabilitySnapshotKind = 'dates' | 'slots';
+export type BookingExecutionPreference = 'auto' | 'browser' | 'rest';
+export type BookingExecutionPath = 'browser' | 'rest';
+
+export const DEFAULT_BOOKING_SNAPSHOT_FRESHNESS_FLOOR_MS = 90_000;
+export const DEFAULT_ON_DEMAND_REFRESH_WAIT_MS = 10_000;
+
+export interface BridgeAdapterProfile {
+	readonly backend: 'acuity';
+	readonly baseUrl: string;
+	readonly selectorProfile?: string;
+	readonly adminApiConfigured?: boolean;
+}
+
+export interface AppointmentCommand {
+	readonly request: BookingRequest;
+	readonly paymentRef: string;
+	readonly paymentProcessor: string;
+	readonly couponCode?: string;
+	readonly serviceName?: string;
+	readonly adapterProfile: BridgeAdapterProfile;
+	readonly couponBypassRequired: boolean;
+	readonly executionPreference: BookingExecutionPreference;
+	readonly snapshotFreshnessFloorMs?: number;
+	readonly onDemandRefreshWaitMs?: number;
+}
+
+export interface AvailabilityDatesRefreshCommand {
+	readonly serviceId: string;
+	readonly serviceName?: string;
+	readonly month: string;
+	readonly adapterProfile: BridgeAdapterProfile;
+}
+
+export interface AvailabilitySlotsRefreshCommand {
+	readonly serviceId: string;
+	readonly serviceName?: string;
+	readonly date: string;
+	readonly adapterProfile: BridgeAdapterProfile;
+}
+
+export type BridgeJobCommand =
+	| {
+			readonly kind: 'availability_dates_refresh';
+			readonly command: AvailabilityDatesRefreshCommand;
+	  }
+	| {
+			readonly kind: 'availability_slots_refresh';
+			readonly command: AvailabilitySlotsRefreshCommand;
+	  }
+	| {
+			readonly kind: 'booking_create_with_payment';
+			readonly command: AppointmentCommand;
+	  };
+
+export interface BridgeJobFailure {
+	readonly status: Exclude<
+		BridgeJobStatus,
+		'queued' | 'leased' | 'running' | 'succeeded' | 'cancelled'
+	>;
+	readonly code: string;
+	readonly message: string;
+	readonly step?: string;
+	readonly retryable: boolean;
+	readonly artifactRefs?: readonly string[];
+}
+
+export type BridgeJobResult =
+	| {
+			readonly kind: 'availability_dates_refresh';
+			readonly dates: readonly AvailableDate[];
+	  }
+	| {
+			readonly kind: 'availability_slots_refresh';
+			readonly slots: readonly TimeSlot[];
+	  }
+	| {
+			readonly kind: 'booking_create_with_payment';
+			readonly booking: Booking;
+	  };
+
+export interface BridgeJobRecord {
+	readonly operationId: string;
+	readonly kind: BridgeJobKind;
+	readonly status: BridgeJobStatus;
+	readonly command: BridgeJobCommand['command'];
+	readonly idempotencyKey?: string;
+	readonly attempts: number;
+	readonly createdAt: string;
+	readonly updatedAt: string;
+	readonly leasedBy?: string;
+	readonly leasedUntil?: string;
+	readonly result?: BridgeJobResult;
+	readonly failure?: BridgeJobFailure;
+}
+
+export interface AvailabilitySnapshot {
+	readonly snapshotId: string;
+	readonly kind: AvailabilitySnapshotKind;
+	readonly serviceId: string;
+	readonly scope: string;
+	readonly adapterProfile: BridgeAdapterProfile;
+	readonly value: readonly AvailableDate[] | readonly TimeSlot[];
+	readonly observedAt: string;
+	readonly staleAt: string;
+	readonly expiresAt: string;
+	readonly version: number;
+	readonly sourceJobId?: string;
+}
+
+export interface AvailabilitySnapshotQuery {
+	readonly kind: AvailabilitySnapshotKind;
+	readonly serviceId: string;
+	readonly scope: string;
+	readonly baseUrl: string;
+}
+
+export interface EnqueueBridgeJobOptions {
+	readonly idempotencyKey?: string;
+}
+
+export interface EnqueueBookingJobRequest {
+	readonly request: BookingRequest;
+	readonly paymentRef: string;
+	readonly paymentProcessor: string;
+	readonly couponCode?: string;
+	readonly idempotencyKey?: string;
+}
+
+export interface EnqueueAvailabilityRefreshRequest {
+	readonly kind: AvailabilitySnapshotKind;
+	readonly serviceId: string;
+	readonly serviceName?: string;
+	readonly month?: string;
+	readonly date?: string;
+	readonly idempotencyKey?: string;
+}
+
+export interface EnqueueBridgeJobResponse {
+	readonly operationId: string;
+	readonly status: BridgeJobStatus;
+	readonly statusUrl: string;
+}

--- a/src/async/worker.test.ts
+++ b/src/async/worker.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createInMemoryBridgeAsyncStore } from './store.js';
+import {
+	BridgeJobExecutionError,
+	drainReadyBridgeJobs,
+	executeBridgeJob,
+	selectBookingExecutionPath,
+	type BridgeJobExecutor,
+} from './worker.js';
+import type { BridgeJobCommand } from './types.js';
+
+const profile = {
+	backend: 'acuity' as const,
+	baseUrl: 'https://example.as.me',
+};
+
+const executor = (): BridgeJobExecutor => ({
+	refreshAvailabilityDates: vi.fn(async () => [{ date: '2026-06-15' }]),
+	refreshAvailabilitySlots: vi.fn(async () => [{
+		datetime: '2026-06-15T16:00:00.000Z',
+		available: true,
+	}]),
+	createBookingWithPayment: vi.fn(async (command, _context) => ({
+		id: 'apt_123',
+		serviceId: command.request.serviceId,
+		serviceName: command.serviceName ?? command.request.serviceId,
+		datetime: command.request.datetime,
+		duration: 30,
+		price: 10500,
+		currency: 'USD',
+		client: command.request.client,
+		status: 'confirmed',
+		confirmationCode: 'confirm_123',
+		paymentStatus: 'paid',
+		paymentRef: command.paymentRef,
+		createdAt: '2026-05-08T12:00:00.000Z',
+	})),
+});
+
+describe('Bridge async worker', () => {
+	it('executes refresh jobs into versioned availability snapshots', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		const job = await store.enqueueJob({
+			kind: 'availability_dates_refresh',
+			command: {
+				serviceId: '53178494',
+				month: '2026-06',
+				adapterProfile: profile,
+			},
+		});
+
+		const result = await executeBridgeJob(store, job, executor(), {
+			workerId: 'worker-a',
+			now: new Date('2026-05-08T12:00:00.000Z'),
+		});
+
+		expect(result).toMatchObject({
+			operationId: job.operationId,
+			status: 'succeeded',
+			result: {
+				kind: 'availability_dates_refresh',
+				dates: [{ date: '2026-06-15' }],
+			},
+		});
+		await expect(store.getAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: '53178494',
+			scope: '2026-06',
+			baseUrl: profile.baseUrl,
+		})).resolves.toMatchObject({
+			sourceJobId: job.operationId,
+			value: [{ date: '2026-06-15' }],
+		});
+	});
+
+	it('marks post-submit booking failures as reconcile-required instead of pre-submit failures', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		const job = await store.enqueueJob({
+			kind: 'booking_create_with_payment',
+			command: {
+				request: {
+					serviceId: '53178494',
+					datetime: '2026-06-15T16:00:00.000Z',
+					client: {
+						firstName: 'Jess',
+						lastName: 'Sullivan',
+						email: 'jess@example.com',
+						phone: '6075551212',
+					},
+				},
+				paymentRef: 'pi_test_123',
+				paymentProcessor: 'stripe',
+				couponCode: 'TEST-100',
+				serviceName: 'TMD single session',
+				adapterProfile: profile,
+				couponBypassRequired: true,
+				executionPreference: 'auto',
+			},
+		} satisfies BridgeJobCommand);
+		const failingExecutor = executor();
+		vi.mocked(failingExecutor.createBookingWithPayment).mockRejectedValueOnce(
+			new BridgeJobExecutionError({
+				status: 'reconcile_required',
+				code: 'SUBMIT_TIMEOUT',
+				message: 'Timed out after submit click',
+				step: 'submit',
+				retryable: false,
+				artifactRefs: ['artifact://trace/123'],
+			}),
+		);
+
+		const result = await executeBridgeJob(store, job, failingExecutor, {
+			workerId: 'worker-a',
+		});
+
+		expect(result).toMatchObject({
+			status: 'reconcile_required',
+			failure: {
+				status: 'reconcile_required',
+				code: 'SUBMIT_TIMEOUT',
+				step: 'submit',
+				retryable: false,
+				artifactRefs: ['artifact://trace/123'],
+			},
+		});
+	});
+
+	it('drains ready jobs in created order', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		await store.enqueueJob({
+			kind: 'availability_dates_refresh',
+			command: {
+				serviceId: '53178494',
+				month: '2026-06',
+				adapterProfile: profile,
+			},
+		});
+		await store.enqueueJob({
+			kind: 'availability_slots_refresh',
+			command: {
+				serviceId: '53178494',
+				date: '2026-06-15',
+				adapterProfile: profile,
+			},
+		});
+
+		const results = await drainReadyBridgeJobs(store, executor(), {
+			workerId: 'worker-a',
+			limit: 10,
+		});
+
+		expect(results.map((job) => job.kind)).toEqual([
+			'availability_dates_refresh',
+			'availability_slots_refresh',
+		]);
+		expect(results.every((job) => job.status === 'succeeded')).toBe(true);
+	});
+
+	it('requeues booking jobs when a fresh slot snapshot cannot be produced within the blocking window', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		const job = await store.enqueueJob({
+			kind: 'booking_create_with_payment',
+			command: {
+				request: {
+					serviceId: '53178494',
+					datetime: '2026-06-15T16:00:00.000Z',
+					client: {
+						firstName: 'Jess',
+						lastName: 'Sullivan',
+						email: 'jess@example.com',
+						phone: '6075551212',
+					},
+				},
+				paymentRef: 'pi_test_123',
+				paymentProcessor: 'stripe',
+				couponCode: 'TEST-100',
+				serviceName: 'TMD single session',
+				adapterProfile: profile,
+				couponBypassRequired: true,
+				executionPreference: 'auto',
+				onDemandRefreshWaitMs: 1,
+			},
+		} satisfies BridgeJobCommand);
+		const slowExecutor = executor();
+		vi.mocked(slowExecutor.refreshAvailabilitySlots).mockReturnValueOnce(
+			new Promise(() => undefined),
+		);
+
+		const result = await executeBridgeJob(store, job, slowExecutor, {
+			workerId: 'worker-a',
+		});
+
+		expect(result).toMatchObject({
+			status: 'queued',
+			failure: {
+				code: 'SNAPSHOT_REFRESH_TIMEOUT',
+				retryable: true,
+			},
+		});
+		expect(slowExecutor.createBookingWithPayment).not.toHaveBeenCalled();
+	});
+
+	it('selects REST only when tenant admin API is configured and coupon bypass is not required', () => {
+		const baseCommand = {
+			request: {
+				serviceId: '53178494',
+				datetime: '2026-06-15T16:00:00.000Z',
+				client: {
+					firstName: 'Jess',
+					lastName: 'Sullivan',
+					email: 'jess@example.com',
+					phone: '6075551212',
+				},
+			},
+			paymentRef: 'pi_test_123',
+			paymentProcessor: 'stripe',
+			couponCode: 'TEST-100',
+			serviceName: 'TMD single session',
+			adapterProfile: profile,
+			couponBypassRequired: false,
+			executionPreference: 'auto' as const,
+		};
+
+		expect(selectBookingExecutionPath({
+			...baseCommand,
+			adapterProfile: { ...profile, adminApiConfigured: true },
+		})).toBe('rest');
+		expect(selectBookingExecutionPath({
+			...baseCommand,
+			adapterProfile: { ...profile, adminApiConfigured: true },
+			couponBypassRequired: true,
+		})).toBe('browser');
+		expect(selectBookingExecutionPath({
+			...baseCommand,
+			adapterProfile: profile,
+		})).toBe('browser');
+	});
+});

--- a/src/async/worker.ts
+++ b/src/async/worker.ts
@@ -1,0 +1,300 @@
+import {
+	DEFAULT_BOOKING_SNAPSHOT_FRESHNESS_FLOOR_MS,
+	DEFAULT_ON_DEMAND_REFRESH_WAIT_MS,
+} from './types.js';
+import type {
+	AppointmentCommand,
+	AvailabilityDatesRefreshCommand,
+	AvailabilitySlotsRefreshCommand,
+	BookingExecutionPath,
+	BridgeJobFailure,
+	BridgeJobRecord,
+	BridgeJobStatus,
+} from './types.js';
+import type { BridgeAsyncStore } from './store.js';
+import type { AvailableDate, Booking, TimeSlot } from '../core/types.js';
+
+export class BridgeJobExecutionError extends Error {
+	readonly status: Extract<BridgeJobStatus, 'failed_pre_submit' | 'reconcile_required'>;
+	readonly code: string;
+	readonly step?: string;
+	readonly retryable: boolean;
+	readonly artifactRefs?: readonly string[];
+
+	constructor(options: {
+		status?: Extract<BridgeJobStatus, 'failed_pre_submit' | 'reconcile_required'>;
+		code: string;
+		message: string;
+		step?: string;
+		retryable?: boolean;
+		artifactRefs?: readonly string[];
+	}) {
+		super(options.message);
+		this.name = 'BridgeJobExecutionError';
+		this.status = options.status ?? 'failed_pre_submit';
+		this.code = options.code;
+		this.step = options.step;
+		this.retryable = options.retryable ?? false;
+		this.artifactRefs = options.artifactRefs;
+	}
+}
+
+export interface BridgeJobExecutor {
+	refreshAvailabilityDates(
+		command: AvailabilityDatesRefreshCommand,
+	): Promise<readonly AvailableDate[]>;
+	refreshAvailabilitySlots(
+		command: AvailabilitySlotsRefreshCommand,
+	): Promise<readonly TimeSlot[]>;
+	createBookingWithPayment(
+		command: AppointmentCommand,
+		context: { executionPath: BookingExecutionPath },
+	): Promise<Booking>;
+}
+
+export interface ExecuteBridgeJobOptions {
+	readonly workerId: string;
+	readonly leaseMs?: number;
+	readonly now?: Date;
+}
+
+const dateFromAppointmentDateTime = (datetime: string): string => datetime.slice(0, 10);
+
+const isSnapshotFresh = (
+	observedAt: string,
+	now: Date,
+	freshnessFloorMs: number,
+): boolean => {
+	const observedMs = Date.parse(observedAt);
+	if (!Number.isFinite(observedMs)) return false;
+	return now.getTime() - observedMs <= freshnessFloorMs;
+};
+
+const withTimeout = async <A>(
+	promise: Promise<A>,
+	timeoutMs: number,
+): Promise<A | null> => {
+	let timeout: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<null>((resolve) => {
+				timeout = setTimeout(() => resolve(null), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+};
+
+export const selectBookingExecutionPath = (
+	command: AppointmentCommand,
+): BookingExecutionPath => {
+	if (
+		command.executionPreference === 'rest' &&
+		command.adapterProfile.adminApiConfigured &&
+		!command.couponBypassRequired
+	) {
+		return 'rest';
+	}
+	if (
+		command.executionPreference === 'auto' &&
+		command.adapterProfile.adminApiConfigured &&
+		!command.couponBypassRequired
+	) {
+		return 'rest';
+	}
+	return 'browser';
+};
+
+const snapshotTimestamps = (observedAt: Date) => ({
+	observedAt: observedAt.toISOString(),
+	staleAt: new Date(observedAt.getTime() + 5 * 60_000).toISOString(),
+	expiresAt: new Date(observedAt.getTime() + 30 * 60_000).toISOString(),
+});
+
+const failureFromUnknown = (error: unknown): BridgeJobFailure => {
+	if (error instanceof BridgeJobExecutionError) {
+		return {
+			status: error.status,
+			code: error.code,
+			message: error.message,
+			step: error.step,
+			retryable: error.retryable,
+			artifactRefs: error.artifactRefs,
+		};
+	}
+	if (
+		typeof error === 'object' &&
+		error !== null &&
+		'status' in error &&
+		'code' in error &&
+		'message' in error
+	) {
+		const bridgeError = error as {
+			status: BridgeJobFailure['status'];
+			code: string;
+			message: string;
+			step?: string;
+			retryable?: boolean;
+			artifactRefs?: readonly string[];
+		};
+		return {
+			status: bridgeError.status,
+			code: bridgeError.code,
+			message: bridgeError.message,
+			step: bridgeError.step,
+			retryable: bridgeError.retryable ?? false,
+			artifactRefs: bridgeError.artifactRefs,
+		};
+	}
+	return {
+		status: 'failed_pre_submit',
+		code: 'UNKNOWN',
+		message: error instanceof Error ? error.message : String(error),
+		retryable: true,
+	};
+};
+
+const ensureFreshSlotSnapshot = async (
+	store: BridgeAsyncStore,
+	record: BridgeJobRecord,
+	command: AppointmentCommand,
+	executor: BridgeJobExecutor,
+	now: Date,
+): Promise<BridgeJobRecord | null> => {
+	const date = dateFromAppointmentDateTime(command.request.datetime);
+	const freshnessFloorMs =
+		command.snapshotFreshnessFloorMs ?? DEFAULT_BOOKING_SNAPSHOT_FRESHNESS_FLOOR_MS;
+	const existing = await store.getAvailabilitySnapshot({
+		kind: 'slots',
+		serviceId: command.request.serviceId,
+		scope: date,
+		baseUrl: command.adapterProfile.baseUrl,
+	});
+	if (existing && isSnapshotFresh(existing.observedAt, now, freshnessFloorMs)) {
+		return null;
+	}
+
+	const refreshWaitMs =
+		command.onDemandRefreshWaitMs ?? DEFAULT_ON_DEMAND_REFRESH_WAIT_MS;
+	const refreshCommand: AvailabilitySlotsRefreshCommand = {
+		serviceId: command.request.serviceId,
+		serviceName: command.serviceName,
+		date,
+		adapterProfile: command.adapterProfile,
+	};
+	const slots = await withTimeout(
+		executor.refreshAvailabilitySlots(refreshCommand),
+		refreshWaitMs,
+	);
+	if (!slots) {
+		return store.requeueJob(record.operationId, {
+			status: 'failed_pre_submit',
+			code: 'SNAPSHOT_REFRESH_TIMEOUT',
+			message: `Timed out after ${refreshWaitMs}ms waiting for fresh slot snapshot`,
+			step: 'availability-refresh',
+			retryable: true,
+		});
+	}
+	await store.upsertAvailabilitySnapshot({
+		kind: 'slots',
+		serviceId: command.request.serviceId,
+		scope: date,
+		adapterProfile: command.adapterProfile,
+		value: slots,
+		sourceJobId: record.operationId,
+		...snapshotTimestamps(new Date()),
+	});
+	return null;
+};
+
+export const executeBridgeJob = async (
+	store: BridgeAsyncStore,
+	record: BridgeJobRecord,
+	executor: BridgeJobExecutor,
+	options: ExecuteBridgeJobOptions,
+): Promise<BridgeJobRecord | null> => {
+	const startedAt = options.now ?? new Date();
+	const leaseMs = options.leaseMs ?? 5 * 60_000;
+	const running = await store.markJobRunning(record.operationId, {
+		workerId: options.workerId,
+		leasedUntil: new Date(startedAt.getTime() + leaseMs),
+	});
+	if (!running) return null;
+
+	try {
+		if (record.kind === 'availability_dates_refresh') {
+			const command = record.command as AvailabilityDatesRefreshCommand;
+			const dates = await executor.refreshAvailabilityDates(command);
+			await store.upsertAvailabilitySnapshot({
+				kind: 'dates',
+				serviceId: command.serviceId,
+				scope: command.month,
+				adapterProfile: command.adapterProfile,
+				value: dates,
+				sourceJobId: record.operationId,
+				...snapshotTimestamps(new Date()),
+			});
+			return store.completeJob(record.operationId, {
+				kind: 'availability_dates_refresh',
+				dates,
+			});
+		}
+
+		if (record.kind === 'availability_slots_refresh') {
+			const command = record.command as AvailabilitySlotsRefreshCommand;
+			const slots = await executor.refreshAvailabilitySlots(command);
+			await store.upsertAvailabilitySnapshot({
+				kind: 'slots',
+				serviceId: command.serviceId,
+				scope: command.date,
+				adapterProfile: command.adapterProfile,
+				value: slots,
+				sourceJobId: record.operationId,
+				...snapshotTimestamps(new Date()),
+			});
+			return store.completeJob(record.operationId, {
+				kind: 'availability_slots_refresh',
+				slots,
+			});
+		}
+
+		const command = record.command as AppointmentCommand;
+		const requeued = await ensureFreshSlotSnapshot(
+			store,
+			record,
+			command,
+			executor,
+			startedAt,
+		);
+		if (requeued) return requeued;
+		const booking = await executor.createBookingWithPayment(command, {
+			executionPath: selectBookingExecutionPath(command),
+		});
+		return store.completeJob(record.operationId, {
+			kind: 'booking_create_with_payment',
+			booking,
+		});
+	} catch (error) {
+		return store.failJob(record.operationId, failureFromUnknown(error));
+	}
+};
+
+export interface DrainBridgeJobsOptions extends ExecuteBridgeJobOptions {
+	readonly limit?: number;
+}
+
+export const drainReadyBridgeJobs = async (
+	store: BridgeAsyncStore,
+	executor: BridgeJobExecutor,
+	options: DrainBridgeJobsOptions,
+): Promise<readonly BridgeJobRecord[]> => {
+	const ready = await store.listReadyJobs(options.limit ?? 10, options.now);
+	const completed: BridgeJobRecord[] = [];
+	for (const record of ready) {
+		const result = await executeBridgeJob(store, record, executor, options);
+		if (result) completed.push(result);
+	}
+	return completed;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,53 @@ export {
 	createRemoteWizardAdapter,
 	type RemoteAdapterConfig,
 } from './shared/remote-adapter.js';
+export {
+	createBridgeAsyncClient,
+	type BridgeAsyncClient,
+} from './shared/async-client.js';
+export {
+	createInMemoryBridgeAsyncStore,
+	type BridgeAsyncStore,
+} from './async/store.js';
+export {
+	BRIDGE_ASYNC_SCHEMA_SQL,
+	createPostgresBridgeAsyncStore,
+	ensureBridgeAsyncSchema,
+	type PostgresBridgeAsyncStoreOptions,
+} from './async/postgres-store.js';
+export {
+	BridgeJobExecutionError,
+	drainReadyBridgeJobs,
+	executeBridgeJob,
+	selectBookingExecutionPath,
+	type BridgeJobExecutor,
+	type DrainBridgeJobsOptions,
+	type ExecuteBridgeJobOptions,
+} from './async/worker.js';
+export {
+	DEFAULT_BOOKING_SNAPSHOT_FRESHNESS_FLOOR_MS,
+	DEFAULT_ON_DEMAND_REFRESH_WAIT_MS,
+} from './async/types.js';
+export type {
+	AppointmentCommand,
+	AvailabilityDatesRefreshCommand,
+	AvailabilitySlotsRefreshCommand,
+	AvailabilitySnapshot,
+	AvailabilitySnapshotKind,
+	AvailabilitySnapshotQuery,
+	BridgeAdapterProfile,
+	BookingExecutionPath,
+	BookingExecutionPreference,
+	BridgeJobCommand,
+	BridgeJobFailure,
+	BridgeJobKind,
+	BridgeJobRecord,
+	BridgeJobResult,
+	BridgeJobStatus,
+	EnqueueAvailabilityRefreshRequest,
+	EnqueueBookingJobRequest,
+	EnqueueBridgeJobResponse,
+} from './async/types.js';
 
 // Shared: browser service (Playwright lifecycle)
 export {
@@ -86,6 +133,11 @@ export {
 	BRIDGE_PROTOCOL_ENDPOINTS,
 	BRIDGE_PROTOCOL_CAPABILITIES,
 } from './server/health.js';
+export {
+	createAcuityBridgeJobExecutor,
+	createWorkerStore,
+	runBridgeWorkerLoop,
+} from './server/worker.js';
 
 // Payment capabilities extraction
 export { extractCapabilities } from './capabilities.js';

--- a/src/server/__tests__/async-endpoints.test.ts
+++ b/src/server/__tests__/async-endpoints.test.ts
@@ -1,0 +1,177 @@
+import { type AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createInMemoryBridgeAsyncStore } from '../../async/store.js';
+
+const service = {
+	id: '53178494',
+	name: 'TMD single session',
+	duration: 30,
+	price: 10500,
+	currency: 'USD',
+	category: 'TMD',
+	description: 'TMD appointment',
+};
+
+const bookingRequest = {
+	serviceId: service.id,
+	datetime: '2026-06-15T16:00:00.000Z',
+	client: {
+		firstName: 'Jess',
+		lastName: 'Sullivan',
+		email: 'jess@example.com',
+		phone: '6075551212',
+	},
+};
+
+const listen = async (store = createInMemoryBridgeAsyncStore()) => {
+	const {
+		server,
+		__setBridgeAsyncStoreForTest,
+	} = await import('../handler.js');
+	__setBridgeAsyncStoreForTest(store);
+	await new Promise<void>((resolve) => {
+		server.listen(0, '127.0.0.1', resolve);
+	});
+	const address = server.address() as AddressInfo;
+	return {
+		server,
+		store,
+		baseUrl: `http://127.0.0.1:${address.port}`,
+	};
+};
+
+describe('bridge async protocol endpoints', () => {
+	let activeServer: Awaited<ReturnType<typeof listen>>['server'] | null = null;
+
+	beforeEach(() => {
+		vi.resetModules();
+		process.env.ACUITY_BASE_URL = 'https://example.as.me';
+		process.env.SERVICES_JSON = JSON.stringify([service]);
+		process.env.ACUITY_BYPASS_COUPON = 'TEST-100';
+		delete process.env.REDIS_URL;
+		delete process.env.AUTH_TOKEN;
+	});
+
+	afterEach(async () => {
+		if (activeServer?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				activeServer!.close((error) => (error ? reject(error) : resolve()));
+			});
+		}
+		activeServer = null;
+		delete process.env.ACUITY_BASE_URL;
+		delete process.env.SERVICES_JSON;
+		delete process.env.ACUITY_BYPASS_COUPON;
+	});
+
+	it('enqueues paid booking commands without running browser automation in the request', async () => {
+		const running = await listen();
+		activeServer = running.server;
+
+		const response = await fetch(`${running.baseUrl}/booking/jobs`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				request: bookingRequest,
+				paymentRef: 'pi_test_123',
+				paymentProcessor: 'stripe',
+				idempotencyKey: 'booking:pi_test_123',
+			}),
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(202);
+		expect(body).toMatchObject({
+			success: true,
+			data: {
+				status: 'queued',
+				statusUrl: expect.stringMatching(/^\/jobs\//),
+			},
+		});
+
+		const operationId = body.data.operationId as string;
+		const statusResponse = await fetch(`${running.baseUrl}/jobs/${operationId}`);
+		const statusBody = await statusResponse.json();
+
+		expect(statusResponse.status).toBe(200);
+		expect(statusBody).toMatchObject({
+			success: true,
+			data: {
+				operationId,
+				kind: 'booking_create_with_payment',
+				status: 'queued',
+				command: {
+					paymentRef: 'pi_test_123',
+					paymentProcessor: 'stripe',
+					couponCode: 'TEST-100',
+					serviceName: service.name,
+					couponBypassRequired: true,
+					executionPreference: 'auto',
+					adapterProfile: {
+						backend: 'acuity',
+						baseUrl: 'https://example.as.me',
+					},
+				},
+			},
+		});
+	});
+
+	it('deduplicates async booking enqueue by idempotency key', async () => {
+		const running = await listen();
+		activeServer = running.server;
+		const payload = {
+			request: bookingRequest,
+			paymentRef: 'pi_test_123',
+			paymentProcessor: 'stripe',
+			idempotencyKey: 'booking:pi_test_123',
+		};
+
+		const first = await fetch(`${running.baseUrl}/booking/jobs`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(payload),
+		}).then((response) => response.json());
+		const second = await fetch(`${running.baseUrl}/booking/jobs`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(payload),
+		}).then((response) => response.json());
+
+		expect(second.data.operationId).toBe(first.data.operationId);
+	});
+
+	it('returns stored availability snapshots without scraping on the request path', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		await store.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: service.id,
+			scope: '2026-06',
+			adapterProfile: {
+				backend: 'acuity',
+				baseUrl: 'https://example.as.me',
+			},
+			value: [{ date: '2026-06-15' }],
+			observedAt: '2026-05-08T12:00:00.000Z',
+			staleAt: '2026-05-08T12:05:00.000Z',
+			expiresAt: '2026-05-08T12:30:00.000Z',
+		});
+		const running = await listen(store);
+		activeServer = running.server;
+
+		const response = await fetch(
+			`${running.baseUrl}/availability/snapshot?kind=dates&serviceId=${service.id}&scope=2026-06`,
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({
+			success: true,
+			data: {
+				kind: 'dates',
+				serviceId: service.id,
+				scope: '2026-06',
+				value: [{ date: '2026-06-15' }],
+			},
+		});
+	});
+});

--- a/src/server/__tests__/booking-create-with-payment.test.ts
+++ b/src/server/__tests__/booking-create-with-payment.test.ts
@@ -133,7 +133,7 @@ describe('POST /booking/create-with-payment', () => {
 		delete process.env.ACUITY_BYPASS_COUPON;
 	});
 
-	it('uses the static catalog service name, bypass coupon, and payment reference', async () => {
+	it('rejects the synchronous paid booking endpoint so consumers migrate to async jobs', async () => {
 		const running = await listen();
 		activeServer = running.server;
 
@@ -152,37 +152,19 @@ describe('POST /booking/create-with-payment', () => {
 
 		const body = await response.json();
 
-		expect(response.status).toBe(200);
+		expect(response.status).toBe(410);
 		expect(body).toMatchObject({
-			success: true,
-			data: {
-				id: 'apt_123',
-				paymentRef: '[STRIPE] Transaction: pi_test_123',
+			success: false,
+			error: {
+				tag: 'Deprecated',
+				code: 'ASYNC_REQUIRED',
 			},
 		});
-		expect(stepMocks.navigateToBooking).toHaveBeenCalledWith(
-			expect.objectContaining({
-				serviceName: service.name,
-				datetime: bookingRequest.datetime,
-				appointmentTypeId: service.id,
-			}),
-		);
-		expect(stepMocks.bypassPayment).toHaveBeenCalledWith('TEST-100');
-		expect(stepMocks.toBooking).toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining({ serviceId: service.id }),
-			'pi_test_123',
-			'stripe',
-			expect.objectContaining({
-				name: service.name,
-				duration: service.duration,
-				price: service.price,
-				currency: service.currency,
-			}),
-		);
+		expect(stepMocks.navigateToBooking).not.toHaveBeenCalled();
+		expect(stepMocks.bypassPayment).not.toHaveBeenCalled();
 	});
 
-	it('accepts a request-scoped coupon code override', async () => {
+	it('does not run the old sync endpoint even when a request-scoped coupon is present', async () => {
 		const running = await listen();
 		activeServer = running.server;
 
@@ -200,11 +182,11 @@ describe('POST /booking/create-with-payment', () => {
 			},
 		);
 
-		expect(response.status).toBe(200);
-		expect(stepMocks.bypassPayment).toHaveBeenCalledWith('REQUEST-100');
+		expect(response.status).toBe(410);
+		expect(stepMocks.bypassPayment).not.toHaveBeenCalled();
 	});
 
-	it('rejects paid booking finalization before navigation when no bypass coupon is configured', async () => {
+	it('fails fast before sync paid booking validation when no bypass coupon is configured', async () => {
 		delete process.env.ACUITY_BYPASS_COUPON;
 		const running = await listen();
 		activeServer = running.server;
@@ -224,12 +206,12 @@ describe('POST /booking/create-with-payment', () => {
 
 		const body = await response.json();
 
-		expect(response.status).toBe(400);
+		expect(response.status).toBe(410);
 		expect(body).toMatchObject({
 			success: false,
 			error: {
-				tag: 'ValidationError',
-				code: 'couponCode',
+				tag: 'Deprecated',
+				code: 'ASYNC_REQUIRED',
 			},
 		});
 		expect(stepMocks.navigateToBooking).not.toHaveBeenCalled();

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -3,7 +3,7 @@
  *
  * Standalone Node.js HTTP server wrapping the Effect TS wizard programs.
  * Designed to run inside a Docker container with Playwright + Chromium
- * on Modal Labs, Fly.io, or any host.
+ * on Kubernetes, Docker, or any host.
  *
  * Endpoints:
  *   GET  /health                    - Health check
@@ -12,8 +12,12 @@
  *   POST /availability/dates        - Available dates for a service
  *   POST /availability/slots        - Time slots for a date
  *   POST /availability/check        - Check if a slot is available
+ *   POST /availability/refresh      - Enqueue async availability refresh
+ *   GET  /availability/snapshot     - Read latest availability snapshot
  *   POST /booking/create            - Create booking (standard)
- *   POST /booking/create-with-payment - Create booking with payment ref (coupon bypass)
+ *   POST /booking/create-with-payment - Deprecated sync paid booking endpoint
+ *   POST /booking/jobs              - Enqueue async paid booking job
+ *   GET  /jobs/:operationId         - Read async job status
  *
  * Environment variables:
  *   PORT                - Server port (default: 3001)
@@ -83,6 +87,18 @@ import {
 	selectSlotPrewarmDates,
 } from './slot-prewarm.js';
 import { ndjsonLog } from '../shared/logger.js';
+import {
+	createInMemoryBridgeAsyncStore,
+	type BridgeAsyncStore,
+} from '../async/store.js';
+import { createPostgresBridgeAsyncStore } from '../async/postgres-store.js';
+import type {
+	AvailabilitySnapshotKind,
+	BridgeAdapterProfile,
+	BridgeJobCommand,
+	BridgeJobRecord,
+	EnqueueBridgeJobResponse,
+} from '../async/types.js';
 import type {
 	Booking,
 	BookingRequest,
@@ -117,7 +133,7 @@ export const __setAcuityStepOverridesForTest = (
 
 const PORT = Number(process.env.PORT ?? 3001);
 const AUTH_TOKEN = process.env.AUTH_TOKEN;
-const ACUITY_BASE_URL = process.env.ACUITY_BASE_URL ?? 'https://MassageIthaca.as.me';
+const ACUITY_BASE_URL = process.env.ACUITY_BASE_URL ?? 'https://example.as.me';
 const COUPON_CODE = process.env.ACUITY_BYPASS_COUPON;
 const SERVICE_CACHE_TTL_MS = (() => {
 	const parsed = Number(process.env.ACUITY_SERVICE_CACHE_TTL_MS ?? 5 * 60_000);
@@ -362,6 +378,7 @@ export const __setEffectRunnerForTest = (runner: RunEffect | null) => {
 // If REDIS_URL is missing (local dev), `redisL2` stays `undefined` and the
 // catalog falls back to its in-process single-flight path.
 
+const BRIDGE_DATABASE_URL = process.env.BRIDGE_DATABASE_URL;
 const REDIS_URL = process.env.REDIS_URL;
 const REDIS_PASSWORD = process.env.REDIS_PASSWORD;
 
@@ -420,6 +437,46 @@ const serviceCatalog = createAcuityServiceCatalog({
 	logger: createServiceCatalogLogger(),
 	redisL2: serviceCatalogRedisL2,
 });
+
+let closeBridgeAsyncStore: (() => Promise<void>) | null = null;
+
+const createBridgeAsyncStore = (): BridgeAsyncStore => {
+	if (BRIDGE_DATABASE_URL) {
+		const store = createPostgresBridgeAsyncStore({
+			connectionString: BRIDGE_DATABASE_URL,
+			ssl: process.env.BRIDGE_DATABASE_SSL === 'true',
+			migrate: process.env.BRIDGE_DATABASE_MIGRATE !== 'false',
+		});
+		closeBridgeAsyncStore = store.close;
+		void store.ready().catch((error) => {
+			logEvent('ERROR', 'Bridge async Postgres store migration failed', {
+				event: 'bridge_async_store_ready_failed',
+				error: describeLogValue(error),
+			});
+		});
+		logEvent('INFO', 'Bridge async store selected', {
+			event: 'bridge_async_store_selected',
+			mode: 'postgres',
+			migrate: process.env.BRIDGE_DATABASE_MIGRATE !== 'false',
+		});
+		return store;
+	}
+	logEvent('INFO', 'Bridge async store selected', {
+		event: 'bridge_async_store_selected',
+		mode: 'memory',
+	});
+	return createInMemoryBridgeAsyncStore();
+};
+
+let bridgeAsyncStore: BridgeAsyncStore = createBridgeAsyncStore();
+
+export const __setBridgeAsyncStoreForTest = (store: BridgeAsyncStore | null) => {
+	if (closeBridgeAsyncStore) {
+		void closeBridgeAsyncStore().catch(() => undefined);
+		closeBridgeAsyncStore = null;
+	}
+	bridgeAsyncStore = store ?? createInMemoryBridgeAsyncStore();
+};
 
 const isSchedulingError = (error: unknown): error is SchedulingError =>
 	typeof error === 'object' && error !== null && '_tag' in error;
@@ -488,6 +545,62 @@ const resolveServiceName = async (serviceId: string, serviceName?: string): Prom
 };
 
 const isAcuityAppointmentTypeId = (serviceId: string): boolean => /^\d+$/.test(serviceId);
+
+const adapterProfile = (): BridgeAdapterProfile => ({
+	backend: 'acuity',
+	baseUrl: ACUITY_BASE_URL,
+	selectorProfile: process.env.ACUITY_SELECTOR_PROFILE,
+	adminApiConfigured: process.env.ACUITY_ADMIN_API_CONFIGURED === 'true',
+});
+
+const jobStatusUrl = (operationId: string): string =>
+	`/jobs/${encodeURIComponent(operationId)}`;
+
+const toEnqueueResponse = (job: BridgeJobRecord): EnqueueBridgeJobResponse => ({
+	operationId: job.operationId,
+	status: job.status,
+	statusUrl: jobStatusUrl(job.operationId),
+});
+
+const sendAccepted = <T>(res: ServerResponse, data: T) =>
+	sendJson(res, 202, { success: true, data });
+
+const snapshotTimestamps = (observedAt = new Date()) => {
+	const staleAfterMs = Number(process.env.BRIDGE_SNAPSHOT_STALE_MS ?? 5 * 60_000);
+	const expiresAfterMs = Number(process.env.BRIDGE_SNAPSHOT_EXPIRES_MS ?? 30 * 60_000);
+	return {
+		observedAt: observedAt.toISOString(),
+		staleAt: new Date(observedAt.getTime() + staleAfterMs).toISOString(),
+		expiresAt: new Date(observedAt.getTime() + expiresAfterMs).toISOString(),
+	};
+};
+
+const recordAvailabilitySnapshot = async (
+	kind: AvailabilitySnapshotKind,
+	serviceId: string,
+	scope: string,
+	value: readonly unknown[],
+	context: RequestContext,
+) => {
+	try {
+		await bridgeAsyncStore.upsertAvailabilitySnapshot({
+			kind,
+			serviceId,
+			scope,
+			adapterProfile: adapterProfile(),
+			value: value as never,
+			...snapshotTimestamps(),
+		});
+	} catch (error) {
+		logRequestEvent('WARN', 'Availability snapshot write failed', context, {
+			event: 'availability_snapshot_write_failed',
+			kind,
+			serviceId,
+			scope,
+			error: describeLogValue(error),
+		});
+	}
+};
 
 const scheduleDatePrewarm = (
 	context: RequestContext,
@@ -736,6 +849,13 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Availability lookup failed' },
 		});
 	}
+	await recordAvailabilitySnapshot(
+		'dates',
+		body.serviceId,
+		targetMonth ?? 'current',
+		Array.isArray(result.value) ? result.value : [],
+		context,
+	);
 	scheduleDatePrewarm(context, body.serviceId, targetMonth);
 	scheduleSlotPrewarm(context, body.serviceId, result.value);
 	sendSuccess(res, result.value);
@@ -802,6 +922,13 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Slot lookup failed' },
 		});
 	}
+	await recordAvailabilitySnapshot(
+		'slots',
+		body.serviceId,
+		body.date,
+		Array.isArray(result.value) ? result.value : [],
+		context,
+	);
 	sendSuccess(res, result.value);
 };
 
@@ -893,72 +1020,193 @@ const handleCreateBooking = async (req: IncomingMessage, res: ServerResponse, co
 	sendSuccess(res, result.value);
 };
 
-const handleCreateBookingWithPayment = async (
+const handleDeprecatedSyncPaymentBooking = (res: ServerResponse) =>
+	sendJson(res, 410, {
+		success: false,
+		error: {
+			tag: 'Deprecated',
+			code: 'ASYNC_REQUIRED',
+			message: 'Use POST /booking/jobs and poll GET /jobs/:operationId',
+		},
+	});
+
+const handleEnqueueBookingJob = async (
 	req: IncomingMessage,
 	res: ServerResponse,
 	context: RequestContext,
 ) => {
-	const body = (await parseBody(req)) as {
-		request: BookingRequest;
-		paymentRef: string;
-		paymentProcessor: string;
-		couponCode?: string;
-	};
-	const { request, paymentRef, paymentProcessor } = body;
-	const coupon = body.couponCode ?? COUPON_CODE;
-
-	if (!coupon) {
+	const rawBody = await parseBody(req);
+	if (!isRecord(rawBody)) {
+		return sendValidationError(res, 'body', 'Request body must be an object');
+	}
+	if (!isRecord(rawBody.request)) {
+		return sendValidationError(res, 'request', 'request is required');
+	}
+	if (!isNonEmptyString(rawBody.paymentRef)) {
+		return sendValidationError(res, 'paymentRef', 'paymentRef is required');
+	}
+	if (!isNonEmptyString(rawBody.paymentProcessor)) {
+		return sendValidationError(res, 'paymentProcessor', 'paymentProcessor is required');
+	}
+	const coupon = optionalString(rawBody.couponCode) ?? COUPON_CODE;
+	const profile = adapterProfile();
+	const couponBypassRequired = Boolean(coupon) || !profile.adminApiConfigured;
+	if (couponBypassRequired && !coupon) {
 		return sendJson(res, 400, {
 			success: false,
 			error: { tag: 'ValidationError', code: 'couponCode', message: 'Coupon code is required for payment bypass' },
 		});
 	}
-
+	const idempotencyKey = optionalString(rawBody.idempotencyKey) ?? undefined;
+	const request = rawBody.request as unknown as BookingRequest;
 	const serviceName = await resolveServiceName(request.serviceId);
-	const service = serviceCatalog.getCachedService(request.serviceId);
-	logRequestEvent('INFO', 'Booking create with payment requested', context, {
-		event: 'booking_create_with_payment_requested',
+	const job: BridgeJobCommand = {
+		kind: 'booking_create_with_payment',
+		command: {
+			request,
+			paymentRef: rawBody.paymentRef,
+			paymentProcessor: rawBody.paymentProcessor,
+			couponCode: coupon,
+			serviceName,
+			adapterProfile: profile,
+			couponBypassRequired,
+			executionPreference: 'auto',
+		},
+	};
+	const record = await bridgeAsyncStore.enqueueJob(job, { idempotencyKey });
+
+	logRequestEvent('INFO', 'Booking async job enqueued', context, {
+		event: 'booking_job_enqueued',
+		operationId: record.operationId,
+		status: record.status,
 		serviceId: request.serviceId,
 		datetime: request.datetime,
-		paymentProcessor,
+		idempotent: Boolean(idempotencyKey),
 	});
 
-	const result = await runEffect(
-		Effect.gen(function* () {
-			yield* acuitySteps.navigateToBooking({
-				serviceName: serviceName ?? request.serviceId,
-				datetime: request.datetime,
-				client: request.client,
-				appointmentTypeId: request.serviceId,
-			});
-			yield* acuitySteps.fillFormFields({ client: request.client, customFields: request.client.customFields });
-			yield* acuitySteps.bypassPayment(coupon);
-			yield* acuitySteps.submitBooking();
-			const confirmation = yield* acuitySteps.extractConfirmation();
-			return acuitySteps.toBooking(
-				confirmation,
-				request,
-				paymentRef,
-				paymentProcessor,
-				service ? { name: service.name, duration: service.duration, price: service.price, currency: service.currency } : undefined,
-			);
-		}),
-	);
+	return sendAccepted(res, toEnqueueResponse(record));
+};
 
-	if (!result.ok) {
-		logRequestEvent('ERROR', 'Booking create with payment failed', context, {
-			event: 'booking_create_with_payment_failed',
-			serviceId: request.serviceId,
-			datetime: request.datetime,
-			paymentProcessor,
-			errorTag: result.error._tag,
-			errorCode: 'code' in result.error ? result.error.code : 'UNKNOWN',
-			errorMessage:
-				'message' in result.error ? result.error.message : 'Booking create with payment failed',
-		});
-		return sendError(res, 500, result.error);
+const handleEnqueueAvailabilityRefresh = async (
+	req: IncomingMessage,
+	res: ServerResponse,
+	context: RequestContext,
+) => {
+	const rawBody = await parseBody(req);
+	if (!isRecord(rawBody)) {
+		return sendValidationError(res, 'body', 'Request body must be an object');
 	}
-	sendSuccess(res, result.value);
+	const kind = rawBody.kind;
+	if (kind !== 'dates' && kind !== 'slots') {
+		return sendValidationError(res, 'kind', 'kind must be "dates" or "slots"');
+	}
+	if (!isNonEmptyString(rawBody.serviceId)) {
+		return sendValidationError(res, 'serviceId', 'serviceId is required');
+	}
+	const serviceName = optionalString(rawBody.serviceName);
+	if (serviceName === null) {
+		return sendValidationError(res, 'serviceName', 'serviceName must be a string');
+	}
+
+	const idempotencyKeyOverride = optionalString(rawBody.idempotencyKey);
+	if (idempotencyKeyOverride === null) {
+		return sendValidationError(res, 'idempotencyKey', 'idempotencyKey must be a string');
+	}
+
+	const month = rawBody.month;
+	const date = rawBody.date;
+	if (kind === 'dates' && !isNonEmptyString(month)) {
+		return sendValidationError(res, 'month', 'month is required for date refresh jobs');
+	}
+	if (kind === 'slots' && !isNonEmptyString(date)) {
+		return sendValidationError(res, 'date', 'date is required for slot refresh jobs');
+	}
+
+	const idempotencyKey = idempotencyKeyOverride ?? [
+		'availability-refresh',
+		ACUITY_BASE_URL,
+		kind,
+		rawBody.serviceId,
+		kind === 'dates' ? month : date,
+	].join(':');
+
+	const job: BridgeJobCommand = kind === 'dates'
+		? {
+				kind: 'availability_dates_refresh',
+				command: {
+					serviceId: rawBody.serviceId,
+					serviceName,
+					month: month as string,
+					adapterProfile: adapterProfile(),
+				},
+			}
+		: {
+				kind: 'availability_slots_refresh',
+				command: {
+					serviceId: rawBody.serviceId,
+					serviceName,
+					date: date as string,
+					adapterProfile: adapterProfile(),
+				},
+			};
+
+	const record = await bridgeAsyncStore.enqueueJob(job, { idempotencyKey });
+
+	logRequestEvent('INFO', 'Availability refresh job enqueued', context, {
+		event: 'availability_refresh_enqueued',
+		operationId: record.operationId,
+		status: record.status,
+		kind: record.kind,
+		serviceId: rawBody.serviceId,
+	});
+
+	return sendAccepted(res, toEnqueueResponse(record));
+};
+
+const handleGetAsyncJob = async (operationId: string, res: ServerResponse) => {
+	const record = await bridgeAsyncStore.getJob(operationId);
+	if (!record) {
+		return sendJson(res, 404, {
+			success: false,
+			error: { tag: 'InfrastructureError', code: 'NOT_FOUND', message: `Job ${operationId} not found` },
+		});
+	}
+	return sendSuccess(res, record);
+};
+
+const handleGetAvailabilitySnapshot = async (
+	url: URL,
+	res: ServerResponse,
+) => {
+	const kind = url.searchParams.get('kind');
+	const serviceId = url.searchParams.get('serviceId');
+	const scope = url.searchParams.get('scope');
+	if (kind !== 'dates' && kind !== 'slots') {
+		return sendValidationError(res, 'kind', 'kind must be "dates" or "slots"');
+	}
+	if (!serviceId) {
+		return sendValidationError(res, 'serviceId', 'serviceId is required');
+	}
+	if (!scope) {
+		return sendValidationError(res, 'scope', 'scope is required');
+	}
+	const snapshot = await bridgeAsyncStore.getAvailabilitySnapshot({
+		kind,
+		serviceId,
+		scope,
+		baseUrl: ACUITY_BASE_URL,
+	});
+	if (!snapshot) {
+		return sendJson(res, 404, {
+			success: false,
+			error: {
+				tag: 'InfrastructureError',
+				code: 'NOT_FOUND',
+				message: `No ${kind} snapshot found for ${serviceId}/${scope}`,
+			},
+		});
+	}
+	return sendSuccess(res, snapshot);
 };
 
 // =============================================================================
@@ -1042,11 +1290,28 @@ const server = createServer(async (req, res) => {
 		if (path === '/availability/check' && method === 'POST') {
 			return await handleCheckSlot(req, res, context);
 		}
+		if (path === '/availability/refresh' && method === 'POST') {
+			return await handleEnqueueAvailabilityRefresh(req, res, context);
+		}
+		if (path === '/availability/snapshot' && method === 'GET') {
+			return await handleGetAvailabilitySnapshot(url, res);
+		}
+		if (path.startsWith('/jobs/') && method === 'GET') {
+			const operationId = decodeURIComponent(path.slice('/jobs/'.length));
+			return await handleGetAsyncJob(operationId, res);
+		}
 		if (path === '/booking/create' && method === 'POST') {
 			return await handleCreateBooking(req, res, context);
 		}
 		if (path === '/booking/create-with-payment' && method === 'POST') {
-			return await handleCreateBookingWithPayment(req, res, context);
+			return handleDeprecatedSyncPaymentBooking(res);
+		}
+		if (path === '/booking/jobs' && method === 'POST') {
+			return await handleEnqueueBookingJob(req, res, context);
+		}
+		if (path.startsWith('/booking/jobs/') && method === 'GET') {
+			const operationId = decodeURIComponent(path.slice('/booking/jobs/'.length));
+			return await handleGetAsyncJob(operationId, res);
 		}
 
 		logRequestEvent('WARN', 'Unknown route requested', context, {
@@ -1090,8 +1355,15 @@ const disposeRedisClient = () => {
 	void redisClient.quit().catch(() => undefined);
 };
 
+const disposeBridgeAsyncStore = () => {
+	if (!closeBridgeAsyncStore) return;
+	void closeBridgeAsyncStore().catch(() => undefined);
+	closeBridgeAsyncStore = null;
+};
+
 server.on('close', disposeBrowserRuntime);
 server.on('close', disposeRedisClient);
+server.on('close', disposeBridgeAsyncStore);
 
 // Only start listening when this file is executed directly (not imported)
 if (process.argv[1]?.match(/handler\.(ts|js|mjs)$/)) {

--- a/src/server/health.ts
+++ b/src/server/health.ts
@@ -1,4 +1,4 @@
-export const BRIDGE_PROTOCOL_VERSION = '1.0.0' as const;
+export const BRIDGE_PROTOCOL_VERSION = '1.1.0' as const;
 
 export const BRIDGE_PROTOCOL_ENDPOINTS = {
 	health: '/health',
@@ -7,8 +7,12 @@ export const BRIDGE_PROTOCOL_ENDPOINTS = {
 	availabilityDates: '/availability/dates',
 	availabilitySlots: '/availability/slots',
 	availabilityCheck: '/availability/check',
+	availabilityRefresh: '/availability/refresh',
+	availabilitySnapshot: '/availability/snapshot',
 	bookingCreate: '/booking/create',
 	bookingCreateWithPayment: '/booking/create-with-payment',
+	bookingJobs: '/booking/jobs',
+	jobStatus: '/jobs/:operationId',
 } as const;
 
 export const BRIDGE_PROTOCOL_CAPABILITIES = [
@@ -17,8 +21,12 @@ export const BRIDGE_PROTOCOL_CAPABILITIES = [
 	'availability:dates',
 	'availability:slots',
 	'availability:check',
+	'availability:refresh-async',
+	'availability:snapshot',
 	'booking:create',
-	'booking:create-with-payment',
+	'booking:create-with-payment:deprecated',
+	'booking:create-with-payment-async',
+	'booking:job-status',
 	'service-catalog:static-fallback',
 	'service-catalog:business-extract',
 	'service-catalog:scraper-fallback',

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -1,0 +1,299 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { Effect, Exit, Cause, ManagedRuntime, Scope } from 'effect';
+import {
+	BrowserProcessLive,
+	BrowserService,
+	BrowserSessionLive,
+	defaultBrowserConfig,
+	type BrowserConfig,
+} from '../shared/browser-service.js';
+import { toSchedulingError, type MiddlewareError } from '../adapters/acuity/errors.js';
+import {
+	navigateToBooking,
+	fillFormFields,
+	bypassPayment,
+	submitBooking,
+	extractConfirmation,
+	toBooking,
+	readAvailableDates,
+	readTimeSlots,
+} from '../adapters/acuity/steps/index.js';
+import {
+	readDatesViaUrl,
+	readSlotsViaUrl,
+} from '../adapters/acuity/steps/read-via-url.js';
+import type {
+	AppointmentCommand,
+	AvailabilityDatesRefreshCommand,
+	AvailabilitySlotsRefreshCommand,
+} from '../async/types.js';
+import type { BridgeAsyncStore } from '../async/store.js';
+import { createInMemoryBridgeAsyncStore } from '../async/store.js';
+import { createPostgresBridgeAsyncStore } from '../async/postgres-store.js';
+import {
+	BridgeJobExecutionError,
+	drainReadyBridgeJobs,
+	selectBookingExecutionPath,
+	type BridgeJobExecutor,
+} from '../async/worker.js';
+import { ndjsonLog } from '../shared/logger.js';
+
+const ACUITY_BASE_URL = process.env.ACUITY_BASE_URL ?? 'https://example.as.me';
+const BRIDGE_DATABASE_URL = process.env.BRIDGE_DATABASE_URL;
+
+const browserConfig: BrowserConfig = {
+	...defaultBrowserConfig,
+	baseUrl: ACUITY_BASE_URL,
+	headless: process.env.PLAYWRIGHT_HEADLESS !== 'false',
+	timeout: Number(process.env.PLAYWRIGHT_TIMEOUT ?? 30000),
+	executablePath: process.env.CHROMIUM_EXECUTABLE_PATH,
+	launchArgs: process.env.CHROMIUM_LAUNCH_ARGS?.split(','),
+};
+
+const browserRuntime = ManagedRuntime.make(BrowserProcessLive(browserConfig));
+
+const logEvent = (
+	level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR',
+	msg: string,
+	data?: Record<string, unknown>,
+) => {
+	ndjsonLog(level, msg, {
+		flowOwner: 'scheduling-bridge',
+		backend: 'acuity',
+		transport: 'async-worker',
+		modalEnvironment: process.env.MODAL_ENVIRONMENT,
+		releaseSha: process.env.MIDDLEWARE_RELEASE_SHA,
+		releaseVersion: process.env.MIDDLEWARE_RELEASE_VERSION ?? process.env.npm_package_version,
+		...data,
+	});
+};
+
+const isAcuityAppointmentTypeId = (serviceId: string): boolean => /^\d+$/.test(serviceId);
+
+const schedulingErrorFields = (error: unknown) => {
+	if (typeof error === 'object' && error !== null) {
+		const maybe = error as { _tag?: string; code?: string; message?: string };
+		return {
+			code: maybe.code ?? maybe._tag ?? 'UNKNOWN',
+			message: maybe.message ?? JSON.stringify(error),
+		};
+	}
+	return {
+		code: 'UNKNOWN',
+		message: error instanceof Error ? error.message : String(error),
+	};
+};
+
+const exitToValue = <A>(
+	exit: Exit.Exit<A, MiddlewareError | undefined>,
+	step: string,
+	status: 'failed_pre_submit' | 'reconcile_required',
+): A => {
+	if (Exit.isSuccess(exit)) return exit.value;
+	const failure = Cause.failureOption(exit.cause);
+	const error = failure._tag === 'Some' && failure.value !== undefined
+		? toSchedulingError(failure.value)
+		: { _tag: 'InfrastructureError', code: 'UNKNOWN', message: Cause.pretty(exit.cause) };
+	const fields = schedulingErrorFields(error);
+	throw new BridgeJobExecutionError({
+		status,
+		code: fields.code,
+		message: fields.message,
+		step,
+		retryable: status === 'failed_pre_submit',
+	});
+};
+
+const runWizardStep = async <A>(
+	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
+	step: string,
+	status: 'failed_pre_submit' | 'reconcile_required' = 'failed_pre_submit',
+): Promise<A> => {
+	const exit = await browserRuntime.runPromiseExit(
+		Effect.scoped(effect.pipe(Effect.provide(BrowserSessionLive))),
+	);
+	return exitToValue(exit, step, status);
+};
+
+const assertPaymentBypassProven = (result: {
+	readonly couponApplied: boolean;
+	readonly totalAfterCoupon: string | null;
+}) => {
+	const numericTotal = result.totalAfterCoupon
+		? Number(result.totalAfterCoupon.replace(/[^0-9.]/g, ''))
+		: null;
+	if (!result.couponApplied || numericTotal !== 0) {
+		throw new BridgeJobExecutionError({
+			status: 'failed_pre_submit',
+			code: 'PAYMENT_BYPASS_NOT_PROVEN',
+			message: 'Payment bypass was not proven before submit',
+			step: 'bypass-payment',
+			retryable: false,
+		});
+	}
+};
+
+export const createAcuityBridgeJobExecutor = (): BridgeJobExecutor => ({
+	refreshAvailabilityDates: async (command: AvailabilityDatesRefreshCommand) => {
+		if (isAcuityAppointmentTypeId(command.serviceId)) {
+			return runWizardStep(
+				readDatesViaUrl(command.serviceId, command.month),
+				'refresh-availability-dates',
+			);
+		}
+		return runWizardStep(
+			readAvailableDates({
+				serviceName: command.serviceName ?? command.serviceId,
+				targetMonth: command.month,
+				monthsToScan: 2,
+			}),
+			'refresh-availability-dates',
+		);
+	},
+
+	refreshAvailabilitySlots: async (command: AvailabilitySlotsRefreshCommand) => {
+		if (isAcuityAppointmentTypeId(command.serviceId)) {
+			return runWizardStep(
+				readSlotsViaUrl(command.serviceId, command.date),
+				'refresh-availability-slots',
+			);
+		}
+		return runWizardStep(
+			readTimeSlots({
+				serviceName: command.serviceName ?? command.serviceId,
+				date: command.date,
+			}),
+			'refresh-availability-slots',
+		);
+	},
+
+	createBookingWithPayment: async (command: AppointmentCommand, context) => {
+		if (context.executionPath === 'rest') {
+			throw new BridgeJobExecutionError({
+				status: 'failed_pre_submit',
+				code: 'REST_BOOKING_NOT_WIRED',
+				message: 'Acuity REST booking execution is selected but not wired in this worker',
+				step: 'execution-path',
+				retryable: false,
+			});
+		}
+		const serviceName = command.serviceName ?? command.request.serviceId;
+		await runWizardStep(
+			navigateToBooking({
+				serviceName,
+				datetime: command.request.datetime,
+				client: command.request.client,
+				appointmentTypeId: command.request.serviceId,
+			}),
+			'navigate',
+		);
+		await runWizardStep(
+			fillFormFields({
+				client: command.request.client,
+				customFields: command.request.client.customFields,
+			}),
+			'fill-form',
+		);
+		if (!command.couponCode) {
+			throw new BridgeJobExecutionError({
+				status: 'failed_pre_submit',
+				code: 'COUPON_REQUIRED',
+				message: 'Browser booking execution requires a coupon bypass code',
+				step: 'bypass-payment',
+				retryable: false,
+			});
+		}
+		const bypass = await runWizardStep(
+			bypassPayment(command.couponCode),
+			'bypass-payment',
+		);
+		assertPaymentBypassProven(bypass);
+		await runWizardStep(
+			submitBooking(),
+			'submit',
+			'reconcile_required',
+		);
+		const confirmation = await runWizardStep(
+			extractConfirmation(),
+			'extract-confirmation',
+			'reconcile_required',
+		);
+		return toBooking(
+			confirmation,
+			command.request,
+			command.paymentRef,
+			command.paymentProcessor,
+		);
+	},
+});
+
+export const createWorkerStore = (): BridgeAsyncStore & {
+	readonly close?: () => Promise<void>;
+} => {
+	if (!BRIDGE_DATABASE_URL) {
+		logEvent('WARN', 'Bridge worker using in-memory store', {
+			event: 'bridge_worker_memory_store',
+		});
+		return createInMemoryBridgeAsyncStore();
+	}
+	const store = createPostgresBridgeAsyncStore({
+		connectionString: BRIDGE_DATABASE_URL,
+		ssl: process.env.BRIDGE_DATABASE_SSL === 'true',
+		migrate: process.env.BRIDGE_DATABASE_MIGRATE !== 'false',
+	});
+	return store;
+};
+
+export const runBridgeWorkerLoop = async (
+	store = createWorkerStore(),
+	executor = createAcuityBridgeJobExecutor(),
+	options: {
+		readonly workerId?: string;
+		readonly intervalMs?: number;
+		readonly limit?: number;
+		readonly signal?: AbortSignal;
+	} = {},
+) => {
+	const workerId = options.workerId ?? process.env.HOSTNAME ?? `worker-${process.pid}`;
+	const intervalMs = options.intervalMs ?? Number(process.env.BRIDGE_WORKER_POLL_MS ?? 1000);
+	const limit = options.limit ?? Number(process.env.BRIDGE_WORKER_BATCH_SIZE ?? 5);
+
+	logEvent('INFO', 'Bridge worker loop started', {
+		event: 'bridge_worker_started',
+		workerId,
+		intervalMs,
+		limit,
+	});
+
+	while (!options.signal?.aborted) {
+		const results = await drainReadyBridgeJobs(store, executor, {
+			workerId,
+			limit,
+		});
+		if (results.length > 0) {
+			logEvent('INFO', 'Bridge worker drained jobs', {
+				event: 'bridge_worker_drained_jobs',
+				workerId,
+				count: results.length,
+				statuses: results.map((job) => job.status),
+				executionPaths: results
+					.filter((job) => job.kind === 'booking_create_with_payment')
+					.map((job) => selectBookingExecutionPath(job.command as AppointmentCommand)),
+			});
+		}
+		await delay(intervalMs, undefined, { signal: options.signal }).catch((error) => {
+			if (options.signal?.aborted) return;
+			throw error;
+		});
+	}
+};
+
+if (process.argv[1]?.match(/worker\.(ts|js|mjs)$/)) {
+	runBridgeWorkerLoop().catch((error) => {
+		logEvent('ERROR', 'Bridge worker failed', {
+			event: 'bridge_worker_failed',
+			error: error instanceof Error ? error.message : String(error),
+		});
+		process.exitCode = 1;
+	});
+}

--- a/src/shared/async-client.ts
+++ b/src/shared/async-client.ts
@@ -1,0 +1,96 @@
+import type {
+	AvailabilitySnapshot,
+	EnqueueAvailabilityRefreshRequest,
+	EnqueueBookingJobRequest,
+	EnqueueBridgeJobResponse,
+	BridgeJobRecord,
+} from '../async/types.js';
+import type { RemoteAdapterConfig } from './remote-adapter.js';
+
+interface RemoteEnvelope<T> {
+	readonly success: boolean;
+	readonly data?: T;
+	readonly error?: {
+		readonly tag: string;
+		readonly code: string;
+		readonly message: string;
+	};
+}
+
+const buildHeaders = (config: RemoteAdapterConfig): Record<string, string> => {
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json',
+	};
+	if (config.authToken) {
+		headers.Authorization = `Bearer ${config.authToken}`;
+	}
+	for (const [name, value] of Object.entries(config.headers ?? {})) {
+		if (!['authorization', 'content-type'].includes(name.toLowerCase())) {
+			headers[name] = value;
+		}
+	}
+	return headers;
+};
+
+const request = async <T>(
+	config: RemoteAdapterConfig,
+	path: string,
+	init: { method: 'GET' | 'POST'; body?: unknown },
+): Promise<T> => {
+	const response = await fetch(`${config.baseUrl}${path}`, {
+		method: init.method,
+		headers: buildHeaders(config),
+		body: init.body === undefined ? undefined : JSON.stringify(init.body),
+		signal: AbortSignal.timeout(config.timeout ?? 60_000),
+	});
+
+	const json = (await response.json().catch(() => ({}))) as RemoteEnvelope<T>;
+	if (!response.ok || !json.success) {
+		throw new Error(json.error?.message ?? `Bridge async request failed: HTTP ${response.status}`);
+	}
+	return json.data as T;
+};
+
+export interface BridgeAsyncClient {
+	enqueueBookingJob(
+		body: EnqueueBookingJobRequest,
+	): Promise<EnqueueBridgeJobResponse>;
+	getJob(operationId: string): Promise<BridgeJobRecord>;
+	enqueueAvailabilityRefresh(
+		body: EnqueueAvailabilityRefreshRequest,
+	): Promise<EnqueueBridgeJobResponse>;
+	getAvailabilitySnapshot(params: {
+		kind: 'dates' | 'slots';
+		serviceId: string;
+		scope: string;
+	}): Promise<AvailabilitySnapshot>;
+}
+
+export const createBridgeAsyncClient = (
+	config: RemoteAdapterConfig,
+): BridgeAsyncClient => ({
+	enqueueBookingJob: (body) =>
+		request<EnqueueBridgeJobResponse>(config, '/booking/jobs', {
+			method: 'POST',
+			body,
+		}),
+	getJob: (operationId) =>
+		request<BridgeJobRecord>(
+			config,
+			`/jobs/${encodeURIComponent(operationId)}`,
+			{ method: 'GET' },
+		),
+	enqueueAvailabilityRefresh: (body) =>
+		request<EnqueueBridgeJobResponse>(config, '/availability/refresh', {
+			method: 'POST',
+			body,
+		}),
+	getAvailabilitySnapshot: ({ kind, serviceId, scope }) => {
+		const query = new URLSearchParams({ kind, serviceId, scope });
+		return request<AvailabilitySnapshot>(
+			config,
+			`/availability/snapshot?${query.toString()}`,
+			{ method: 'GET' },
+		);
+	},
+});

--- a/src/shared/browser-service.ts
+++ b/src/shared/browser-service.ts
@@ -44,7 +44,7 @@ const positiveIntEnv = (name: string, fallback: number): number => {
 };
 
 export const defaultBrowserConfig: BrowserConfig = {
-	baseUrl: 'https://MassageIthaca.as.me',
+	baseUrl: 'https://example.as.me',
 	headless: true,
 	timeout: 30000,
 	userAgent:


### PR DESCRIPTION
## Summary
- Bumps scheduling-bridge to 0.5.0 while preserving scheduling-kit 0.7.7 consumption.
- Adds durable async job and availability snapshot contracts with in-memory and Postgres stores.
- Adds async booking/availability endpoints, worker loop, status polling client, and queue-oriented tests.
- Deprecates the synchronous paid booking endpoint with 410 ASYNC_REQUIRED.
- Disables automatic Modal deploys; legacy Modal dispatch now requires explicit acknowledgement.

## Validation
- pnpm docs:generate
- pnpm docs:check
- pnpm check:release-metadata
- pnpm check:artifact-authority
- pnpm typecheck
- pnpm test:host
- pnpm test
- pnpm check:package
- git diff --check