### PR TITLE
Add Redis-backed async bridge prewarm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ That makes this repo central to the migration paper and to the operational beta-
 
 ## Current Tracking
 
-As of `2026-04-25`, the active structural work here is:
+As of `2026-05-08`, the active structural work here is:
 
 - `TIN-89` package, Bazel, CI, publish, and dependency truth across shared
   scheduling packages
@@ -52,11 +52,11 @@ As of `2026-04-25`, the active structural work here is:
 
 Operationally relevant truth:
 
-- current package metadata is `@tummycrypt/scheduling-bridge` `0.4.10`
-- `0.4.10` depends on `@tummycrypt/scheduling-kit ^0.7.7`
-- as of `2026-05-06`, the package metadata is ahead of the last published
-  release so scheduling-kit dependency freshness can be validated before the
-  next tag/publish edge
+- current package metadata is `@tummycrypt/scheduling-bridge` `0.5.2`
+- `0.5.2` depends on `@tummycrypt/scheduling-kit ^0.8.0`
+- the `0.5.x` line is the async bridge redesign lane: async booking jobs,
+  availability snapshots, Redis/Postgres async stores, and request-path
+  availability prewarm enqueueing
 - package metadata, git tags, npm dist-tags, GitHub releases, and deployed
   bridge runtime tuples remain separate authority surfaces and should be
   verified explicitly
@@ -73,8 +73,9 @@ Current provider truth:
 
 - K8s/container execution is the accepted next-production bridge route and is
   the current K8s shadow runtime for MassageIthaca scheduling-bridge traffic.
-- Modal remains legacy proofing/fallback context, and may still serve stable
-  live consumer traffic until that traffic is deliberately moved to K8s.
+- Modal remains legacy proofing context only. The forward production path is
+  K8s-native bridge execution; do not re-enable automatic Modal deploys without
+  reopening the provider-spend/runtime decision.
 - Cluster state, tailnet exposure, and public-edge routing are infrastructure
   concerns outside this repo.
 - Docker/container execution must mirror the same built Node entrypoint so K8s
@@ -102,6 +103,18 @@ entrypoint and runtime assumptions as every other provider.
 
 If Modal, Docker, and K8s drift from the actual Node entrypoint, that is an
 operational bug.
+
+K8s async runtime truth:
+
+- `BRIDGE_DATABASE_URL` is the strict durable async queue/snapshot store when
+  Postgres is configured.
+- `REDIS_URL` is also a valid K8s async store when Postgres is absent; it backs
+  both the read cache and the Redis job/snapshot store.
+- `BRIDGE_INLINE_WORKER_ENABLED` defaults on when Postgres or Redis is
+  configured, so a single HTTP deployment can drain queued jobs until a
+  separate worker deployment exists.
+- request-path date/slot prewarm must enqueue async refresh jobs; browser
+  scraping for prewarm is worker-owned, not request-owned.
 
 ### Release Coordination
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.1",
+    version = "0.5.2",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.1",
+    version = "0.5.2",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,13 @@ dashboard state when `/health` is available.
 |----------|----------|---------|-------------|
 | `PORT` | No | `3001` | Server port |
 | `ACUITY_BASE_URL` | No | `https://example.as.me` | Acuity scheduling page URL |
-| `BRIDGE_DATABASE_URL` | For async K8s runtime | -- | Postgres queue/snapshot store for async jobs |
+| `BRIDGE_DATABASE_URL` | For strict async runtime | -- | Postgres queue/snapshot store for async jobs; takes precedence over Redis |
 | `BRIDGE_DATABASE_SSL` | No | `false` | Enable SSL for `BRIDGE_DATABASE_URL` |
 | `BRIDGE_DATABASE_MIGRATE` | No | `true` | Run async queue/snapshot schema creation at startup |
+| `REDIS_URL` | For K8s read cache / Redis async runtime | -- | Redis read cache plus async queue/snapshot store when `BRIDGE_DATABASE_URL` is unset |
+| `REDIS_PASSWORD` | No | -- | Password for `REDIS_URL` |
+| `BRIDGE_REDIS_ASYNC_PREFIX` | No | `bridge-async:v1` | Redis key prefix for async jobs and snapshots |
+| `BRIDGE_INLINE_WORKER_ENABLED` | No | `true` when Postgres or Redis is configured | Drain async jobs inside the HTTP container; set `false` only when a separate worker deployment is active |
 | `BRIDGE_WORKER_POLL_MS` | No | `1000` | Worker queue poll interval |
 | `BRIDGE_WORKER_BATCH_SIZE` | No | `5` | Maximum jobs drained per worker poll |
 | `AUTH_TOKEN` | Recommended | -- | Bearer token for all endpoints (except /health) |
@@ -96,6 +100,7 @@ dashboard state when `/health` is available.
 | `SERVICES_JSON` | No | -- | Optional static service catalog to bypass live Acuity reads |
 | `ACUITY_SERVICE_CACHE_TTL_MS` | No | `300000` | TTL for cached live service catalogs before BUSINESS/scraper refresh |
 | `ACUITY_URL_READ_NETWORK_IDLE_MS` | No | `1500` | Bounded post-navigation network-idle settle for direct URL availability reads; set `0` to skip |
+| `ACUITY_DATE_PREWARM_MONTHS` | No | `1` | Number of future months queued for async date refresh after a successful date read; max `3`, set `0` to disable |
 | `ACUITY_SLOT_PREWARM_LIMIT` | No | `1` | Number of first available dates to warm in the slots cache after a successful Acuity dates read; max `3`, set `0` to disable |
 | `SCHEDULING_BRIDGE_SLOT_PROFILE_THRESHOLD_MS` | No | `1500` | Threshold in ms for logging long-tail slot-read profile events |
 | `SCHEDULING_BRIDGE_PROFILE_SLOT_READS` | No | `false` | Force logging of slot-read profile events even when under threshold |

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.1`
-- Bazel module version: `0.5.1`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.1`
+- package version: `0.5.2`
+- Bazel module version: `0.5.2`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.2`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/async/redis-store.test.ts
+++ b/src/async/redis-store.test.ts
@@ -1,0 +1,133 @@
+import IORedisMock from 'ioredis-mock';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createRedisBridgeAsyncStore } from './redis-store.js';
+import type { BridgeJobCommand } from './types.js';
+
+const profile = {
+	backend: 'acuity' as const,
+	baseUrl: 'https://example.as.me',
+};
+
+const datesJob: BridgeJobCommand = {
+	kind: 'availability_dates_refresh',
+	command: {
+		serviceId: '53178494',
+		month: '2026-06',
+		adapterProfile: profile,
+	},
+};
+
+const createStore = (redis: IORedisMock) =>
+	createRedisBridgeAsyncStore({
+		client: redis as never,
+		keyPrefix: `test-bridge-async:${Date.now()}:${Math.random()}`,
+	});
+
+describe('RedisBridgeAsyncStore', () => {
+	let redis: IORedisMock;
+
+	beforeEach(async () => {
+		redis = new IORedisMock();
+		await redis.flushall();
+	});
+
+	it('deduplicates enqueue by idempotency key across store instances', async () => {
+		const firstStore = createStore(redis);
+		const secondStore = createRedisBridgeAsyncStore({
+			client: redis as never,
+			keyPrefix: 'test-bridge-async:dedupe',
+		});
+		const thirdStore = createRedisBridgeAsyncStore({
+			client: redis as never,
+			keyPrefix: 'test-bridge-async:dedupe',
+		});
+		await firstStore.clear?.();
+
+		const first = await secondStore.enqueueJob(datesJob, {
+			idempotencyKey: 'dates:53178494:2026-06',
+		});
+		const second = await thirdStore.enqueueJob(datesJob, {
+			idempotencyKey: 'dates:53178494:2026-06',
+		});
+
+		expect(second.operationId).toBe(first.operationId);
+		expect(second.status).toBe('queued');
+	});
+
+	it('leases a queued job to only one worker and re-exposes expired leases', async () => {
+		const store = createStore(redis);
+		const job = await store.enqueueJob(datesJob);
+		const leasedUntil = new Date(Date.now() + 60_000);
+
+		const leaseA = await store.markJobRunning(job.operationId, {
+			workerId: 'worker-a',
+			leasedUntil,
+		});
+		const leaseB = await store.markJobRunning(job.operationId, {
+			workerId: 'worker-b',
+			leasedUntil,
+		});
+
+		expect(leaseA).toMatchObject({
+			operationId: job.operationId,
+			status: 'running',
+			leasedBy: 'worker-a',
+		});
+		expect(leaseB).toBeNull();
+
+		await expect(
+			store.listReadyJobs(10, new Date(leasedUntil.getTime() - 1000)),
+		).resolves.toHaveLength(0);
+		await expect(
+			store.listReadyJobs(10, new Date(leasedUntil.getTime() + 1000)),
+		).resolves.toMatchObject([{ operationId: job.operationId }]);
+	});
+
+	it('stores versioned snapshots shared across store instances', async () => {
+		const keyPrefix = 'test-bridge-async:snapshots';
+		const firstStore = createRedisBridgeAsyncStore({
+			client: redis as never,
+			keyPrefix,
+		});
+		const secondStore = createRedisBridgeAsyncStore({
+			client: redis as never,
+			keyPrefix,
+		});
+		await firstStore.clear?.();
+
+		const first = await firstStore.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: '53178494',
+			scope: '2026-06',
+			adapterProfile: profile,
+			value: [{ date: '2026-06-15' }],
+			observedAt: '2026-05-08T12:00:00.000Z',
+			staleAt: '2026-05-08T12:05:00.000Z',
+			expiresAt: '2026-05-08T12:30:00.000Z',
+		});
+		const second = await secondStore.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: '53178494',
+			scope: '2026-06',
+			adapterProfile: profile,
+			value: [{ date: '2026-06-16' }],
+			observedAt: '2026-05-08T12:01:00.000Z',
+			staleAt: '2026-05-08T12:06:00.000Z',
+			expiresAt: '2026-05-08T12:31:00.000Z',
+		});
+
+		expect(second.snapshotId).toBe(first.snapshotId);
+		expect(second.version).toBe(2);
+		await expect(
+			firstStore.getAvailabilitySnapshot({
+				kind: 'dates',
+				serviceId: '53178494',
+				scope: '2026-06',
+				baseUrl: profile.baseUrl,
+			}),
+		).resolves.toMatchObject({
+			version: 2,
+			value: [{ date: '2026-06-16' }],
+		});
+	});
+});

--- a/src/async/redis-store.ts
+++ b/src/async/redis-store.ts
@@ -1,0 +1,310 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import { Redis as IORedisImpl } from 'ioredis';
+import type { Redis as IORedis, RedisOptions } from 'ioredis';
+import type {
+	AvailabilitySnapshot,
+	AvailabilitySnapshotQuery,
+	BridgeJobCommand,
+	BridgeJobFailure,
+	BridgeJobRecord,
+	BridgeJobResult,
+	EnqueueBridgeJobOptions,
+} from './types.js';
+import type { BridgeAsyncStore } from './store.js';
+
+const LUA_CAS_DEL = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end`;
+
+const DEFAULT_PREFIX = 'bridge-async:v1';
+const DEFAULT_JOB_TTL_SECONDS = 7 * 24 * 60 * 60;
+const DEFAULT_SNAPSHOT_TTL_SECONDS = 24 * 60 * 60;
+
+export interface RedisBridgeAsyncStoreOptions {
+	readonly client?: IORedis;
+	readonly url?: string;
+	readonly redisOptions?: RedisOptions;
+	readonly keyPrefix?: string;
+	readonly jobTtlSeconds?: number;
+	readonly snapshotTtlSeconds?: number;
+}
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const nowIso = (now = new Date()): string => now.toISOString();
+
+const encodeKeyPart = (value: string): string => Buffer.from(value).toString('base64url');
+
+const snapshotStorageKey = (prefix: string, query: AvailabilitySnapshotQuery): string =>
+	[
+		prefix,
+		'snapshot',
+		query.kind,
+		encodeKeyPart(query.baseUrl),
+		encodeKeyPart(query.serviceId),
+		encodeKeyPart(query.scope),
+	].join(':');
+
+const jobStorageKey = (prefix: string, operationId: string): string =>
+	`${prefix}:job:${operationId}`;
+
+const idempotencyStorageKey = (prefix: string, idempotencyKey: string): string =>
+	`${prefix}:idempotency:${encodeKeyPart(idempotencyKey)}`;
+
+const readyJobsKey = (prefix: string): string => `${prefix}:jobs:ready`;
+
+const claimLockKey = (prefix: string, operationId: string): string =>
+	`${prefix}:claim:${operationId}`;
+
+const readJson = async <A>(client: IORedis, key: string): Promise<A | null> => {
+	const raw = await client.get(key);
+	return raw ? (JSON.parse(raw) as A) : null;
+};
+
+const writeJson = async <A>(
+	client: IORedis,
+	key: string,
+	value: A,
+	ttlSeconds: number,
+): Promise<void> => {
+	await client.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+};
+
+export const createRedisBridgeAsyncStore = (
+	options: RedisBridgeAsyncStoreOptions,
+): BridgeAsyncStore & {
+	close?: () => Promise<void>;
+	ready: () => Promise<void>;
+} => {
+	if (!options.client && !options.url) {
+		throw new Error('createRedisBridgeAsyncStore requires client or url');
+	}
+
+	const ownsClient = !options.client;
+	const client = options.client ?? new IORedisImpl(options.url!, options.redisOptions ?? {});
+	const prefix = options.keyPrefix ?? DEFAULT_PREFIX;
+	const jobTtlSeconds = options.jobTtlSeconds ?? DEFAULT_JOB_TTL_SECONDS;
+	const snapshotTtlSeconds = options.snapshotTtlSeconds ?? DEFAULT_SNAPSHOT_TTL_SECONDS;
+
+	const readJob = (operationId: string): Promise<BridgeJobRecord | null> =>
+		readJson<BridgeJobRecord>(client, jobStorageKey(prefix, operationId));
+
+	const writeJob = (job: BridgeJobRecord): Promise<void> =>
+		writeJson(client, jobStorageKey(prefix, job.operationId), job, jobTtlSeconds);
+
+	const store: BridgeAsyncStore & {
+		close?: () => Promise<void>;
+		ready: () => Promise<void>;
+	} = {
+		async enqueueJob(job: BridgeJobCommand, options?: EnqueueBridgeJobOptions) {
+			if (options?.idempotencyKey) {
+				const idempotencyKey = idempotencyStorageKey(prefix, options.idempotencyKey);
+				const operationId = randomUUID();
+				const claimed = await client.set(idempotencyKey, operationId, 'EX', jobTtlSeconds, 'NX');
+				if (claimed !== 'OK') {
+					const existingOperationId = await client.get(idempotencyKey);
+					if (existingOperationId) {
+						const existing = await readJob(existingOperationId);
+						if (existing) return existing;
+					}
+					await client.del(idempotencyKey);
+					return this.enqueueJob(job, options);
+				}
+
+				const timestamp = nowIso();
+				const record: BridgeJobRecord = {
+					operationId,
+					kind: job.kind,
+					status: 'queued',
+					command: clone(job.command),
+					idempotencyKey: options.idempotencyKey,
+					attempts: 0,
+					createdAt: timestamp,
+					updatedAt: timestamp,
+				};
+				await writeJob(record);
+				await client.zadd(readyJobsKey(prefix), Date.parse(record.createdAt), operationId);
+				return clone(record);
+			}
+
+			const operationId = randomUUID();
+			const timestamp = nowIso();
+			const record: BridgeJobRecord = {
+				operationId,
+				kind: job.kind,
+				status: 'queued',
+				command: clone(job.command),
+				attempts: 0,
+				createdAt: timestamp,
+				updatedAt: timestamp,
+			};
+			await writeJob(record);
+			await client.zadd(readyJobsKey(prefix), Date.parse(record.createdAt), operationId);
+			return clone(record);
+		},
+
+		async getJob(operationId) {
+			const found = await readJob(operationId);
+			return found ? clone(found) : null;
+		},
+
+		async listReadyJobs(limit, now = new Date()) {
+			const operationIds = await client.zrangebyscore(
+				readyJobsKey(prefix),
+				'-inf',
+				String(now.getTime()),
+			);
+			const ready: BridgeJobRecord[] = [];
+			for (const operationId of operationIds) {
+				if (ready.length >= limit) break;
+				const job = await readJob(operationId);
+				if (!job) {
+					await client.zrem(readyJobsKey(prefix), operationId);
+					continue;
+				}
+				if (job.status === 'queued') {
+					ready.push(clone(job));
+					continue;
+				}
+				if (
+					(job.status === 'leased' || job.status === 'running') &&
+					job.leasedUntil &&
+					Date.parse(job.leasedUntil) <= now.getTime()
+				) {
+					ready.push(clone(job));
+					continue;
+				}
+				await client.zrem(readyJobsKey(prefix), operationId);
+			}
+			return ready;
+		},
+
+		async markJobRunning(operationId, lease) {
+			const token = randomBytes(16).toString('hex');
+			const lockKey = claimLockKey(prefix, operationId);
+			const claimed = await client.set(lockKey, token, 'PX', 5000, 'NX');
+			if (claimed !== 'OK') return null;
+
+			try {
+				const found = await readJob(operationId);
+				if (!found) return null;
+				if (found.status !== 'queued' && found.status !== 'leased' && found.status !== 'running') {
+					await client.zrem(readyJobsKey(prefix), operationId);
+					return null;
+				}
+				if (
+					found.status !== 'queued' &&
+					found.leasedUntil &&
+					Date.parse(found.leasedUntil) > Date.now()
+				) {
+					return null;
+				}
+
+				const next: BridgeJobRecord = {
+					...found,
+					status: 'running',
+					attempts: found.attempts + 1,
+					leasedBy: lease.workerId,
+					leasedUntil: lease.leasedUntil.toISOString(),
+					updatedAt: nowIso(),
+				};
+				await writeJob(next);
+				await client.zadd(readyJobsKey(prefix), lease.leasedUntil.getTime(), operationId);
+				return clone(next);
+			} finally {
+				await client.eval(LUA_CAS_DEL, 1, lockKey, token).catch(() => undefined);
+			}
+		},
+
+		async completeJob(operationId, result) {
+			const found = await readJob(operationId);
+			if (!found) return null;
+			const next: BridgeJobRecord = {
+				...found,
+				status: 'succeeded',
+				result: clone(result),
+				failure: undefined,
+				updatedAt: nowIso(),
+			};
+			await writeJob(next);
+			await client.zrem(readyJobsKey(prefix), operationId);
+			return clone(next);
+		},
+
+		async failJob(operationId, failure) {
+			const found = await readJob(operationId);
+			if (!found) return null;
+			const next: BridgeJobRecord = {
+				...found,
+				status: failure.status,
+				failure: clone(failure),
+				updatedAt: nowIso(),
+			};
+			await writeJob(next);
+			await client.zrem(readyJobsKey(prefix), operationId);
+			return clone(next);
+		},
+
+		async requeueJob(operationId, failure?: BridgeJobFailure) {
+			const found = await readJob(operationId);
+			if (!found) return null;
+			const next: BridgeJobRecord = {
+				...found,
+				status: 'queued',
+				failure: failure ? clone(failure) : found.failure,
+				leasedBy: undefined,
+				leasedUntil: undefined,
+				updatedAt: nowIso(),
+			};
+			await writeJob(next);
+			await client.zadd(readyJobsKey(prefix), Date.now(), operationId);
+			return clone(next);
+		},
+
+		async upsertAvailabilitySnapshot(snapshot) {
+			const query: AvailabilitySnapshotQuery = {
+				kind: snapshot.kind,
+				serviceId: snapshot.serviceId,
+				scope: snapshot.scope,
+				baseUrl: snapshot.adapterProfile.baseUrl,
+			};
+			const key = snapshotStorageKey(prefix, query);
+			const previous = await readJson<AvailabilitySnapshot>(client, key);
+			const next: AvailabilitySnapshot = {
+				...clone(snapshot),
+				snapshotId: previous?.snapshotId ?? randomUUID(),
+				version: (previous?.version ?? 0) + 1,
+			};
+			await writeJson(client, key, next, snapshotTtlSeconds);
+			return clone(next);
+		},
+
+		async getAvailabilitySnapshot(query) {
+			const found = await readJson<AvailabilitySnapshot>(client, snapshotStorageKey(prefix, query));
+			return found ? clone(found) : null;
+		},
+
+		async clear() {
+			const keys = await client.keys(`${prefix}:*`);
+			if (keys.length > 0) await client.del(...keys);
+		},
+
+		async ready() {
+			await client.ping();
+		},
+	};
+
+	if (ownsClient) {
+		store.close = async () => {
+			await client.quit().then(
+				() => undefined,
+				() => undefined,
+			);
+		};
+	}
+
+	return store;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,10 @@ export {
 	type PostgresBridgeAsyncStoreOptions,
 } from './async/postgres-store.js';
 export {
+	createRedisBridgeAsyncStore,
+	type RedisBridgeAsyncStoreOptions,
+} from './async/redis-store.js';
+export {
 	BridgeJobExecutionError,
 	drainReadyBridgeJobs,
 	executeBridgeJob,

--- a/src/server/__tests__/async-endpoints.test.ts
+++ b/src/server/__tests__/async-endpoints.test.ts
@@ -1,4 +1,5 @@
 import { type AddressInfo } from 'node:net';
+import IORedisMock from 'ioredis-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createInMemoryBridgeAsyncStore } from '../../async/store.js';
 
@@ -27,6 +28,7 @@ const listen = async (store = createInMemoryBridgeAsyncStore()) => {
 	const {
 		server,
 		__setBridgeAsyncStoreForTest,
+		__setEffectRunnerForTest,
 	} = await import('../handler.js');
 	__setBridgeAsyncStoreForTest(store);
 	await new Promise<void>((resolve) => {
@@ -37,6 +39,7 @@ const listen = async (store = createInMemoryBridgeAsyncStore()) => {
 		server,
 		store,
 		baseUrl: `http://127.0.0.1:${address.port}`,
+		setEffectRunnerForTest: __setEffectRunnerForTest,
 	};
 };
 
@@ -62,6 +65,9 @@ describe('bridge async protocol endpoints', () => {
 		delete process.env.ACUITY_BASE_URL;
 		delete process.env.SERVICES_JSON;
 		delete process.env.ACUITY_BYPASS_COUPON;
+		delete process.env.ACUITY_DATE_PREWARM_MONTHS;
+		delete process.env.ACUITY_SLOT_PREWARM_LIMIT;
+		vi.doUnmock('ioredis');
 	});
 
 	it('enqueues paid booking commands without running browser automation in the request', async () => {
@@ -173,5 +179,61 @@ describe('bridge async protocol endpoints', () => {
 				value: [{ date: '2026-06-15' }],
 			},
 		});
+	});
+
+	it('queues availability prewarm jobs instead of running prewarm browser work on the request path', async () => {
+		vi.doMock('ioredis', () => ({
+			Redis: IORedisMock,
+			default: IORedisMock,
+		}));
+		process.env.REDIS_URL = 'redis://localhost:6379/0';
+		process.env.ACUITY_DATE_PREWARM_MONTHS = '1';
+		process.env.ACUITY_SLOT_PREWARM_LIMIT = '1';
+		const store = createInMemoryBridgeAsyncStore();
+		const running = await listen(store);
+		activeServer = running.server;
+		running.setEffectRunnerForTest(async () => ({
+			ok: true,
+			value: [{ date: '2026-06-15' }],
+		}));
+
+		const response = await fetch(`${running.baseUrl}/availability/dates`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				serviceId: service.id,
+				serviceName: service.name,
+				startDate: '2026-06-01',
+			}),
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({
+			success: true,
+			data: [{ date: '2026-06-15' }],
+		});
+
+		await new Promise((resolve) => setImmediate(resolve));
+		const readyJobs = await store.listReadyJobs(10);
+
+		expect(readyJobs).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: 'availability_dates_refresh',
+					command: expect.objectContaining({
+						serviceId: service.id,
+						month: '2026-07',
+					}),
+				}),
+				expect.objectContaining({
+					kind: 'availability_slots_refresh',
+					command: expect.objectContaining({
+						serviceId: service.id,
+						date: '2026-06-15',
+					}),
+				}),
+			]),
+		);
 	});
 });

--- a/src/server/__tests__/availability-dates-cache.test.ts
+++ b/src/server/__tests__/availability-dates-cache.test.ts
@@ -2,6 +2,7 @@ import { type AddressInfo } from 'node:net';
 import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BrowserError } from '../../adapters/acuity/errors.js';
+import { createInMemoryBridgeAsyncStore } from '../../async/store.js';
 
 const readViaUrlMocks = vi.hoisted(() => ({
 	readDatesViaUrl: vi.fn(),
@@ -97,8 +98,11 @@ const listen = async () => {
 		__runEffectWithoutBrowserForTest,
 		__setEffectRunnerForTest,
 		__setAcuityStepOverridesForTest,
+		__setBridgeAsyncStoreForTest,
 	} = await import('../handler.js');
+	const store = createInMemoryBridgeAsyncStore();
 	__setEffectRunnerForTest(__runEffectWithoutBrowserForTest);
+	__setBridgeAsyncStoreForTest(store);
 	__setAcuityStepOverridesForTest({
 		readDatesViaUrl: readViaUrlMocks.readDatesViaUrl,
 		readSlotsViaUrl: readViaUrlMocks.readSlotsViaUrl,
@@ -111,6 +115,7 @@ const listen = async () => {
 	const address = server.address() as AddressInfo;
 	return {
 		server,
+		store,
 		baseUrl: `http://127.0.0.1:${address.port}`,
 	};
 };
@@ -164,7 +169,7 @@ describe('POST /availability/dates cache prewarm', () => {
 		delete process.env.AUTH_TOKEN;
 	});
 
-	it('warms the next month after a successful date request', async () => {
+	it('queues the next month after a successful date request', async () => {
 		const running = await listen();
 		activeServer = running.server;
 
@@ -176,39 +181,40 @@ describe('POST /availability/dates cache prewarm', () => {
 			data: [{ date: '2026-07-15' }],
 		});
 
-		await vi.waitFor(
-			() => {
-				expect(readViaUrlMocks.readDatesViaUrl).toHaveBeenCalledWith(
-					serviceId,
-					'2026-08',
-				);
-				expect(
-					redisState.values.get(
-						`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
-					),
-				).toBe(JSON.stringify([{ date: '2026-08-15' }]));
-			},
-			{ timeout: 5_000 },
+		await new Promise((resolve) => setImmediate(resolve));
+		expect(readViaUrlMocks.readDatesViaUrl).toHaveBeenCalledWith(
+			serviceId,
+			'2026-07',
 		);
+		expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalledWith(
+			serviceId,
+			'2026-08',
+		);
+		await expect(running.store.listReadyJobs(10)).resolves.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: 'availability_dates_refresh',
+					command: expect.objectContaining({
+						serviceId,
+						month: '2026-08',
+					}),
+				}),
+			]),
+		);
+		expect(
+			redisState.values.get(
+				`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
+			),
+		).toBeUndefined();
 	});
 
-	it('serves a prewarmed month from Redis without rereading Acuity for that month', async () => {
+	it('serves a cached month from Redis and queues the following month', async () => {
+		redisState.values.set(
+			`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
+			JSON.stringify([{ date: '2026-08-15' }]),
+		);
 		const running = await listen();
 		activeServer = running.server;
-
-		await postAvailabilityDates(running.baseUrl, '2026-07-01');
-		await vi.waitFor(
-			() => {
-				expect(
-					redisState.values.get(
-						`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
-					),
-				).toBe(JSON.stringify([{ date: '2026-08-15' }]));
-			},
-			{ timeout: 5_000 },
-		);
-
-		readViaUrlMocks.readDatesViaUrl.mockClear();
 
 		const response = await postAvailabilityDates(running.baseUrl, '2026-08-01');
 
@@ -221,15 +227,17 @@ describe('POST /availability/dates cache prewarm', () => {
 			serviceId,
 			'2026-08',
 		);
-		await vi.waitFor(
-			() => {
-				expect(
-					redisState.values.get(
-						`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-09`,
-					),
-				).toBe(JSON.stringify([{ date: '2026-09-15' }]));
-			},
-			{ timeout: 5_000 },
+		await new Promise((resolve) => setImmediate(resolve));
+		await expect(running.store.listReadyJobs(10)).resolves.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: 'availability_dates_refresh',
+					command: expect.objectContaining({
+						serviceId,
+						month: '2026-09',
+					}),
+				}),
+			]),
 		);
 	});
 

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -92,6 +92,7 @@ import {
 	type BridgeAsyncStore,
 } from '../async/store.js';
 import { createPostgresBridgeAsyncStore } from '../async/postgres-store.js';
+import { createRedisBridgeAsyncStore } from '../async/redis-store.js';
 import type {
 	AvailabilitySnapshotKind,
 	BridgeAdapterProfile,
@@ -99,6 +100,10 @@ import type {
 	BridgeJobRecord,
 	EnqueueBridgeJobResponse,
 } from '../async/types.js';
+import {
+	createAcuityBridgeJobExecutor,
+	runBridgeWorkerLoop,
+} from './worker.js';
 import type {
 	Booking,
 	BookingRequest,
@@ -381,6 +386,12 @@ export const __setEffectRunnerForTest = (runner: RunEffect | null) => {
 const BRIDGE_DATABASE_URL = process.env.BRIDGE_DATABASE_URL;
 const REDIS_URL = process.env.REDIS_URL;
 const REDIS_PASSWORD = process.env.REDIS_PASSWORD;
+const BRIDGE_INLINE_WORKER_ENABLED = (() => {
+	const raw = process.env.BRIDGE_INLINE_WORKER_ENABLED;
+	if (raw === 'true') return true;
+	if (raw === 'false') return false;
+	return Boolean(BRIDGE_DATABASE_URL || REDIS_URL);
+})();
 
 const redisClient: IORedis | null = REDIS_URL
 	? new IORedisImpl(REDIS_URL, {
@@ -461,6 +472,23 @@ const createBridgeAsyncStore = (): BridgeAsyncStore => {
 		});
 		return store;
 	}
+	if (redisClient) {
+		const store = createRedisBridgeAsyncStore({
+			client: redisClient,
+			keyPrefix: process.env.BRIDGE_REDIS_ASYNC_PREFIX,
+		});
+		void store.ready().catch((error) => {
+			logEvent('ERROR', 'Bridge async Redis store readiness failed', {
+				event: 'bridge_async_store_ready_failed',
+				error: describeLogValue(error),
+			});
+		});
+		logEvent('INFO', 'Bridge async store selected', {
+			event: 'bridge_async_store_selected',
+			mode: 'redis',
+		});
+		return store;
+	}
 	logEvent('INFO', 'Bridge async store selected', {
 		event: 'bridge_async_store_selected',
 		mode: 'memory',
@@ -469,8 +497,42 @@ const createBridgeAsyncStore = (): BridgeAsyncStore => {
 };
 
 let bridgeAsyncStore: BridgeAsyncStore = createBridgeAsyncStore();
+let inlineWorkerAbortController: AbortController | null = null;
+
+const startInlineWorker = () => {
+	if (!BRIDGE_INLINE_WORKER_ENABLED || inlineWorkerAbortController) return;
+	inlineWorkerAbortController = new AbortController();
+	const workerId = `${process.env.HOSTNAME ?? `pid-${process.pid}`}:inline`;
+	void runBridgeWorkerLoop(
+		bridgeAsyncStore,
+		createAcuityBridgeJobExecutor({ redisClient }),
+		{
+			workerId,
+			signal: inlineWorkerAbortController.signal,
+		},
+	).catch((error) => {
+		if (inlineWorkerAbortController?.signal.aborted) return;
+		logEvent('ERROR', 'Inline bridge worker failed', {
+			event: 'bridge_inline_worker_failed',
+			workerId,
+			error: describeLogValue(error),
+		});
+	});
+	logEvent('INFO', 'Inline bridge worker started', {
+		event: 'bridge_inline_worker_started',
+		workerId,
+		store: BRIDGE_DATABASE_URL ? 'postgres' : redisClient ? 'redis' : 'memory',
+	});
+};
+
+const stopInlineWorker = () => {
+	if (!inlineWorkerAbortController) return;
+	inlineWorkerAbortController.abort();
+	inlineWorkerAbortController = null;
+};
 
 export const __setBridgeAsyncStoreForTest = (store: BridgeAsyncStore | null) => {
+	stopInlineWorker();
 	if (closeBridgeAsyncStore) {
 		void closeBridgeAsyncStore().catch(() => undefined);
 		closeBridgeAsyncStore = null;
@@ -602,9 +664,67 @@ const recordAvailabilitySnapshot = async (
 	}
 };
 
+const enqueueAvailabilityPrewarmJob = (
+	context: RequestContext,
+	options: {
+		readonly kind: AvailabilitySnapshotKind;
+		readonly serviceId: string;
+		readonly serviceName?: string;
+		readonly scope: string;
+	},
+) => {
+	const idempotencyKey = [
+		'availability-prewarm',
+		ACUITY_BASE_URL,
+		options.kind,
+		options.serviceId,
+		options.scope,
+	].join(':');
+
+	const job: BridgeJobCommand = options.kind === 'dates'
+		? {
+				kind: 'availability_dates_refresh',
+				command: {
+					serviceId: options.serviceId,
+					serviceName: options.serviceName,
+					month: options.scope,
+					adapterProfile: adapterProfile(),
+				},
+			}
+		: {
+				kind: 'availability_slots_refresh',
+				command: {
+					serviceId: options.serviceId,
+					serviceName: options.serviceName,
+					date: options.scope,
+					adapterProfile: adapterProfile(),
+				},
+			};
+
+	void bridgeAsyncStore.enqueueJob(job, { idempotencyKey }).then((record) => {
+		logRequestEvent('INFO', 'Availability prewarm job enqueued', context, {
+			event: 'availability_prewarm_job_enqueued',
+			operationId: record.operationId,
+			status: record.status,
+			kind: options.kind,
+			serviceId: options.serviceId,
+			scope: options.scope,
+		});
+	}).catch((error) => {
+		logRequestEvent('WARN', 'Availability prewarm enqueue failed', context, {
+			event: 'availability_prewarm_enqueue_failed',
+			kind: options.kind,
+			serviceId: options.serviceId,
+			scope: options.scope,
+			error: describeLogValue(error),
+		});
+	});
+};
+
 const scheduleDatePrewarm = (
 	context: RequestContext,
 	serviceId: string,
+	serviceName: string | undefined,
 	currentMonth: string | undefined,
 ): void => {
 	if (!redisClient || DATE_PREWARM_MONTHS <= 0 || !isAcuityAppointmentTypeId(serviceId)) {
@@ -612,28 +732,11 @@ const scheduleDatePrewarm = (
 	}
 
 	for (const month of selectDatePrewarmMonths(currentMonth, DATE_PREWARM_MONTHS)) {
-		const cacheKey = buildAvailabilityDatesCacheKey(ACUITY_BASE_URL, serviceId, month);
-		void runCachedBridgeRead(context, 'availability_dates', cacheKey, () =>
-			runEffect(acuitySteps.readDatesViaUrl(serviceId, month)),
-		).then((result) => {
-			if (!result.ok) {
-				logRequestEvent('WARN', 'Availability dates prewarm failed', context, {
-					event: 'availability_dates_prewarm_failed',
-					serviceId,
-					targetMonth: month,
-					errorTag: result.error._tag,
-					errorCode: 'code' in result.error ? result.error.code : 'UNKNOWN',
-					errorMessage: 'message' in result.error ? result.error.message : 'Date prewarm failed',
-				});
-				return;
-			}
-
-			logRequestEvent('INFO', 'Availability dates prewarm completed', context, {
-				event: 'availability_dates_prewarm_completed',
-				serviceId,
-				targetMonth: month,
-				dateCount: Array.isArray(result.value) ? result.value.length : undefined,
-			});
+		enqueueAvailabilityPrewarmJob(context, {
+			kind: 'dates',
+			serviceId,
+			serviceName,
+			scope: month,
 		});
 	}
 };
@@ -641,6 +744,7 @@ const scheduleDatePrewarm = (
 const scheduleSlotPrewarm = (
 	context: RequestContext,
 	serviceId: string,
+	serviceName: string | undefined,
 	dates: readonly { date?: unknown }[],
 ): void => {
 	if (!redisClient || SLOT_PREWARM_LIMIT <= 0 || !isAcuityAppointmentTypeId(serviceId)) {
@@ -657,39 +761,14 @@ const scheduleSlotPrewarm = (
 		limit: SLOT_PREWARM_LIMIT,
 	});
 
-	void (async () => {
-		for (const date of prewarmDates) {
-			const startedAt = Date.now();
-			const cacheKey = buildAvailabilitySlotsCacheKey(ACUITY_BASE_URL, serviceId, date);
-			const result = await runCachedBridgeRead(context, 'availability_slots', cacheKey, () =>
-				runEffect(
-					acuitySteps.readSlotsViaUrl(
-						serviceId,
-						date,
-						createSlotReadTelemetryContext(context, 'availability_slots_prewarm'),
-					),
-				),
-			);
-
-			logRequestEvent(result.ok ? 'INFO' : 'WARN', 'Availability slot prewarm completed', context, {
-				event: 'availability_slot_prewarm_completed',
-				serviceId,
-				date,
-				durationMs: Date.now() - startedAt,
-				ok: result.ok,
-				...(result.ok
-					? { slots: Array.isArray(result.value) ? result.value.length : undefined }
-					: { error: describeLogValue(result.error) }),
-			});
-		}
-	})().catch((error) => {
-		logRequestEvent('ERROR', 'Availability slot prewarm failed', context, {
-			event: 'availability_slot_prewarm_failed',
+	for (const date of prewarmDates) {
+		enqueueAvailabilityPrewarmJob(context, {
+			kind: 'slots',
 			serviceId,
-			dates: prewarmDates,
-			error: describeLogValue(error),
+			serviceName,
+			scope: date,
 		});
-	});
+	}
 };
 
 // =============================================================================
@@ -856,8 +935,8 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 		Array.isArray(result.value) ? result.value : [],
 		context,
 	);
-	scheduleDatePrewarm(context, body.serviceId, targetMonth);
-	scheduleSlotPrewarm(context, body.serviceId, result.value);
+	scheduleDatePrewarm(context, body.serviceId, body.serviceName, targetMonth);
+	scheduleSlotPrewarm(context, body.serviceId, body.serviceName, result.value);
 	sendSuccess(res, result.value);
 };
 
@@ -1361,13 +1440,15 @@ const disposeBridgeAsyncStore = () => {
 	closeBridgeAsyncStore = null;
 };
 
+server.on('close', stopInlineWorker);
 server.on('close', disposeBrowserRuntime);
-server.on('close', disposeRedisClient);
 server.on('close', disposeBridgeAsyncStore);
+server.on('close', disposeRedisClient);
 
 // Only start listening when this file is executed directly (not imported)
 if (process.argv[1]?.match(/handler\.(ts|js|mjs)$/)) {
 	server.listen(PORT, '0.0.0.0', () => {
+		startInlineWorker();
 		logEvent('INFO', 'Middleware server listening', {
 			event: 'runtime_started',
 			port: PORT,

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -1,5 +1,7 @@
 import { setTimeout as delay } from 'node:timers/promises';
 import { Effect, Exit, Cause, ManagedRuntime, Scope } from 'effect';
+import { Redis as IORedisImpl } from 'ioredis';
+import type { Redis as IORedis } from 'ioredis';
 import {
 	BrowserProcessLive,
 	BrowserService,
@@ -22,6 +24,8 @@ import {
 	readDatesViaUrl,
 	readSlotsViaUrl,
 } from '../adapters/acuity/steps/read-via-url.js';
+import { buildAvailabilityDatesCacheKey } from './date-prewarm.js';
+import { buildAvailabilitySlotsCacheKey } from './slot-prewarm.js';
 import type {
 	AppointmentCommand,
 	AvailabilityDatesRefreshCommand,
@@ -30,6 +34,7 @@ import type {
 import type { BridgeAsyncStore } from '../async/store.js';
 import { createInMemoryBridgeAsyncStore } from '../async/store.js';
 import { createPostgresBridgeAsyncStore } from '../async/postgres-store.js';
+import { createRedisBridgeAsyncStore } from '../async/redis-store.js';
 import {
 	BridgeJobExecutionError,
 	drainReadyBridgeJobs,
@@ -40,6 +45,16 @@ import { ndjsonLog } from '../shared/logger.js';
 
 const ACUITY_BASE_URL = process.env.ACUITY_BASE_URL ?? 'https://example.as.me';
 const BRIDGE_DATABASE_URL = process.env.BRIDGE_DATABASE_URL;
+const REDIS_URL = process.env.REDIS_URL;
+const REDIS_PASSWORD = process.env.REDIS_PASSWORD;
+const READ_CACHE_TTL_SECONDS = (() => {
+	const parsed = Number(process.env.ACUITY_READ_CACHE_TTL_SECONDS ?? 20 * 60);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 20 * 60;
+})();
+const EMPTY_READ_CACHE_TTL_SECONDS = (() => {
+	const parsed = Number(process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS ?? 2 * 60);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 2 * 60;
+})();
 
 const browserConfig: BrowserConfig = {
 	...defaultBrowserConfig,
@@ -51,6 +66,23 @@ const browserConfig: BrowserConfig = {
 };
 
 const browserRuntime = ManagedRuntime.make(BrowserProcessLive(browserConfig));
+
+const createRedisClient = (): IORedis | null =>
+	REDIS_URL
+		? new IORedisImpl(REDIS_URL, {
+				password: REDIS_PASSWORD,
+				maxRetriesPerRequest: 3,
+			})
+		: null;
+
+let defaultExecutorRedisClient: IORedis | null | undefined;
+
+const getDefaultExecutorRedisClient = (): IORedis | null => {
+	if (defaultExecutorRedisClient === undefined) {
+		defaultExecutorRedisClient = createRedisClient();
+	}
+	return defaultExecutorRedisClient;
+};
 
 const logEvent = (
 	level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR',
@@ -133,115 +165,191 @@ const assertPaymentBypassProven = (result: {
 	}
 };
 
-export const createAcuityBridgeJobExecutor = (): BridgeJobExecutor => ({
-	refreshAvailabilityDates: async (command: AvailabilityDatesRefreshCommand) => {
-		if (isAcuityAppointmentTypeId(command.serviceId)) {
-			return runWizardStep(
-				readDatesViaUrl(command.serviceId, command.month),
-				'refresh-availability-dates',
-			);
-		}
-		return runWizardStep(
-			readAvailableDates({
-				serviceName: command.serviceName ?? command.serviceId,
-				targetMonth: command.month,
-				monthsToScan: 2,
-			}),
-			'refresh-availability-dates',
-		);
-	},
+const valueTtlSeconds = (value: readonly unknown[]): number =>
+	value.length === 0 ? EMPTY_READ_CACHE_TTL_SECONDS : READ_CACHE_TTL_SECONDS;
 
-	refreshAvailabilitySlots: async (command: AvailabilitySlotsRefreshCommand) => {
-		if (isAcuityAppointmentTypeId(command.serviceId)) {
-			return runWizardStep(
-				readSlotsViaUrl(command.serviceId, command.date),
-				'refresh-availability-slots',
-			);
-		}
-		return runWizardStep(
-			readTimeSlots({
-				serviceName: command.serviceName ?? command.serviceId,
-				date: command.date,
-			}),
-			'refresh-availability-slots',
+const writeReadCache = async (
+	redisClient: IORedis | null,
+	cacheKind: 'availability_dates' | 'availability_slots',
+	cacheKey: string,
+	value: readonly unknown[],
+) => {
+	if (!redisClient) return;
+	try {
+		await redisClient.set(
+			cacheKey,
+			JSON.stringify(value),
+			'EX',
+			valueTtlSeconds(value),
 		);
-	},
+		logEvent('INFO', 'Bridge worker wrote read cache', {
+			event: 'bridge_worker_read_cache_written',
+			cacheKind,
+			cacheKey,
+			valueCount: value.length,
+		});
+	} catch (error) {
+		logEvent('WARN', 'Bridge worker read cache write failed', {
+			event: 'bridge_worker_read_cache_write_failed',
+			cacheKind,
+			cacheKey,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+};
 
-	createBookingWithPayment: async (command: AppointmentCommand, context) => {
-		if (context.executionPath === 'rest') {
-			throw new BridgeJobExecutionError({
-				status: 'failed_pre_submit',
-				code: 'REST_BOOKING_NOT_WIRED',
-				message: 'Acuity REST booking execution is selected but not wired in this worker',
-				step: 'execution-path',
-				retryable: false,
-			});
-		}
-		const serviceName = command.serviceName ?? command.request.serviceId;
-		await runWizardStep(
-			navigateToBooking({
-				serviceName,
-				datetime: command.request.datetime,
-				client: command.request.client,
-				appointmentTypeId: command.request.serviceId,
-			}),
-			'navigate',
-		);
-		await runWizardStep(
-			fillFormFields({
-				client: command.request.client,
-				customFields: command.request.client.customFields,
-			}),
-			'fill-form',
-		);
-		if (!command.couponCode) {
-			throw new BridgeJobExecutionError({
-				status: 'failed_pre_submit',
-				code: 'COUPON_REQUIRED',
-				message: 'Browser booking execution requires a coupon bypass code',
-				step: 'bypass-payment',
-				retryable: false,
-			});
-		}
-		const bypass = await runWizardStep(
-			bypassPayment(command.couponCode),
-			'bypass-payment',
-		);
-		assertPaymentBypassProven(bypass);
-		await runWizardStep(
-			submitBooking(),
-			'submit',
-			'reconcile_required',
-		);
-		const confirmation = await runWizardStep(
-			extractConfirmation(),
-			'extract-confirmation',
-			'reconcile_required',
-		);
-		return toBooking(
-			confirmation,
-			command.request,
-			command.paymentRef,
-			command.paymentProcessor,
-		);
-	},
-});
+export interface AcuityBridgeJobExecutorOptions {
+	readonly redisClient?: IORedis | null;
+}
+
+export const createAcuityBridgeJobExecutor = (
+	options: AcuityBridgeJobExecutorOptions = {},
+): BridgeJobExecutor => {
+	const readCacheRedisClient =
+		options.redisClient === undefined
+			? getDefaultExecutorRedisClient()
+			: options.redisClient;
+
+	return {
+		refreshAvailabilityDates: async (command: AvailabilityDatesRefreshCommand) => {
+			const dates = isAcuityAppointmentTypeId(command.serviceId)
+				? await runWizardStep(
+						readDatesViaUrl(command.serviceId, command.month),
+						'refresh-availability-dates',
+					)
+				: await runWizardStep(
+					readAvailableDates({
+						serviceName: command.serviceName ?? command.serviceId,
+						targetMonth: command.month,
+						monthsToScan: 2,
+					}),
+					'refresh-availability-dates',
+				);
+			await writeReadCache(
+				readCacheRedisClient,
+				'availability_dates',
+				buildAvailabilityDatesCacheKey(
+					command.adapterProfile.baseUrl,
+					command.serviceId,
+					command.month,
+				),
+				dates,
+			);
+			return dates;
+		},
+
+		refreshAvailabilitySlots: async (command: AvailabilitySlotsRefreshCommand) => {
+			const slots = isAcuityAppointmentTypeId(command.serviceId)
+				? await runWizardStep(
+						readSlotsViaUrl(command.serviceId, command.date),
+						'refresh-availability-slots',
+					)
+				: await runWizardStep(
+					readTimeSlots({
+						serviceName: command.serviceName ?? command.serviceId,
+						date: command.date,
+					}),
+					'refresh-availability-slots',
+				);
+			await writeReadCache(
+				readCacheRedisClient,
+				'availability_slots',
+				buildAvailabilitySlotsCacheKey(
+					command.adapterProfile.baseUrl,
+					command.serviceId,
+					command.date,
+				),
+				slots,
+			);
+			return slots;
+		},
+
+		createBookingWithPayment: async (command: AppointmentCommand, context) => {
+			if (context.executionPath === 'rest') {
+				throw new BridgeJobExecutionError({
+					status: 'failed_pre_submit',
+					code: 'REST_BOOKING_NOT_WIRED',
+					message: 'Acuity REST booking execution is selected but not wired in this worker',
+					step: 'execution-path',
+					retryable: false,
+				});
+			}
+			const serviceName = command.serviceName ?? command.request.serviceId;
+			await runWizardStep(
+				navigateToBooking({
+					serviceName,
+					datetime: command.request.datetime,
+					client: command.request.client,
+					appointmentTypeId: command.request.serviceId,
+				}),
+				'navigate',
+			);
+			await runWizardStep(
+				fillFormFields({
+					client: command.request.client,
+					customFields: command.request.client.customFields,
+				}),
+				'fill-form',
+			);
+			if (!command.couponCode) {
+				throw new BridgeJobExecutionError({
+					status: 'failed_pre_submit',
+					code: 'COUPON_REQUIRED',
+					message: 'Browser booking execution requires a coupon bypass code',
+					step: 'bypass-payment',
+					retryable: false,
+				});
+			}
+			const bypass = await runWizardStep(
+				bypassPayment(command.couponCode),
+				'bypass-payment',
+			);
+			assertPaymentBypassProven(bypass);
+			await runWizardStep(
+				submitBooking(),
+				'submit',
+				'reconcile_required',
+			);
+			const confirmation = await runWizardStep(
+				extractConfirmation(),
+				'extract-confirmation',
+				'reconcile_required',
+			);
+			return toBooking(
+				confirmation,
+				command.request,
+				command.paymentRef,
+				command.paymentProcessor,
+			);
+		},
+	};
+};
 
 export const createWorkerStore = (): BridgeAsyncStore & {
 	readonly close?: () => Promise<void>;
 } => {
-	if (!BRIDGE_DATABASE_URL) {
-		logEvent('WARN', 'Bridge worker using in-memory store', {
-			event: 'bridge_worker_memory_store',
+	if (BRIDGE_DATABASE_URL) {
+		const store = createPostgresBridgeAsyncStore({
+			connectionString: BRIDGE_DATABASE_URL,
+			ssl: process.env.BRIDGE_DATABASE_SSL === 'true',
+			migrate: process.env.BRIDGE_DATABASE_MIGRATE !== 'false',
 		});
-		return createInMemoryBridgeAsyncStore();
+		return store;
 	}
-	const store = createPostgresBridgeAsyncStore({
-		connectionString: BRIDGE_DATABASE_URL,
-		ssl: process.env.BRIDGE_DATABASE_SSL === 'true',
-		migrate: process.env.BRIDGE_DATABASE_MIGRATE !== 'false',
+	if (REDIS_URL) {
+		return createRedisBridgeAsyncStore({
+			url: REDIS_URL,
+			redisOptions: {
+				password: REDIS_PASSWORD,
+				maxRetriesPerRequest: 3,
+			},
+			keyPrefix: process.env.BRIDGE_REDIS_ASYNC_PREFIX,
+		});
+	}
+	logEvent('WARN', 'Bridge worker using in-memory store', {
+		event: 'bridge_worker_memory_store',
 	});
-	return store;
+	return createInMemoryBridgeAsyncStore();
 };
 
 export const runBridgeWorkerLoop = async (


### PR DESCRIPTION
## Summary

- add a Redis-backed `BridgeAsyncStore` for K8s when `BRIDGE_DATABASE_URL` is absent
- start an inline worker by default when Postgres or Redis async storage is configured
- change availability date/slot prewarm from request-path browser work to queued async refresh jobs
- have worker-owned availability refresh jobs write the same Redis read-cache keys used by public reads
- document the 0.5.2 runtime contract and generated package facts

## Root Cause

The live K8s bridge had Redis configured but no `BRIDGE_DATABASE_URL` and no separate worker deployment. That meant the 0.5.1 async protocol could enqueue work only into process-local memory, with no durable cross-pod queue or guaranteed drain path. Date/slot prewarm was also still doing browser reads from request context instead of queueing worker-owned work.

## Validation

- `pnpm test:host src/server/__tests__/availability-dates-cache.test.ts src/server/__tests__/availability-slots-cache.test.ts src/server/__tests__/async-endpoints.test.ts src/async/redis-store.test.ts src/async/store.test.ts src/async/worker.test.ts src/server/date-prewarm.test.ts src/server/slot-prewarm.test.ts src/shared/bridge-read-cache.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm typecheck`
- `pnpm docs:check`
- `pnpm build`
- `pnpm check:artifact-authority`
- `pnpm check:release-metadata`
- `pnpm check:package`
