### PR TITLE
Bump bridge to scheduling-kit 0.8

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.0",
+    version = "0.5.1",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.0",
+    version = "0.5.1",
     compatibility_level = 1,
 )
 
@@ -46,7 +46,7 @@ bazel_dep(name = "aspect_rules_swc", version = "2.6.1")
 # =============================================================================
 
 # Primary dependency: scheduling-kit (peer; bridge orchestrates over kit's adapters).
-bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.7.7")
+bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.8.0")
 
 # Auth surface (payment capability types come through tinyland-auth).
 bazel_dep(name = "tummycrypt_tinyland_auth", version = "0.3.0")

--- a/docs/blog-post.mdx
+++ b/docs/blog-post.mdx
@@ -44,7 +44,7 @@ That advice is bad.
 
 Here is what I actually built:
 
-A 16-method `SchedulingAdapter` interface- services, providers, availability, reservations, bookings, clients- with every method returning `Effect<T, SchedulingError>` from Effect TS. Monadic composition all the way down. You cannot accidentally ignore an error because the type system won't let you access the success value without handling the error channel first.
+A 16-method `SchedulingAdapter` interface- services, providers, availability, advisory soft holds, bookings, clients- with every method returning `Effect<T, SchedulingError>` from Effect TS. Monadic composition all the way down. You cannot accidentally ignore an error because the type system won't let you access the success value without handling the error channel first.
 
 Then I implemented that interface twice.
 
@@ -180,7 +180,7 @@ I then wrote three targeted fix scripts to correct the specific wrong-priced app
 | Create booking     | ~30-60s (wizard)  | <200ms         | ~300x     |
 ```
 
-Two orders of magnitude. The browser path exists to maintain service continuity during migration. The homegrown adapter has full 16/16 method coverage. The wizard adapter has 12/16 (no `getBooking`, `cancelBooking`, or slot reservations through the public UI).
+Two orders of magnitude. The browser path exists to maintain service continuity during migration. The homegrown adapter has full 16/16 method coverage. The wizard adapter has 12/16 (no `getBooking`, `cancelBooking`, or advisory soft holds through the public UI).
 
 879 tests across the scheduling stack. 39 dedicated availability engine tests covering slot generation, DST transitions, overlap detection, buffer time, and the kind of edge cases that make you question whether `America/New_York` was a deliberate choice by the IANA or a cosmic prank.
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.0`
-- Bazel module version: `0.5.0`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.0`
+- package version: `0.5.1`
+- Bazel module version: `0.5.1`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.1`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -25,7 +25,7 @@ The key insight is that browser automation middleware is not the destination -- 
 
 This paper makes five contributions:
 
-1. A formal 17-method `SchedulingAdapter` interface that abstracts scheduling operations (services, providers, availability, reservations, bookings, clients) across heterogeneous backends, with all methods returning monadic `Effect<T, SchedulingError>` for composable error handling.
+1. A formal 17-method `SchedulingAdapter` interface that abstracts scheduling operations (services, providers, availability, advisory soft holds, bookings, clients) across heterogeneous backends, with all methods returning monadic `Effect<T, SchedulingError>` for composable error handling.
 
 2. An adapter hub architecture (`scheduling-bridge`) that separates the interface definition from vendor-specific implementations, enabling multiple SaaS backends to be wrapped as discrete packages -- a reusable FOSS offramp pattern for small businesses escaping proprietary scheduling services.
 
@@ -55,7 +55,7 @@ Fowler [4] describes the strangler fig pattern as a metaphor for incremental sys
 
 ### D. Anti-Corruption Layer
 
-Evans [10] defines the Anti-Corruption Layer as a pattern for isolating a bounded context from the domain model of an external system. The `SchedulingAdapter` interface serves this role: it prevents Acuity's domain concepts (appointment type IDs, React wizard steps, Square payment integration) from leaking into the homegrown domain model (UUID-based services, slot reservations, Stripe/Venmo payments). The dual-ID resolution pattern in the homegrown adapter -- accepting both UUID and legacy `acuityId` -- is an explicit corruption-containment mechanism.
+Evans [10] defines the Anti-Corruption Layer as a pattern for isolating a bounded context from the domain model of an external system. The `SchedulingAdapter` interface serves this role: it prevents Acuity's domain concepts (appointment type IDs, React wizard steps, Square payment integration) from leaking into the homegrown domain model (UUID-based services, advisory soft holds, Stripe/Venmo payments). The dual-ID resolution pattern in the homegrown adapter -- accepting both UUID and legacy `acuityId` -- is an explicit corruption-containment mechanism.
 
 ### E. Robotic Process Automation
 
@@ -134,9 +134,9 @@ interface SchedulingAdapter {
   getAvailableDates(p: DateParams): SchedulingResult<AvailableDate[]>;
   getAvailableSlots(p: SlotParams): SchedulingResult<TimeSlot[]>;
   checkSlotAvailability(p: CheckParams): SchedulingResult<boolean>;
-  // Reservations (2)
-  createReservation(p: ReserveParams): SchedulingResult<SlotReservation>;
-  releaseReservation(id: string): SchedulingResult<void>;
+  // Advisory soft holds (2)
+  softHoldSlot(p: SoftHoldParams): SchedulingResult<SlotSoftHold>;
+  releaseSoftHold(id: string): SchedulingResult<void>;
   // Bookings (5)
   createBooking(req: BookingRequest): SchedulingResult<Booking>;
   createBookingWithPaymentRef(req, ref, proc): SchedulingResult<Booking>;
@@ -249,11 +249,11 @@ The `HomegrownAdapter` implements all 17 `SchedulingAdapter` methods via direct 
 - **Lazy database connection**: The adapter receives a `getDb` factory function, called per-operation. This avoids import-time connections critical for Vercel cold starts.
 - **Lazy schema imports**: Drizzle schema tables are dynamically imported inside each method, preventing the ORM runtime from being bundled into client-side code.
 - **Dual-ID resolution**: `resolveService` accepts both UUID (homegrown) and integer `acuityId` (legacy) via UUID format detection, enabling backward compatibility during migration.
-- **Real slot reservations**: PG-persisted with `expires_at`, unlike the wizard adapter which cannot support reservations through the public UI.
+- **Advisory soft holds**: PG-persisted with `expires_at`, unlike the wizard adapter which cannot support advisory soft holds through the public UI. Correctness still comes from the final booking write plus backend rejection, not from treating a hold as a reservation.
 
 ### F. Availability Engine
 
-The availability engine is a pure-function module with zero database dependency. All data is passed as arguments. The core algorithm generates candidate slots at configurable intervals within business hours, filters out those overlapping with occupied blocks (bookings + time blocks + active reservations), applies buffer time and minimum advance notice constraints. DST safety is achieved via `Intl.DateTimeFormat` with named timezones -- no manual offset tables. The module has 39 dedicated unit tests.
+The availability engine is a pure-function module with zero database dependency. All data is passed as arguments. The core algorithm generates candidate slots at configurable intervals within business hours, filters out those overlapping with occupied blocks (bookings + time blocks + active soft holds), applies buffer time and minimum advance notice constraints. DST safety is achieved via `Intl.DateTimeFormat` with named timezones -- no manual offset tables. The module has 39 dedicated unit tests.
 
 ---
 
@@ -302,12 +302,12 @@ The browser middleware latency is acceptable only as a migration bridge. The two
 | Services | 2 | 2/2 | 2/2 |
 | Providers | 3 | 3/3 (hardcoded) | 3/3 |
 | Availability | 3 | 3/3 | 3/3 |
-| Reservations | 2 | 0/2 (graceful fail) | 2/2 |
+| Advisory soft holds | 2 | 0/2 (graceful fail) | 2/2 |
 | Bookings | 5 | 2/5 | 5/5 |
 | Clients | 2 | 2/2 (pass-through) | 2/2 |
 | **Total** | **17** | **12/17** | **17/17** |
 
-The wizard adapter's incomplete coverage (no `getBooking`, `cancelBooking`, `rescheduleBooking`, slot reservations) reflects the limitations of the public booking UI -- these operations require admin panel access. The homegrown adapter's full coverage demonstrates feature parity.
+The wizard adapter's incomplete coverage (no `getBooking`, `cancelBooking`, `rescheduleBooking`, advisory soft holds) reflects the limitations of the public booking UI -- these operations require admin panel access. The homegrown adapter's full coverage demonstrates feature parity.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
@@ -50,7 +50,7 @@
     "paper:dev": "node docs/paper/watch.mjs"
   },
   "dependencies": {
-    "@tummycrypt/scheduling-kit": "^0.7.7",
+    "@tummycrypt/scheduling-kit": "^0.8.0",
     "effect": "^3.19.14",
     "ioredis": "^5",
     "pg": "8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@tummycrypt/scheduling-kit':
-        specifier: ^0.7.7
-        version: 0.7.7(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
+        specifier: ^0.8.0
+        version: 0.8.0(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth-pg@0.2.4(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))
       effect:
         specifier: ^3.19.14
         version: 3.21.0
@@ -379,17 +379,20 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@tummycrypt/scheduling-kit@0.7.7':
-    resolution: {integrity: sha512-ChnfRWS7Pb84iyCkDYY3PmD4xKTOKCp/yxjYY2rBJLNDn2+ZVwLDlt10QTaigHAH9YpoVL4BVTcPizqQeRIfQQ==}
+  '@tummycrypt/scheduling-kit@0.8.0':
+    resolution: {integrity: sha512-fm7bsDyqma92LTWU5Qln2na1NVRY5qZn3H03HEcrz2r9DEaJkEvCrM8kGp6gL3L+kbwnTdKxCT26zYYdRGBxJg==}
     engines: {node: '>=20 <25'}
     peerDependencies:
       '@skeletonlabs/skeleton': ^4.0.0
       '@skeletonlabs/skeleton-svelte': ^4.0.0
+      '@tummycrypt/tinyland-auth-pg': ^0.2.1
       svelte: ^5.0.0
     peerDependenciesMeta:
       '@skeletonlabs/skeleton':
         optional: true
       '@skeletonlabs/skeleton-svelte':
+        optional: true
+      '@tummycrypt/tinyland-auth-pg':
         optional: true
 
   '@tummycrypt/tinyland-auth-pg@0.2.4':
@@ -1336,31 +1339,37 @@ snapshots:
   '@neondatabase/serverless@0.10.4':
     dependencies:
       '@types/pg': 8.11.6
+    optional: true
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@otplib/core@12.0.1': {}
+  '@otplib/core@12.0.1':
+    optional: true
 
   '@otplib/plugin-crypto@12.0.1':
     dependencies:
       '@otplib/core': 12.0.1
+    optional: true
 
   '@otplib/plugin-thirty-two@12.0.1':
     dependencies:
       '@otplib/core': 12.0.1
       thirty-two: 1.0.2
+    optional: true
 
   '@otplib/preset-default@12.0.1':
     dependencies:
       '@otplib/core': 12.0.1
       '@otplib/plugin-crypto': 12.0.1
       '@otplib/plugin-thirty-two': 12.0.1
+    optional: true
 
   '@otplib/preset-v11@12.0.1':
     dependencies:
       '@otplib/core': 12.0.1
       '@otplib/plugin-crypto': 12.0.1
       '@otplib/plugin-thirty-two': 12.0.1
+    optional: true
 
   '@oxc-project/types@0.122.0': {}
 
@@ -1424,13 +1433,14 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tummycrypt/scheduling-kit@0.7.7(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
+  '@tummycrypt/scheduling-kit@0.8.0(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth-pg@0.2.4(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6))(@types/pg@8.11.6)(pg@8.20.0)(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
     dependencies:
-      '@tummycrypt/tinyland-auth-pg': 0.2.4(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)
       drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(pg@8.20.0)
       effect: 3.21.0
       svelte: 5.55.1(@typescript-eslint/types@8.58.0)
       zod: 4.3.6
+    optionalDependencies:
+      '@tummycrypt/tinyland-auth-pg': 0.2.4(@opentelemetry/api@1.9.1)(@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0)))(@types/pg@8.11.6)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -1443,7 +1453,6 @@ snapshots:
       - '@planetscale/database'
       - '@prisma/client'
       - '@tidbcloud/serverless'
-      - '@tummycrypt/tinyland-auth'
       - '@types/better-sqlite3'
       - '@types/pg'
       - '@types/sql.js'
@@ -1456,7 +1465,6 @@ snapshots:
       - kysely
       - mysql2
       - pg
-      - pg-native
       - postgres
       - prisma
       - sql.js
@@ -1495,6 +1503,7 @@ snapshots:
       - prisma
       - sql.js
       - sqlite3
+    optional: true
 
   '@tummycrypt/tinyland-auth@0.2.0(svelte@5.55.1(@typescript-eslint/types@8.58.0))':
     dependencies:
@@ -1504,6 +1513,7 @@ snapshots:
       qrcode: 1.5.4
     optionalDependencies:
       svelte: 5.55.1(@typescript-eslint/types@8.58.0)
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -1581,11 +1591,13 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  ansi-regex@5.0.1: {}
+  ansi-regex@5.0.1:
+    optional: true
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+    optional: true
 
   aria-query@5.3.1: {}
 
@@ -1593,11 +1605,13 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  bcryptjs@2.4.3: {}
+  bcryptjs@2.4.3:
+    optional: true
 
   bintrees@1.0.2: {}
 
-  camelcase@5.3.1: {}
+  camelcase@5.3.1:
+    optional: true
 
   chai@6.2.2: {}
 
@@ -1606,6 +1620,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
+    optional: true
 
   clsx@2.1.1: {}
 
@@ -1614,8 +1629,10 @@ snapshots:
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
+    optional: true
 
-  color-name@1.1.4: {}
+  color-name@1.1.4:
+    optional: true
 
   convert-source-map@2.0.0: {}
 
@@ -1623,7 +1640,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decamelize@1.2.0: {}
+  decamelize@1.2.0:
+    optional: true
 
   denque@2.1.0: {}
 
@@ -1631,7 +1649,8 @@ snapshots:
 
   devalue@5.7.1: {}
 
-  dijkstrajs@1.0.3: {}
+  dijkstrajs@1.0.3:
+    optional: true
 
   drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(pg@8.20.0):
     optionalDependencies:
@@ -1645,7 +1664,8 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  emoji-regex@8.0.0: {}
+  emoji-regex@8.0.0:
+    optional: true
 
   es-module-lexer@2.0.0: {}
 
@@ -1714,11 +1734,13 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+    optional: true
 
   fsevents@2.3.3:
     optional: true
 
-  get-caller-file@2.0.5: {}
+  get-caller-file@2.0.5:
+    optional: true
 
   get-tsconfig@4.13.7:
     dependencies:
@@ -1748,7 +1770,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  is-fullwidth-code-point@3.0.0: {}
+  is-fullwidth-code-point@3.0.0:
+    optional: true
 
   is-reference@3.0.3:
     dependencies:
@@ -1808,6 +1831,7 @@ snapshots:
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
+    optional: true
 
   lodash.defaults@4.2.0: {}
 
@@ -1823,7 +1847,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@5.1.9: {}
+  nanoid@5.1.9:
+    optional: true
 
   obuf@1.1.2: {}
 
@@ -1834,20 +1859,25 @@ snapshots:
       '@otplib/core': 12.0.1
       '@otplib/preset-default': 12.0.1
       '@otplib/preset-v11': 12.0.1
+    optional: true
 
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
+    optional: true
 
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
+    optional: true
 
-  p-try@2.2.0: {}
+  p-try@2.2.0:
+    optional: true
 
   package-manager-detector@1.6.0: {}
 
-  path-exists@4.0.0: {}
+  path-exists@4.0.0:
+    optional: true
 
   pathe@2.0.3: {}
 
@@ -1904,7 +1934,8 @@ snapshots:
 
   playwright-core@1.58.1: {}
 
-  pngjs@5.0.0: {}
+  pngjs@5.0.0:
+    optional: true
 
   postcss@8.5.10:
     dependencies:
@@ -1953,6 +1984,7 @@ snapshots:
       dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
+    optional: true
 
   readline-sync@1.4.10: {}
 
@@ -1962,9 +1994,11 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
-  require-directory@2.1.1: {}
+  require-directory@2.1.1:
+    optional: true
 
-  require-main-filename@2.0.0: {}
+  require-main-filename@2.0.0:
+    optional: true
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -1998,7 +2032,8 @@ snapshots:
 
   semver@7.7.4: {}
 
-  set-blocking@2.0.0: {}
+  set-blocking@2.0.0:
+    optional: true
 
   siginfo@2.0.0: {}
 
@@ -2019,10 +2054,12 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+    optional: true
 
   svelte@5.55.1(@typescript-eslint/types@8.58.0):
     dependencies:
@@ -2049,7 +2086,8 @@ snapshots:
     dependencies:
       bintrees: 1.0.2
 
-  thirty-two@1.0.2: {}
+  thirty-two@1.0.2:
+    optional: true
 
   tinybench@2.9.0: {}
 
@@ -2127,7 +2165,8 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  which-module@2.0.1: {}
+  which-module@2.0.1:
+    optional: true
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -2139,15 +2178,18 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+    optional: true
 
   xtend@4.0.2: {}
 
-  y18n@4.0.3: {}
+  y18n@4.0.3:
+    optional: true
 
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
+    optional: true
 
   yargs@15.4.1:
     dependencies:
@@ -2162,6 +2204,7 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+    optional: true
 
   zimmerframe@1.1.4: {}
 

--- a/src/adapters/acuity/wizard.ts
+++ b/src/adapters/acuity/wizard.ts
@@ -403,18 +403,18 @@ export const createWizardAdapter = (config: WizardAdapterConfig): SchedulingAdap
 		},
 
 		// -----------------------------------------------------------------------
-		// Reservation - not supported (pipeline has graceful fallback)
+		// Advisory soft hold - not supported (pipeline has graceful fallback)
 		// -----------------------------------------------------------------------
 
-		createReservation: () =>
+		softHoldSlot: () =>
 			Effect.fail(
 				Errors.reservation(
 					'BLOCK_FAILED',
-					'Reservations not supported by wizard adapter',
+					'Advisory soft holds are not supported by wizard adapter',
 				),
 			),
 
-		releaseReservation: () => Effect.succeed(undefined),
+		releaseSoftHold: () => Effect.succeed(undefined),
 
 		// -----------------------------------------------------------------------
 		// Write operations - Effect TS middleware

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -24,7 +24,7 @@ export type {
   Booking,
   BookingStatus,
   PaymentStatus,
-  SlotReservation,
+  SlotSoftHold,
   PaymentIntent,
   PaymentResult,
   RefundResult,

--- a/src/shared/remote-adapter.ts
+++ b/src/shared/remote-adapter.ts
@@ -28,7 +28,7 @@ import type {
 	Provider,
 	TimeSlot,
 	AvailableDate,
-	SlotReservation,
+	SlotSoftHold,
 	ClientInfo,
 	SchedulingError,
 	SchedulingResult,
@@ -257,13 +257,18 @@ export const createRemoteWizardAdapter = (config: RemoteAdapterConfig): Scheduli
 	},
 
 	// ---------------------------------------------------------------------------
-	// Reservation - not supported (pipeline has graceful fallback)
+	// Advisory soft hold - not supported (pipeline has graceful fallback)
 	// ---------------------------------------------------------------------------
 
-	createReservation: () =>
-		Effect.fail(Errors.reservation('BLOCK_FAILED', 'Reservations not supported by remote wizard adapter')),
+	softHoldSlot: () =>
+		Effect.fail(
+			Errors.reservation(
+				'BLOCK_FAILED',
+				'Advisory soft holds are not supported by remote wizard adapter',
+			),
+		),
 
-	releaseReservation: () => Effect.succeed(undefined),
+	releaseSoftHold: () => Effect.succeed(undefined),
 
 	// ---------------------------------------------------------------------------
 	// Write operations - proxied to remote wizard


### PR DESCRIPTION
Moves scheduling-bridge to `@tummycrypt/scheduling-kit@^0.8.0` and the advisory soft-hold adapter contract after kit `v0.8.0` landed in npm and bazel-registry. This keeps bridge consumers on one kit API surface before app consumption.