### PR TITLE
[codex] Prove availability read singleflight

### DIFF
--- a/src/server/__tests__/availability-dates-cache.test.ts
+++ b/src/server/__tests__/availability-dates-cache.test.ts
@@ -1,288 +1,340 @@
-import { type AddressInfo } from 'node:net';
-import { Effect } from 'effect';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { BrowserError } from '../../adapters/acuity/errors.js';
-import { createInMemoryBridgeAsyncStore } from '../../async/store.js';
+import { type AddressInfo } from "node:net";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserError } from "../../adapters/acuity/errors.js";
+import { createInMemoryBridgeAsyncStore } from "../../async/store.js";
 
 const readViaUrlMocks = vi.hoisted(() => ({
-	readDatesViaUrl: vi.fn(),
-	readSlotsViaUrl: vi.fn(),
+  readDatesViaUrl: vi.fn(),
+  readSlotsViaUrl: vi.fn(),
 }));
 
 const stepMocks = vi.hoisted(() => ({
-	navigateToBooking: vi.fn(),
-	fillFormFields: vi.fn(),
-	bypassPayment: vi.fn(),
-	generateCouponCode: vi.fn(),
-	submitBooking: vi.fn(),
-	extractConfirmation: vi.fn(),
-	toBooking: vi.fn(),
-	readAvailableDates: vi.fn(),
-	readTimeSlots: vi.fn(),
-	fetchBusinessData: vi.fn(),
-	businessToServices: vi.fn(),
+  navigateToBooking: vi.fn(),
+  fillFormFields: vi.fn(),
+  bypassPayment: vi.fn(),
+  generateCouponCode: vi.fn(),
+  submitBooking: vi.fn(),
+  extractConfirmation: vi.fn(),
+  toBooking: vi.fn(),
+  readAvailableDates: vi.fn(),
+  readTimeSlots: vi.fn(),
+  fetchBusinessData: vi.fn(),
+  businessToServices: vi.fn(),
 }));
 
 const redisState = vi.hoisted(() => ({
-	values: new Map<string, string>(),
-	instances: [] as Array<{
-		get: ReturnType<typeof vi.fn>;
-		set: ReturnType<typeof vi.fn>;
-		eval: ReturnType<typeof vi.fn>;
-		exists: ReturnType<typeof vi.fn>;
-		ping: ReturnType<typeof vi.fn>;
-		quit: ReturnType<typeof vi.fn>;
-		on: ReturnType<typeof vi.fn>;
-	}>,
+  values: new Map<string, string>(),
+  instances: [] as Array<{
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    eval: ReturnType<typeof vi.fn>;
+    exists: ReturnType<typeof vi.fn>;
+    ping: ReturnType<typeof vi.fn>;
+    quit: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+  }>,
 }));
 
-vi.mock('../../adapters/acuity/steps/read-via-url.js', () => readViaUrlMocks);
-vi.mock('../../adapters/acuity/steps/index.js', () => stepMocks);
+vi.mock("../../adapters/acuity/steps/read-via-url.js", () => readViaUrlMocks);
+vi.mock("../../adapters/acuity/steps/index.js", () => stepMocks);
 
-vi.mock('ioredis', () => {
-	class Redis {
-		get = vi.fn(async (key: string) => redisState.values.get(key) ?? null);
+vi.mock("ioredis", () => {
+  class Redis {
+    get = vi.fn(async (key: string) => redisState.values.get(key) ?? null);
 
-		set = vi.fn(
-			async (
-				key: string,
-				value: string,
-				...args: Array<string | number>
-			): Promise<'OK' | null> => {
-				const flags = args.map((arg) => String(arg).toUpperCase());
-				if (flags.includes('NX') && redisState.values.has(key)) {
-					return null;
-				}
-				redisState.values.set(key, value);
-				return 'OK';
-			},
-		);
+    set = vi.fn(
+      async (
+        key: string,
+        value: string,
+        ...args: Array<string | number>
+      ): Promise<"OK" | null> => {
+        const flags = args.map((arg) => String(arg).toUpperCase());
+        if (flags.includes("NX") && redisState.values.has(key)) {
+          return null;
+        }
+        redisState.values.set(key, value);
+        return "OK";
+      },
+    );
 
-		eval = vi.fn(
-			async (
-				_script: string,
-				_numKeys: number,
-				key: string,
-				token: string,
-			): Promise<number> => {
-				if (redisState.values.get(key) !== token) return 0;
-				redisState.values.delete(key);
-				return 1;
-			},
-		);
+    eval = vi.fn(
+      async (
+        _script: string,
+        _numKeys: number,
+        key: string,
+        token: string,
+      ): Promise<number> => {
+        if (redisState.values.get(key) !== token) return 0;
+        redisState.values.delete(key);
+        return 1;
+      },
+    );
 
-		exists = vi.fn(async (key: string) => (redisState.values.has(key) ? 1 : 0));
-		ping = vi.fn(async () => 'PONG');
-		quit = vi.fn(async () => 'OK');
-		on = vi.fn(() => this);
+    exists = vi.fn(async (key: string) => (redisState.values.has(key) ? 1 : 0));
+    ping = vi.fn(async () => "PONG");
+    quit = vi.fn(async () => "OK");
+    on = vi.fn(() => this);
 
-		constructor() {
-			redisState.instances.push(this);
-		}
-	}
+    constructor() {
+      redisState.instances.push(this);
+    }
+  }
 
-	return { Redis };
+  return { Redis };
 });
 
-const serviceId = '53178494';
-const baseUrl = 'https://MassageIthaca.as.me';
+const serviceId = "53178494";
+const baseUrl = "https://MassageIthaca.as.me";
 
 const mockAcuityModules = () => {
-	vi.doMock('../../adapters/acuity/steps/read-via-url.js', () => readViaUrlMocks);
-	vi.doMock('../../adapters/acuity/steps/index.js', () => stepMocks);
+  vi.doMock(
+    "../../adapters/acuity/steps/read-via-url.js",
+    () => readViaUrlMocks,
+  );
+  vi.doMock("../../adapters/acuity/steps/index.js", () => stepMocks);
 };
 
 const listen = async () => {
-	const {
-		server,
-		__runEffectWithoutBrowserForTest,
-		__setEffectRunnerForTest,
-		__setAcuityStepOverridesForTest,
-		__setBridgeAsyncStoreForTest,
-	} = await import('../handler.js');
-	const store = createInMemoryBridgeAsyncStore();
-	__setEffectRunnerForTest(__runEffectWithoutBrowserForTest);
-	__setBridgeAsyncStoreForTest(store);
-	__setAcuityStepOverridesForTest({
-		readDatesViaUrl: readViaUrlMocks.readDatesViaUrl,
-		readSlotsViaUrl: readViaUrlMocks.readSlotsViaUrl,
-		readAvailableDates: stepMocks.readAvailableDates,
-		readTimeSlots: stepMocks.readTimeSlots,
-	});
-	await new Promise<void>((resolve) => {
-		server.listen(0, '127.0.0.1', resolve);
-	});
-	const address = server.address() as AddressInfo;
-	return {
-		server,
-		store,
-		baseUrl: `http://127.0.0.1:${address.port}`,
-	};
+  const {
+    server,
+    __runEffectWithoutBrowserForTest,
+    __setEffectRunnerForTest,
+    __setAcuityStepOverridesForTest,
+    __setBridgeAsyncStoreForTest,
+  } = await import("../handler.js");
+  const store = createInMemoryBridgeAsyncStore();
+  __setEffectRunnerForTest(__runEffectWithoutBrowserForTest);
+  __setBridgeAsyncStoreForTest(store);
+  __setAcuityStepOverridesForTest({
+    readDatesViaUrl: readViaUrlMocks.readDatesViaUrl,
+    readSlotsViaUrl: readViaUrlMocks.readSlotsViaUrl,
+    readAvailableDates: stepMocks.readAvailableDates,
+    readTimeSlots: stepMocks.readTimeSlots,
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    server,
+    store,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
 };
 
 const postAvailabilityDates = async (
-	url: string,
-	startDate: string,
-	body: unknown = { serviceId, startDate },
+  url: string,
+  startDate: string,
+  body: unknown = { serviceId, startDate },
 ): Promise<Response> =>
-	fetch(`${url}/availability/dates`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify(body),
-	});
+  fetch(`${url}/availability/dates`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 
-describe('POST /availability/dates cache prewarm', () => {
-	let activeServer: Awaited<ReturnType<typeof listen>>['server'] | null = null;
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
 
-	beforeEach(() => {
-		vi.resetModules();
-		mockAcuityModules();
-		vi.clearAllMocks();
-		redisState.values.clear();
-		redisState.instances.length = 0;
+describe("POST /availability/dates cache prewarm", () => {
+  let activeServer: Awaited<ReturnType<typeof listen>>["server"] | null = null;
 
-		process.env.ACUITY_BASE_URL = baseUrl;
-		process.env.ACUITY_DATE_PREWARM_MONTHS = '1';
-		process.env.ACUITY_SLOT_PREWARM_LIMIT = '0';
-		process.env.REDIS_URL = 'redis://unit.test:6379';
-		delete process.env.REDIS_PASSWORD;
-		delete process.env.AUTH_TOKEN;
+  beforeEach(() => {
+    vi.resetModules();
+    mockAcuityModules();
+    vi.clearAllMocks();
+    redisState.values.clear();
+    redisState.instances.length = 0;
 
-		readViaUrlMocks.readDatesViaUrl.mockImplementation(
-			(_serviceId: string, targetMonth: string | undefined) =>
-				Effect.succeed([{ date: `${targetMonth ?? 'current'}-15` }]),
-		);
-	});
+    process.env.ACUITY_BASE_URL = baseUrl;
+    process.env.ACUITY_DATE_PREWARM_MONTHS = "1";
+    process.env.ACUITY_SLOT_PREWARM_LIMIT = "0";
+    process.env.REDIS_URL = "redis://unit.test:6379";
+    delete process.env.REDIS_PASSWORD;
+    delete process.env.AUTH_TOKEN;
 
-	afterEach(async () => {
-		if (activeServer?.listening) {
-			await new Promise<void>((resolve, reject) => {
-				activeServer!.close((error) => (error ? reject(error) : resolve()));
-			});
-		}
-		activeServer = null;
-		delete process.env.ACUITY_BASE_URL;
-		delete process.env.ACUITY_DATE_PREWARM_MONTHS;
-		delete process.env.ACUITY_SLOT_PREWARM_LIMIT;
-		delete process.env.REDIS_URL;
-		delete process.env.REDIS_PASSWORD;
-		delete process.env.AUTH_TOKEN;
-	});
+    readViaUrlMocks.readDatesViaUrl.mockImplementation(
+      (_serviceId: string, targetMonth: string | undefined) =>
+        Effect.succeed([{ date: `${targetMonth ?? "current"}-15` }]),
+    );
+  });
 
-	it('queues the next month after a successful date request', async () => {
-		const running = await listen();
-		activeServer = running.server;
+  afterEach(async () => {
+    if (activeServer?.listening) {
+      await new Promise<void>((resolve, reject) => {
+        activeServer!.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+    activeServer = null;
+    delete process.env.ACUITY_BASE_URL;
+    delete process.env.ACUITY_DATE_PREWARM_MONTHS;
+    delete process.env.ACUITY_SLOT_PREWARM_LIMIT;
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_PASSWORD;
+    delete process.env.AUTH_TOKEN;
+  });
 
-		const response = await postAvailabilityDates(running.baseUrl, '2026-07-01');
+  it("queues the next month after a successful date request", async () => {
+    const running = await listen();
+    activeServer = running.server;
 
-		expect(response.status).toBe(200);
-		await expect(response.json()).resolves.toMatchObject({
-			success: true,
-			data: [{ date: '2026-07-15' }],
-		});
+    const response = await postAvailabilityDates(running.baseUrl, "2026-07-01");
 
-		await new Promise((resolve) => setImmediate(resolve));
-		expect(readViaUrlMocks.readDatesViaUrl).toHaveBeenCalledWith(
-			serviceId,
-			'2026-07',
-		);
-		expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalledWith(
-			serviceId,
-			'2026-08',
-		);
-		await expect(running.store.listReadyJobs(10)).resolves.toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					kind: 'availability_dates_refresh',
-					command: expect.objectContaining({
-						serviceId,
-						month: '2026-08',
-					}),
-				}),
-			]),
-		);
-		expect(
-			redisState.values.get(
-				`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
-			),
-		).toBeUndefined();
-	});
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: [{ date: "2026-07-15" }],
+    });
 
-	it('serves a cached month from Redis and queues the following month', async () => {
-		redisState.values.set(
-			`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
-			JSON.stringify([{ date: '2026-08-15' }]),
-		);
-		const running = await listen();
-		activeServer = running.server;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(readViaUrlMocks.readDatesViaUrl).toHaveBeenCalledWith(
+      serviceId,
+      "2026-07",
+    );
+    expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalledWith(
+      serviceId,
+      "2026-08",
+    );
+    await expect(running.store.listReadyJobs(10)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "availability_dates_refresh",
+          command: expect.objectContaining({
+            serviceId,
+            month: "2026-08",
+          }),
+        }),
+      ]),
+    );
+    expect(
+      redisState.values.get(
+        `bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
+      ),
+    ).toBeUndefined();
+  });
 
-		const response = await postAvailabilityDates(running.baseUrl, '2026-08-01');
+  it("single-flights concurrent cold month requests at the HTTP route", async () => {
+    process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS = "1000";
+    const releaseRead = deferred();
+    const readStarted = deferred();
+    readViaUrlMocks.readDatesViaUrl.mockImplementationOnce(
+      (_serviceId: string, targetMonth: string | undefined) =>
+        Effect.promise(async () => {
+          readStarted.resolve();
+          await releaseRead.promise;
+          return [{ date: `${targetMonth ?? "current"}-15` }];
+        }),
+    );
+    const running = await listen();
+    activeServer = running.server;
 
-		expect(response.status).toBe(200);
-		await expect(response.json()).resolves.toMatchObject({
-			success: true,
-			data: [{ date: '2026-08-15' }],
-		});
-		expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalledWith(
-			serviceId,
-			'2026-08',
-		);
-		await new Promise((resolve) => setImmediate(resolve));
-		await expect(running.store.listReadyJobs(10)).resolves.toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					kind: 'availability_dates_refresh',
-					command: expect.objectContaining({
-						serviceId,
-						month: '2026-09',
-					}),
-				}),
-			]),
-		);
-	});
+    const responsesPromise = Promise.all(
+      Array.from({ length: 3 }, () =>
+        postAvailabilityDates(running.baseUrl, "2026-07-01"),
+      ),
+    );
+    await readStarted.promise;
+    await new Promise((resolve) => setImmediate(resolve));
+    releaseRead.resolve();
 
-	it('rejects missing service id before cache lookup or Acuity reads', async () => {
-		const running = await listen();
-		activeServer = running.server;
+    const responses = await responsesPromise;
 
-		const response = await postAvailabilityDates(
-			running.baseUrl,
-			'2026-07-01',
-			{ startDate: '2026-07-01' },
-		);
+    expect(readViaUrlMocks.readDatesViaUrl).toHaveBeenCalledTimes(1);
+    for (const response of responses) {
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        success: true,
+        data: [{ date: "2026-07-15" }],
+      });
+    }
+    expect(
+      redisState.values.get(
+        `bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-07`,
+      ),
+    ).toBe(JSON.stringify([{ date: "2026-07-15" }]));
+  });
 
-		expect(response.status).toBe(400);
-		await expect(response.json()).resolves.toMatchObject({
-			success: false,
-			error: {
-				tag: 'ValidationError',
-				code: 'serviceId',
-			},
-		});
-		expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalled();
-	});
+  it("serves a cached month from Redis and queues the following month", async () => {
+    redisState.values.set(
+      `bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-08`,
+      JSON.stringify([{ date: "2026-08-15" }]),
+    );
+    const running = await listen();
+    activeServer = running.server;
 
-	it('surfaces Acuity date-read failures without caching them as empty results', async () => {
-		readViaUrlMocks.readDatesViaUrl.mockImplementationOnce(() =>
-			Effect.fail(new BrowserError({ reason: 'PAGE_FAILED' })),
-		);
-		const running = await listen();
-		activeServer = running.server;
+    const response = await postAvailabilityDates(running.baseUrl, "2026-08-01");
 
-		const response = await postAvailabilityDates(running.baseUrl, '2026-07-01');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: [{ date: "2026-08-15" }],
+    });
+    expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalledWith(
+      serviceId,
+      "2026-08",
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    await expect(running.store.listReadyJobs(10)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "availability_dates_refresh",
+          command: expect.objectContaining({
+            serviceId,
+            month: "2026-09",
+          }),
+        }),
+      ]),
+    );
+  });
 
-		expect(response.status).toBe(500);
-		await expect(response.json()).resolves.toMatchObject({
-			success: false,
-			error: {
-				tag: 'InfrastructureError',
-				code: 'NETWORK',
-			},
-		});
-		expect(
-			redisState.values.get(
-				`bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-07`,
-			),
-		).toBeUndefined();
-	});
+  it("rejects missing service id before cache lookup or Acuity reads", async () => {
+    const running = await listen();
+    activeServer = running.server;
+
+    const response = await postAvailabilityDates(
+      running.baseUrl,
+      "2026-07-01",
+      { startDate: "2026-07-01" },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: {
+        tag: "ValidationError",
+        code: "serviceId",
+      },
+    });
+    expect(readViaUrlMocks.readDatesViaUrl).not.toHaveBeenCalled();
+  });
+
+  it("surfaces Acuity date-read failures without caching them as empty results", async () => {
+    readViaUrlMocks.readDatesViaUrl.mockImplementationOnce(() =>
+      Effect.fail(new BrowserError({ reason: "PAGE_FAILED" })),
+    );
+    const running = await listen();
+    activeServer = running.server;
+
+    const response = await postAvailabilityDates(running.baseUrl, "2026-07-01");
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: {
+        tag: "InfrastructureError",
+        code: "NETWORK",
+      },
+    });
+    expect(
+      redisState.values.get(
+        `bridge-read:v2:dates:${baseUrl}:${serviceId}:2026-07`,
+      ),
+    ).toBeUndefined();
+  });
 });

--- a/src/server/__tests__/availability-slots-cache.test.ts
+++ b/src/server/__tests__/availability-slots-cache.test.ts
@@ -1,298 +1,353 @@
-import { type AddressInfo } from 'node:net';
-import { Effect } from 'effect';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AddressInfo } from "node:net";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const readViaUrlMocks = vi.hoisted(() => ({
-	readDatesViaUrl: vi.fn(),
-	readSlotsViaUrl: vi.fn(),
+  readDatesViaUrl: vi.fn(),
+  readSlotsViaUrl: vi.fn(),
 }));
 
 const stepMocks = vi.hoisted(() => ({
-	navigateToBooking: vi.fn(),
-	fillFormFields: vi.fn(),
-	bypassPayment: vi.fn(),
-	generateCouponCode: vi.fn(),
-	submitBooking: vi.fn(),
-	extractConfirmation: vi.fn(),
-	toBooking: vi.fn(),
-	readAvailableDates: vi.fn(),
-	readTimeSlots: vi.fn(),
-	fetchBusinessData: vi.fn(),
-	businessToServices: vi.fn(),
+  navigateToBooking: vi.fn(),
+  fillFormFields: vi.fn(),
+  bypassPayment: vi.fn(),
+  generateCouponCode: vi.fn(),
+  submitBooking: vi.fn(),
+  extractConfirmation: vi.fn(),
+  toBooking: vi.fn(),
+  readAvailableDates: vi.fn(),
+  readTimeSlots: vi.fn(),
+  fetchBusinessData: vi.fn(),
+  businessToServices: vi.fn(),
 }));
 
 const redisState = vi.hoisted(() => ({
-	values: new Map<string, string>(),
-	instances: [] as Array<{
-		get: ReturnType<typeof vi.fn>;
-		set: ReturnType<typeof vi.fn>;
-		eval: ReturnType<typeof vi.fn>;
-		exists: ReturnType<typeof vi.fn>;
-		ping: ReturnType<typeof vi.fn>;
-		quit: ReturnType<typeof vi.fn>;
-		on: ReturnType<typeof vi.fn>;
-	}>,
+  values: new Map<string, string>(),
+  instances: [] as Array<{
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    eval: ReturnType<typeof vi.fn>;
+    exists: ReturnType<typeof vi.fn>;
+    ping: ReturnType<typeof vi.fn>;
+    quit: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+  }>,
 }));
 
-vi.mock('../../adapters/acuity/steps/read-via-url.js', () => readViaUrlMocks);
-vi.mock('../../adapters/acuity/steps/index.js', () => stepMocks);
+vi.mock("../../adapters/acuity/steps/read-via-url.js", () => readViaUrlMocks);
+vi.mock("../../adapters/acuity/steps/index.js", () => stepMocks);
 
-vi.mock('ioredis', () => {
-	class Redis {
-		get = vi.fn(async (key: string) => redisState.values.get(key) ?? null);
+vi.mock("ioredis", () => {
+  class Redis {
+    get = vi.fn(async (key: string) => redisState.values.get(key) ?? null);
 
-		set = vi.fn(
-			async (
-				key: string,
-				value: string,
-				...args: Array<string | number>
-			): Promise<'OK' | null> => {
-				const flags = args.map((arg) => String(arg).toUpperCase());
-				if (flags.includes('NX') && redisState.values.has(key)) {
-					return null;
-				}
-				redisState.values.set(key, value);
-				return 'OK';
-			},
-		);
+    set = vi.fn(
+      async (
+        key: string,
+        value: string,
+        ...args: Array<string | number>
+      ): Promise<"OK" | null> => {
+        const flags = args.map((arg) => String(arg).toUpperCase());
+        if (flags.includes("NX") && redisState.values.has(key)) {
+          return null;
+        }
+        redisState.values.set(key, value);
+        return "OK";
+      },
+    );
 
-		eval = vi.fn(
-			async (
-				_script: string,
-				_numKeys: number,
-				key: string,
-				token: string,
-			): Promise<number> => {
-				if (redisState.values.get(key) !== token) return 0;
-				redisState.values.delete(key);
-				return 1;
-			},
-		);
+    eval = vi.fn(
+      async (
+        _script: string,
+        _numKeys: number,
+        key: string,
+        token: string,
+      ): Promise<number> => {
+        if (redisState.values.get(key) !== token) return 0;
+        redisState.values.delete(key);
+        return 1;
+      },
+    );
 
-		exists = vi.fn(async (key: string) => (redisState.values.has(key) ? 1 : 0));
-		ping = vi.fn(async () => 'PONG');
-		quit = vi.fn(async () => 'OK');
-		on = vi.fn(() => this);
+    exists = vi.fn(async (key: string) => (redisState.values.has(key) ? 1 : 0));
+    ping = vi.fn(async () => "PONG");
+    quit = vi.fn(async () => "OK");
+    on = vi.fn(() => this);
 
-		constructor() {
-			redisState.instances.push(this);
-		}
-	}
+    constructor() {
+      redisState.instances.push(this);
+    }
+  }
 
-	return { Redis };
+  return { Redis };
 });
 
-const serviceId = '53178494';
-const baseUrl = 'https://MassageIthaca.as.me';
-const slotDate = '2026-08-15';
+const serviceId = "53178494";
+const baseUrl = "https://MassageIthaca.as.me";
+const slotDate = "2026-08-15";
 const slotCacheKey = `bridge-read:v2:slots:${baseUrl}:${serviceId}:${slotDate}`;
 
 const mockAcuityModules = () => {
-	vi.doMock('../../adapters/acuity/steps/read-via-url.js', () => readViaUrlMocks);
-	vi.doMock('../../adapters/acuity/steps/index.js', () => stepMocks);
+  vi.doMock(
+    "../../adapters/acuity/steps/read-via-url.js",
+    () => readViaUrlMocks,
+  );
+  vi.doMock("../../adapters/acuity/steps/index.js", () => stepMocks);
 };
 
 const listen = async () => {
-	const {
-		server,
-		__runEffectWithoutBrowserForTest,
-		__setEffectRunnerForTest,
-		__setAcuityStepOverridesForTest,
-	} = await import('../handler.js');
-	__setEffectRunnerForTest(__runEffectWithoutBrowserForTest);
-	__setAcuityStepOverridesForTest({
-		readDatesViaUrl: readViaUrlMocks.readDatesViaUrl,
-		readSlotsViaUrl: readViaUrlMocks.readSlotsViaUrl,
-		readAvailableDates: stepMocks.readAvailableDates,
-		readTimeSlots: stepMocks.readTimeSlots,
-	});
-	await new Promise<void>((resolve) => {
-		server.listen(0, '127.0.0.1', resolve);
-	});
-	const address = server.address() as AddressInfo;
-	return {
-		server,
-		baseUrl: `http://127.0.0.1:${address.port}`,
-	};
+  const {
+    server,
+    __runEffectWithoutBrowserForTest,
+    __setEffectRunnerForTest,
+    __setAcuityStepOverridesForTest,
+  } = await import("../handler.js");
+  __setEffectRunnerForTest(__runEffectWithoutBrowserForTest);
+  __setAcuityStepOverridesForTest({
+    readDatesViaUrl: readViaUrlMocks.readDatesViaUrl,
+    readSlotsViaUrl: readViaUrlMocks.readSlotsViaUrl,
+    readAvailableDates: stepMocks.readAvailableDates,
+    readTimeSlots: stepMocks.readTimeSlots,
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
 };
 
 const postAvailabilitySlots = async (
-	url: string,
-	body: unknown = { serviceId, date: slotDate },
+  url: string,
+  body: unknown = { serviceId, date: slotDate },
 ): Promise<Response> =>
-	fetch(`${url}/availability/slots`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify(body),
-	});
+  fetch(`${url}/availability/slots`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 
-describe('POST /availability/slots read cache', () => {
-	let activeServer: Awaited<ReturnType<typeof listen>>['server'] | null = null;
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
 
-	beforeEach(() => {
-		vi.resetModules();
-		mockAcuityModules();
-		vi.clearAllMocks();
-		redisState.values.clear();
-		redisState.instances.length = 0;
+describe("POST /availability/slots read cache", () => {
+  let activeServer: Awaited<ReturnType<typeof listen>>["server"] | null = null;
 
-		process.env.ACUITY_BASE_URL = baseUrl;
-		process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS = '7';
-		process.env.ACUITY_READ_CACHE_TTL_SECONDS = '60';
-		process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS = '10';
-		process.env.REDIS_URL = 'redis://unit.test:6379';
-		delete process.env.REDIS_PASSWORD;
-		delete process.env.AUTH_TOKEN;
+  beforeEach(() => {
+    vi.resetModules();
+    mockAcuityModules();
+    vi.clearAllMocks();
+    redisState.values.clear();
+    redisState.instances.length = 0;
 
-		readViaUrlMocks.readSlotsViaUrl.mockImplementation(
-			(_serviceId: string, date: string) =>
-				Effect.succeed([
-					{
-						datetime: `${date}T18:00:00.000Z`,
-						available: true,
-					},
-				]),
-		);
-	});
+    process.env.ACUITY_BASE_URL = baseUrl;
+    process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS = "7";
+    process.env.ACUITY_READ_CACHE_TTL_SECONDS = "60";
+    process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS = "10";
+    process.env.REDIS_URL = "redis://unit.test:6379";
+    delete process.env.REDIS_PASSWORD;
+    delete process.env.AUTH_TOKEN;
 
-	afterEach(async () => {
-		if (activeServer?.listening) {
-			await new Promise<void>((resolve, reject) => {
-				activeServer!.close((error) => (error ? reject(error) : resolve()));
-			});
-		}
-		activeServer = null;
-		delete process.env.ACUITY_BASE_URL;
-		delete process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS;
-		delete process.env.ACUITY_READ_CACHE_TTL_SECONDS;
-		delete process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS;
-		delete process.env.REDIS_URL;
-		delete process.env.REDIS_PASSWORD;
-		delete process.env.AUTH_TOKEN;
-	});
+    readViaUrlMocks.readSlotsViaUrl.mockImplementation(
+      (_serviceId: string, date: string) =>
+        Effect.succeed([
+          {
+            datetime: `${date}T18:00:00.000Z`,
+            available: true,
+          },
+        ]),
+    );
+  });
 
-	it('serves repeated slot requests from Redis without rereading Acuity', async () => {
-		const running = await listen();
-		activeServer = running.server;
+  afterEach(async () => {
+    if (activeServer?.listening) {
+      await new Promise<void>((resolve, reject) => {
+        activeServer!.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+    activeServer = null;
+    delete process.env.ACUITY_BASE_URL;
+    delete process.env.ACUITY_EMPTY_READ_CACHE_TTL_SECONDS;
+    delete process.env.ACUITY_READ_CACHE_TTL_SECONDS;
+    delete process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS;
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_PASSWORD;
+    delete process.env.AUTH_TOKEN;
+  });
 
-		const first = await postAvailabilitySlots(running.baseUrl);
+  it("serves repeated slot requests from Redis without rereading Acuity", async () => {
+    const running = await listen();
+    activeServer = running.server;
 
-		expect(first.status).toBe(200);
-		await expect(first.json()).resolves.toMatchObject({
-			success: true,
-			data: [{ datetime: `${slotDate}T18:00:00.000Z`, available: true }],
-		});
-		expect(redisState.values.get(slotCacheKey)).toBe(
-			JSON.stringify([
-				{ datetime: `${slotDate}T18:00:00.000Z`, available: true },
-			]),
-		);
+    const first = await postAvailabilitySlots(running.baseUrl);
 
-		readViaUrlMocks.readSlotsViaUrl.mockClear();
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toMatchObject({
+      success: true,
+      data: [{ datetime: `${slotDate}T18:00:00.000Z`, available: true }],
+    });
+    expect(redisState.values.get(slotCacheKey)).toBe(
+      JSON.stringify([
+        { datetime: `${slotDate}T18:00:00.000Z`, available: true },
+      ]),
+    );
 
-		const second = await postAvailabilitySlots(running.baseUrl);
+    readViaUrlMocks.readSlotsViaUrl.mockClear();
 
-		expect(second.status).toBe(200);
-		await expect(second.json()).resolves.toMatchObject({
-			success: true,
-			data: [{ datetime: `${slotDate}T18:00:00.000Z`, available: true }],
-		});
-		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
-	});
+    const second = await postAvailabilitySlots(running.baseUrl);
 
-	it('uses the empty-read TTL for empty slot arrays', async () => {
-		readViaUrlMocks.readSlotsViaUrl.mockImplementationOnce(() =>
-			Effect.succeed([]),
-		);
-		const running = await listen();
-		activeServer = running.server;
+    expect(second.status).toBe(200);
+    await expect(second.json()).resolves.toMatchObject({
+      success: true,
+      data: [{ datetime: `${slotDate}T18:00:00.000Z`, available: true }],
+    });
+    expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
+  });
 
-		const response = await postAvailabilitySlots(running.baseUrl);
+  it("single-flights concurrent cold slot requests at the HTTP route", async () => {
+    process.env.ACUITY_READ_CACHE_WAIT_TIMEOUT_MS = "1000";
+    const releaseRead = deferred();
+    const readStarted = deferred();
+    readViaUrlMocks.readSlotsViaUrl.mockImplementationOnce(
+      (_serviceId: string, date: string) =>
+        Effect.promise(async () => {
+          readStarted.resolve();
+          await releaseRead.promise;
+          return [
+            {
+              datetime: `${date}T18:00:00.000Z`,
+              available: true,
+            },
+          ];
+        }),
+    );
+    const running = await listen();
+    activeServer = running.server;
 
-		expect(response.status).toBe(200);
-		await expect(response.json()).resolves.toMatchObject({
-			success: true,
-			data: [],
-		});
-		expect(redisState.instances[0]?.set).toHaveBeenCalledWith(
-			slotCacheKey,
-			JSON.stringify([]),
-			'EX',
-			7,
-		);
-	});
+    const responsesPromise = Promise.all(
+      Array.from({ length: 3 }, () => postAvailabilitySlots(running.baseUrl)),
+    );
+    await readStarted.promise;
+    await new Promise((resolve) => setImmediate(resolve));
+    releaseRead.resolve();
 
-	it('returns timeout instead of rereading Acuity when another caller owns the cache fill', async () => {
-		redisState.values.set(`lock:${slotCacheKey}`, 'winner-token');
-		const running = await listen();
-		activeServer = running.server;
+    const responses = await responsesPromise;
 
-		const response = await postAvailabilitySlots(running.baseUrl);
+    expect(readViaUrlMocks.readSlotsViaUrl).toHaveBeenCalledTimes(1);
+    for (const response of responses) {
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        success: true,
+        data: [{ datetime: `${slotDate}T18:00:00.000Z`, available: true }],
+      });
+    }
+    expect(redisState.values.get(slotCacheKey)).toBe(
+      JSON.stringify([
+        { datetime: `${slotDate}T18:00:00.000Z`, available: true },
+      ]),
+    );
+  });
 
-		expect(response.status).toBe(500);
-		await expect(response.json()).resolves.toMatchObject({
-			success: false,
-			error: {
-				tag: 'InfrastructureError',
-				code: 'TIMEOUT',
-			},
-		});
-		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
-	});
+  it("uses the empty-read TTL for empty slot arrays", async () => {
+    readViaUrlMocks.readSlotsViaUrl.mockImplementationOnce(() =>
+      Effect.succeed([]),
+    );
+    const running = await listen();
+    activeServer = running.server;
 
-	it('rejects missing service id before cache lookup or Acuity reads', async () => {
-		const running = await listen();
-		activeServer = running.server;
+    const response = await postAvailabilitySlots(running.baseUrl);
 
-		const response = await postAvailabilitySlots(running.baseUrl, {
-			date: slotDate,
-		});
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: [],
+    });
+    expect(redisState.instances[0]?.set).toHaveBeenCalledWith(
+      slotCacheKey,
+      JSON.stringify([]),
+      "EX",
+      7,
+    );
+  });
 
-		expect(response.status).toBe(400);
-		await expect(response.json()).resolves.toMatchObject({
-			success: false,
-			error: {
-				tag: 'ValidationError',
-				code: 'serviceId',
-			},
-		});
-		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
-	});
+  it("returns timeout instead of rereading Acuity when another caller owns the cache fill", async () => {
+    redisState.values.set(`lock:${slotCacheKey}`, "winner-token");
+    const running = await listen();
+    activeServer = running.server;
 
-	it('rejects unauthenticated slot requests before cache lookup or Acuity reads', async () => {
-		process.env.AUTH_TOKEN = 'bridge-secret';
-		const running = await listen();
-		activeServer = running.server;
+    const response = await postAvailabilitySlots(running.baseUrl);
 
-		const response = await postAvailabilitySlots(running.baseUrl);
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: {
+        tag: "InfrastructureError",
+        code: "TIMEOUT",
+      },
+    });
+    expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
+  });
 
-		expect(response.status).toBe(401);
-		await expect(response.json()).resolves.toMatchObject({
-			success: false,
-			error: {
-				tag: 'InfrastructureError',
-				code: 'UNAUTHORIZED',
-			},
-		});
-		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
-	});
+  it("rejects missing service id before cache lookup or Acuity reads", async () => {
+    const running = await listen();
+    activeServer = running.server;
 
-	it('does not run slot reads for unsupported methods', async () => {
-		const running = await listen();
-		activeServer = running.server;
+    const response = await postAvailabilitySlots(running.baseUrl, {
+      date: slotDate,
+    });
 
-		const response = await fetch(`${running.baseUrl}/availability/slots`, {
-			method: 'GET',
-		});
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: {
+        tag: "ValidationError",
+        code: "serviceId",
+      },
+    });
+    expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
+  });
 
-		expect(response.status).toBe(404);
-		await expect(response.json()).resolves.toMatchObject({
-			success: false,
-			error: {
-				tag: 'InfrastructureError',
-				code: 'NOT_FOUND',
-			},
-		});
-		expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
-	});
+  it("rejects unauthenticated slot requests before cache lookup or Acuity reads", async () => {
+    process.env.AUTH_TOKEN = "bridge-secret";
+    const running = await listen();
+    activeServer = running.server;
+
+    const response = await postAvailabilitySlots(running.baseUrl);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: {
+        tag: "InfrastructureError",
+        code: "UNAUTHORIZED",
+      },
+    });
+    expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
+  });
+
+  it("does not run slot reads for unsupported methods", async () => {
+    const running = await listen();
+    activeServer = running.server;
+
+    const response = await fetch(`${running.baseUrl}/availability/slots`, {
+      method: "GET",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: {
+        tag: "InfrastructureError",
+        code: "NOT_FOUND",
+      },
+    });
+    expect(readViaUrlMocks.readSlotsViaUrl).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Adds HTTP route-level regression coverage proving the scheduling bridge single-flights concurrent cold Redis misses for both availability dates and slots.

## Why

Live K8s app evidence showed duplicate app-level `x-schedule-cache: miss` slot reads. This PR locks down the bridge side of the boundary: direct bridge `/availability/dates` and `/availability/slots` calls should perform one Acuity read while concurrent callers wait for the shared Redis fill.

## Validation

- `pnpm test:host src/server/__tests__/availability-slots-cache.test.ts src/server/__tests__/availability-dates-cache.test.ts`
- `pnpm typecheck`
- `pnpm exec prettier --check src/server/__tests__/availability-dates-cache.test.ts src/server/__tests__/availability-slots-cache.test.ts`
