### PR TITLE
Serve availability snapshots on request path

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.2",
+    version = "0.5.3",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.2",
+    version = "0.5.3",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ HTTP Request
 | POST | `/booking/jobs` | Enqueue async paid booking job |
 | GET | `/jobs/:operationId` | Read async job status |
 
+Availability date/slot request handlers are snapshot-first after Redis read-cache
+misses: a fresh durable snapshot returns immediately, a stale-but-not-expired
+snapshot returns immediately and queues an async refresh, and an expired/missing
+snapshot falls through to the Acuity read path. Serving a stale snapshot does
+not re-stamp it as freshly observed; only successful Acuity reads or worker
+refresh jobs advance snapshot freshness.
+
 ### Health Contract
 
 `GET /health` is the stable downstream runtime-truth surface.
@@ -91,6 +98,8 @@ dashboard state when `/health` is available.
 | `BRIDGE_INLINE_WORKER_ENABLED` | No | `true` when Postgres or Redis is configured | Drain async jobs inside the HTTP container; set `false` only when a separate worker deployment is active |
 | `BRIDGE_WORKER_POLL_MS` | No | `1000` | Worker queue poll interval |
 | `BRIDGE_WORKER_BATCH_SIZE` | No | `5` | Maximum jobs drained per worker poll |
+| `BRIDGE_SNAPSHOT_STALE_MS` | No | `300000` | Age after which a durable availability snapshot is served stale and refresh is queued |
+| `BRIDGE_SNAPSHOT_EXPIRES_MS` | No | `1800000` | Age after which a durable availability snapshot is ignored and a live Acuity read is required |
 | `AUTH_TOKEN` | Recommended | -- | Bearer token for all endpoints (except /health) |
 | `ACUITY_BYPASS_COUPON` | For payment bypass | -- | 100% gift certificate code |
 | `PLAYWRIGHT_HEADLESS` | No | `true` | Run browser headless |

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.2`
-- Bazel module version: `0.5.2`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.2`
+- package version: `0.5.3`
+- Bazel module version: `0.5.3`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.3`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/server/__tests__/async-endpoints.test.ts
+++ b/src/server/__tests__/async-endpoints.test.ts
@@ -25,11 +25,7 @@ const bookingRequest = {
 };
 
 const listen = async (store = createInMemoryBridgeAsyncStore()) => {
-	const {
-		server,
-		__setBridgeAsyncStoreForTest,
-		__setEffectRunnerForTest,
-	} = await import('../handler.js');
+	const { server, __setBridgeAsyncStoreForTest, __setEffectRunnerForTest } = await import('../handler.js');
 	__setBridgeAsyncStoreForTest(store);
 	await new Promise<void>((resolve) => {
 		server.listen(0, '127.0.0.1', resolve);
@@ -178,6 +174,163 @@ describe('bridge async protocol endpoints', () => {
 				scope: '2026-06',
 				value: [{ date: '2026-06-15' }],
 			},
+		});
+	});
+
+	it('serves fresh date snapshots on the availability request path', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		await store.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: service.id,
+			scope: '2026-06',
+			adapterProfile: {
+				backend: 'acuity',
+				baseUrl: 'https://example.as.me',
+			},
+			value: [{ date: '2026-06-15' }],
+			observedAt: '2999-01-01T00:00:00.000Z',
+			staleAt: '2999-01-01T00:05:00.000Z',
+			expiresAt: '2999-01-01T00:30:00.000Z',
+		});
+		const running = await listen(store);
+		activeServer = running.server;
+		const runner = vi.fn(async () => ({
+			ok: false as const,
+			error: {
+				_tag: 'InfrastructureError' as const,
+				code: 'UNEXPECTED_BROWSER_READ',
+				message: 'browser read should not run',
+			},
+		}));
+		running.setEffectRunnerForTest(runner);
+
+		const response = await fetch(`${running.baseUrl}/availability/dates`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				serviceId: service.id,
+				serviceName: service.name,
+				startDate: '2026-06-01',
+			}),
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({
+			success: true,
+			data: [{ date: '2026-06-15' }],
+		});
+		expect(runner).not.toHaveBeenCalled();
+	});
+
+	it('serves stale slot snapshots and queues async refresh', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		await store.upsertAvailabilitySnapshot({
+			kind: 'slots',
+			serviceId: service.id,
+			scope: '2026-06-15',
+			adapterProfile: {
+				backend: 'acuity',
+				baseUrl: 'https://example.as.me',
+			},
+			value: [{ time: '4:00 PM', datetime: '2026-06-15T16:00:00-04:00' }],
+			observedAt: '2000-01-01T00:00:00.000Z',
+			staleAt: '2000-01-01T00:01:00.000Z',
+			expiresAt: '2999-01-01T00:30:00.000Z',
+		});
+		const running = await listen(store);
+		activeServer = running.server;
+		const runner = vi.fn(async () => ({
+			ok: false as const,
+			error: {
+				_tag: 'InfrastructureError' as const,
+				code: 'UNEXPECTED_BROWSER_READ',
+				message: 'browser read should not run',
+			},
+		}));
+		running.setEffectRunnerForTest(runner);
+
+		const response = await fetch(`${running.baseUrl}/availability/slots`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				serviceId: service.id,
+				serviceName: service.name,
+				date: '2026-06-15',
+			}),
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({
+			success: true,
+			data: [{ time: '4:00 PM', datetime: '2026-06-15T16:00:00-04:00' }],
+		});
+		expect(runner).not.toHaveBeenCalled();
+
+		await new Promise((resolve) => setImmediate(resolve));
+		await expect(store.listReadyJobs(10)).resolves.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: 'availability_slots_refresh',
+					command: expect.objectContaining({
+						serviceId: service.id,
+						date: '2026-06-15',
+					}),
+				}),
+			]),
+		);
+	});
+
+	it('ignores expired request-path snapshots and refreshes from Acuity', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		await store.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: service.id,
+			scope: '2026-08',
+			adapterProfile: {
+				backend: 'acuity',
+				baseUrl: 'https://example.as.me',
+			},
+			value: [{ date: '2026-08-01' }],
+			observedAt: '2000-01-01T00:00:00.000Z',
+			staleAt: '2000-01-01T00:01:00.000Z',
+			expiresAt: '2000-01-01T00:30:00.000Z',
+		});
+		const running = await listen(store);
+		activeServer = running.server;
+		const runner = vi.fn(async () => ({
+			ok: true as const,
+			value: [{ date: '2026-08-15' }],
+		}));
+		running.setEffectRunnerForTest(runner);
+
+		const response = await fetch(`${running.baseUrl}/availability/dates`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				serviceId: service.id,
+				serviceName: service.name,
+				startDate: '2026-08-01',
+			}),
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({
+			success: true,
+			data: [{ date: '2026-08-15' }],
+		});
+		expect(runner).toHaveBeenCalledTimes(1);
+		await expect(
+			store.getAvailabilitySnapshot({
+				kind: 'dates',
+				serviceId: service.id,
+				scope: '2026-08',
+				baseUrl: 'https://example.as.me',
+			}),
+		).resolves.toMatchObject({
+			value: [{ date: '2026-08-15' }],
 		});
 	});
 

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -53,11 +53,8 @@ import {
 	type ServiceCatalogRedisL2,
 } from '../shared/acuity-service-catalog.js';
 import { getCached as redisL2GetCached, RedisL2 } from '../shared/redis-l2.js';
-import {
-	runBridgeReadCached,
-	type BridgeReadCacheClient,
-} from '../shared/bridge-read-cache.js';
-import { metrics, renderMetrics } from '../shared/metrics.js';
+import { runBridgeReadCached, type BridgeReadCacheClient } from '../shared/bridge-read-cache.js';
+import { metrics, recordAvailabilitySnapshotServed, renderMetrics } from '../shared/metrics.js';
 import { toSchedulingError, type MiddlewareError } from '../adapters/acuity/errors.js';
 import {
 	navigateToBooking,
@@ -70,46 +67,25 @@ import {
 	readAvailableDates,
 	readTimeSlots,
 } from '../adapters/acuity/steps/index.js';
-import {
-	readDatesViaUrl,
-	readSlotsViaUrl,
-} from '../adapters/acuity/steps/read-via-url.js';
+import { readDatesViaUrl, readSlotsViaUrl } from '../adapters/acuity/steps/read-via-url.js';
 import { buildHealthPayload } from './health.js';
 import { handleReady as _handleReady } from './ready.js';
-import {
-	buildAvailabilityDatesCacheKey,
-	getDatePrewarmMonths,
-	selectDatePrewarmMonths,
-} from './date-prewarm.js';
-import {
-	buildAvailabilitySlotsCacheKey,
-	getSlotPrewarmLimit,
-	selectSlotPrewarmDates,
-} from './slot-prewarm.js';
+import { buildAvailabilityDatesCacheKey, getDatePrewarmMonths, selectDatePrewarmMonths } from './date-prewarm.js';
+import { buildAvailabilitySlotsCacheKey, getSlotPrewarmLimit, selectSlotPrewarmDates } from './slot-prewarm.js';
 import { ndjsonLog } from '../shared/logger.js';
-import {
-	createInMemoryBridgeAsyncStore,
-	type BridgeAsyncStore,
-} from '../async/store.js';
+import { createInMemoryBridgeAsyncStore, type BridgeAsyncStore } from '../async/store.js';
 import { createPostgresBridgeAsyncStore } from '../async/postgres-store.js';
 import { createRedisBridgeAsyncStore } from '../async/redis-store.js';
 import type {
+	AvailabilitySnapshot,
 	AvailabilitySnapshotKind,
 	BridgeAdapterProfile,
 	BridgeJobCommand,
 	BridgeJobRecord,
 	EnqueueBridgeJobResponse,
 } from '../async/types.js';
-import {
-	createAcuityBridgeJobExecutor,
-	runBridgeWorkerLoop,
-} from './worker.js';
-import type {
-	Booking,
-	BookingRequest,
-	Service,
-	SchedulingError,
-} from '../core/types.js';
+import { createAcuityBridgeJobExecutor, runBridgeWorkerLoop } from './worker.js';
+import type { Booking, BookingRequest, AvailableDate, Service, SchedulingError, TimeSlot } from '../core/types.js';
 import { Errors } from '../core/types.js';
 
 const acuitySteps = {
@@ -126,9 +102,7 @@ const acuitySteps = {
 	readSlotsViaUrl,
 };
 
-export const __setAcuityStepOverridesForTest = (
-	overrides: Partial<typeof acuitySteps>,
-) => {
+export const __setAcuityStepOverridesForTest = (overrides: Partial<typeof acuitySteps>) => {
 	Object.assign(acuitySteps, overrides);
 };
 
@@ -204,8 +178,7 @@ const sendJson = (res: ServerResponse, status: number, body: SuccessResponse<unk
 	res.end(JSON.stringify(body));
 };
 
-const sendSuccess = <T>(res: ServerResponse, data: T) =>
-	sendJson(res, 200, { success: true, data });
+const sendSuccess = <T>(res: ServerResponse, data: T) => sendJson(res, 200, { success: true, data });
 
 const sendError = (res: ServerResponse, status: number, err: SchedulingError) =>
 	sendJson(res, status, {
@@ -254,23 +227,14 @@ const runtimeLogFields = () => ({
 	releaseVersion: process.env.MIDDLEWARE_RELEASE_VERSION ?? process.env.npm_package_version,
 });
 
-const logEvent = (
-	level: LogLevel,
-	msg: string,
-	data?: Record<string, unknown>,
-) => {
+const logEvent = (level: LogLevel, msg: string, data?: Record<string, unknown>) => {
 	ndjsonLog(level, msg, {
 		...runtimeLogFields(),
 		...data,
 	});
 };
 
-const logRequestEvent = (
-	level: LogLevel,
-	msg: string,
-	context: RequestContext,
-	data?: Record<string, unknown>,
-) => {
+const logRequestEvent = (level: LogLevel, msg: string, context: RequestContext, data?: Record<string, unknown>) => {
 	logEvent(level, msg, {
 		event: 'request',
 		requestId: context.requestId,
@@ -308,10 +272,7 @@ const createServiceCatalogLogger = () => ({
 		}),
 });
 
-const createSlotReadTelemetryContext = (
-	context: RequestContext,
-	endpoint: string,
-) => ({
+const createSlotReadTelemetryContext = (context: RequestContext, endpoint: string) => ({
 	requestId: context.requestId,
 	endpoint,
 	...runtimeLogFields(),
@@ -325,9 +286,7 @@ const browserRuntime = ManagedRuntime.make(BrowserProcessLive(browserConfig));
 
 type Result<A> = { ok: true; value: A } | { ok: false; error: SchedulingError };
 
-const exitToResult = <A>(
-	exit: Exit.Exit<A, MiddlewareError | undefined>,
-): Result<A> => {
+const exitToResult = <A>(exit: Exit.Exit<A, MiddlewareError | undefined>): Result<A> => {
 	if (Exit.isSuccess(exit)) {
 		return { ok: true, value: exit.value };
 	}
@@ -335,7 +294,14 @@ const exitToResult = <A>(
 	if (failure._tag === 'Some' && failure.value !== undefined) {
 		return { ok: false, error: toSchedulingError(failure.value) };
 	}
-	return { ok: false, error: { _tag: 'InfrastructureError', code: 'UNKNOWN', message: Cause.pretty(exit.cause) } };
+	return {
+		ok: false,
+		error: {
+			_tag: 'InfrastructureError',
+			code: 'UNKNOWN',
+			message: Cause.pretty(exit.cause),
+		},
+	};
 };
 
 type RunEffect = <A>(
@@ -345,9 +311,7 @@ type RunEffect = <A>(
 const runEffectWithBrowser: RunEffect = async <A>(
 	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
 ): Promise<Result<A>> => {
-	const exit = await browserRuntime.runPromiseExit(
-		Effect.scoped(effect.pipe(Effect.provide(BrowserSessionLive))),
-	);
+	const exit = await browserRuntime.runPromiseExit(Effect.scoped(effect.pipe(Effect.provide(BrowserSessionLive))));
 	return exitToResult(exit);
 };
 
@@ -356,9 +320,7 @@ let runEffect: RunEffect = runEffectWithBrowser;
 export const __runEffectWithoutBrowserForTest: RunEffect = async <A>(
 	effect: Effect.Effect<A, MiddlewareError | undefined, BrowserService | Scope.Scope>,
 ): Promise<Result<A>> => {
-	const exit = await Effect.runPromiseExit(
-		effect as Effect.Effect<A, MiddlewareError | undefined, never>,
-	);
+	const exit = await Effect.runPromiseExit(effect as Effect.Effect<A, MiddlewareError | undefined, never>);
 	return exitToResult(exit);
 };
 
@@ -420,11 +382,7 @@ if (redisClient) {
 
 const serviceCatalogRedisL2: ServiceCatalogRedisL2 | undefined = redisClient
 	? {
-			getCached: <A>(
-				key: string,
-				ttlSeconds: number,
-				mk: Effect.Effect<A>,
-			): Effect.Effect<A> => {
+			getCached: <A>(key: string, ttlSeconds: number, mk: Effect.Effect<A>): Effect.Effect<A> => {
 				const mkPromise = (): Promise<A> => Effect.runPromise(mk);
 				// Provide the RedisL2 service for the real `getCached`, then erase
 				// the `RedisError | CacheTimeoutError` channel so the result fits
@@ -503,14 +461,10 @@ const startInlineWorker = () => {
 	if (!BRIDGE_INLINE_WORKER_ENABLED || inlineWorkerAbortController) return;
 	inlineWorkerAbortController = new AbortController();
 	const workerId = `${process.env.HOSTNAME ?? `pid-${process.pid}`}:inline`;
-	void runBridgeWorkerLoop(
-		bridgeAsyncStore,
-		createAcuityBridgeJobExecutor({ redisClient }),
-		{
-			workerId,
-			signal: inlineWorkerAbortController.signal,
-		},
-	).catch((error) => {
+	void runBridgeWorkerLoop(bridgeAsyncStore, createAcuityBridgeJobExecutor({ redisClient }), {
+		workerId,
+		signal: inlineWorkerAbortController.signal,
+	}).catch((error) => {
 		if (inlineWorkerAbortController?.signal.aborted) return;
 		logEvent('ERROR', 'Inline bridge worker failed', {
 			event: 'bridge_inline_worker_failed',
@@ -546,8 +500,7 @@ const isSchedulingError = (error: unknown): error is SchedulingError =>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const isNonEmptyString = (value: unknown): value is string =>
-	typeof value === 'string' && value.trim().length > 0;
+const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
 
 const optionalString = (value: unknown): string | undefined | null => {
 	if (value === undefined) return undefined;
@@ -559,6 +512,7 @@ const runCachedBridgeRead = async <A>(
 	cacheKind: string,
 	cacheKey: string,
 	read: () => Promise<Result<A>>,
+	shouldCache?: (value: A) => boolean,
 ): Promise<Result<A>> => {
 	return runBridgeReadCached({
 		redisClient: redisClient as BridgeReadCacheClient | null,
@@ -570,24 +524,17 @@ const runCachedBridgeRead = async <A>(
 		waitTimeoutMs: READ_CACHE_WAIT_TIMEOUT_MS,
 		waitTimeoutResult: (waitMs) => ({
 			ok: false,
-			error: Errors.infrastructure(
-				'TIMEOUT',
-				`Timed out after ${waitMs}ms waiting for ${cacheKind} cache fill`,
-			),
+			error: Errors.infrastructure('TIMEOUT', `Timed out after ${waitMs}ms waiting for ${cacheKind} cache fill`),
 		}),
 		read,
+		shouldCache,
 		log: ({ event, cacheKind, waitMs, error }) => {
-			logRequestEvent(
-				error ? 'ERROR' : 'INFO',
-				'Bridge read cache event',
-				context,
-				{
-					event,
-					cacheKind,
-					...(waitMs === undefined ? {} : { waitMs }),
-					...(error === undefined ? {} : { error: describeLogValue(error) }),
-				},
-			);
+			logRequestEvent(error ? 'ERROR' : 'INFO', 'Bridge read cache event', context, {
+				event,
+				cacheKind,
+				...(waitMs === undefined ? {} : { waitMs }),
+				...(error === undefined ? {} : { error: describeLogValue(error) }),
+			});
 		},
 	});
 };
@@ -615,8 +562,7 @@ const adapterProfile = (): BridgeAdapterProfile => ({
 	adminApiConfigured: process.env.ACUITY_ADMIN_API_CONFIGURED === 'true',
 });
 
-const jobStatusUrl = (operationId: string): string =>
-	`/jobs/${encodeURIComponent(operationId)}`;
+const jobStatusUrl = (operationId: string): string => `/jobs/${encodeURIComponent(operationId)}`;
 
 const toEnqueueResponse = (job: BridgeJobRecord): EnqueueBridgeJobResponse => ({
 	operationId: job.operationId,
@@ -624,8 +570,7 @@ const toEnqueueResponse = (job: BridgeJobRecord): EnqueueBridgeJobResponse => ({
 	statusUrl: jobStatusUrl(job.operationId),
 });
 
-const sendAccepted = <T>(res: ServerResponse, data: T) =>
-	sendJson(res, 202, { success: true, data });
+const sendAccepted = <T>(res: ServerResponse, data: T) => sendJson(res, 202, { success: true, data });
 
 const snapshotTimestamps = (observedAt = new Date()) => {
 	const staleAfterMs = Number(process.env.BRIDGE_SNAPSHOT_STALE_MS ?? 5 * 60_000);
@@ -673,52 +618,119 @@ const enqueueAvailabilityPrewarmJob = (
 		readonly scope: string;
 	},
 ) => {
-	const idempotencyKey = [
-		'availability-prewarm',
-		ACUITY_BASE_URL,
-		options.kind,
-		options.serviceId,
-		options.scope,
-	].join(':');
+	const idempotencyKey = ['availability-prewarm', ACUITY_BASE_URL, options.kind, options.serviceId, options.scope].join(
+		':',
+	);
 
-	const job: BridgeJobCommand = options.kind === 'dates'
-		? {
-				kind: 'availability_dates_refresh',
-				command: {
-					serviceId: options.serviceId,
-					serviceName: options.serviceName,
-					month: options.scope,
-					adapterProfile: adapterProfile(),
-				},
-			}
-		: {
-				kind: 'availability_slots_refresh',
-				command: {
-					serviceId: options.serviceId,
-					serviceName: options.serviceName,
-					date: options.scope,
-					adapterProfile: adapterProfile(),
-				},
-			};
+	const job: BridgeJobCommand =
+		options.kind === 'dates'
+			? {
+					kind: 'availability_dates_refresh',
+					command: {
+						serviceId: options.serviceId,
+						serviceName: options.serviceName,
+						month: options.scope,
+						adapterProfile: adapterProfile(),
+					},
+				}
+			: {
+					kind: 'availability_slots_refresh',
+					command: {
+						serviceId: options.serviceId,
+						serviceName: options.serviceName,
+						date: options.scope,
+						adapterProfile: adapterProfile(),
+					},
+				};
 
-	void bridgeAsyncStore.enqueueJob(job, { idempotencyKey }).then((record) => {
-		logRequestEvent('INFO', 'Availability prewarm job enqueued', context, {
-			event: 'availability_prewarm_job_enqueued',
-			operationId: record.operationId,
-			status: record.status,
+	void bridgeAsyncStore
+		.enqueueJob(job, { idempotencyKey })
+		.then((record) => {
+			logRequestEvent('INFO', 'Availability prewarm job enqueued', context, {
+				event: 'availability_prewarm_job_enqueued',
+				operationId: record.operationId,
+				status: record.status,
+				kind: options.kind,
+				serviceId: options.serviceId,
+				scope: options.scope,
+			});
+		})
+		.catch((error) => {
+			logRequestEvent('WARN', 'Availability prewarm enqueue failed', context, {
+				event: 'availability_prewarm_enqueue_failed',
+				kind: options.kind,
+				serviceId: options.serviceId,
+				scope: options.scope,
+				error: describeLogValue(error),
+			});
+		});
+};
+
+type AvailabilitySnapshotFreshness = 'fresh' | 'stale' | 'expired';
+
+const classifyAvailabilitySnapshotFreshness = (
+	snapshot: AvailabilitySnapshot,
+	now = new Date(),
+): AvailabilitySnapshotFreshness => {
+	const nowMs = now.getTime();
+	const expiresAtMs = Date.parse(snapshot.expiresAt);
+	if (!Number.isFinite(expiresAtMs) || expiresAtMs <= nowMs) {
+		return 'expired';
+	}
+
+	const staleAtMs = Date.parse(snapshot.staleAt);
+	return Number.isFinite(staleAtMs) && staleAtMs > nowMs ? 'fresh' : 'stale';
+};
+
+const readUsableAvailabilitySnapshot = async <A extends readonly unknown[]>(
+	context: RequestContext,
+	options: {
+		readonly kind: AvailabilitySnapshotKind;
+		readonly serviceId: string;
+		readonly serviceName?: string;
+		readonly scope: string;
+	},
+): Promise<Result<A> | null> => {
+	try {
+		const snapshot = await bridgeAsyncStore.getAvailabilitySnapshot({
 			kind: options.kind,
 			serviceId: options.serviceId,
 			scope: options.scope,
+			baseUrl: ACUITY_BASE_URL,
 		});
-	}).catch((error) => {
-		logRequestEvent('WARN', 'Availability prewarm enqueue failed', context, {
-			event: 'availability_prewarm_enqueue_failed',
+		if (!snapshot) return null;
+
+		const freshness = classifyAvailabilitySnapshotFreshness(snapshot);
+		logRequestEvent('INFO', 'Availability snapshot considered', context, {
+			event: 'availability_snapshot_considered',
+			kind: options.kind,
+			serviceId: options.serviceId,
+			scope: options.scope,
+			freshness,
+			version: snapshot.version,
+			observedAt: snapshot.observedAt,
+			staleAt: snapshot.staleAt,
+			expiresAt: snapshot.expiresAt,
+		});
+
+		if (freshness === 'expired') return null;
+
+		recordAvailabilitySnapshotServed(options.kind, freshness);
+		if (freshness === 'stale') {
+			enqueueAvailabilityPrewarmJob(context, options);
+		}
+
+		return { ok: true, value: snapshot.value as A };
+	} catch (error) {
+		logRequestEvent('WARN', 'Availability snapshot read failed', context, {
+			event: 'availability_snapshot_read_failed',
 			kind: options.kind,
 			serviceId: options.serviceId,
 			scope: options.scope,
 			error: describeLogValue(error),
 		});
-	});
+		return null;
+	}
 };
 
 const scheduleDatePrewarm = (
@@ -793,13 +805,9 @@ const handleReady = (res: ServerResponse) =>
 	_handleReady(res, {
 		redisPing: redisClient ? () => redisClient!.ping() : null,
 		browserConnected: () =>
-			browserRuntime.runPromise(
-				BrowserProcess.pipe(Effect.map(({ browser }) => browser.isConnected())),
-			),
+			browserRuntime.runPromise(BrowserProcess.pipe(Effect.map(({ browser }) => browser.isConnected()))),
 		catalogL1Count: () => serviceCatalog.getCachedCount(),
-		catalogL2Exists: redisClient
-			? () => redisClient!.exists(CATALOG_REDIS_KEY)
-			: null,
+		catalogL2Exists: redisClient ? () => redisClient!.exists(CATALOG_REDIS_KEY) : null,
 		catalogWarm: async () => (await serviceCatalog.getServices()).length,
 	});
 
@@ -820,7 +828,6 @@ const handleHealth = (_req: IncomingMessage, res: ServerResponse) => {
 		}),
 	);
 };
-
 
 const handleGetServices = async (_req: IncomingMessage, res: ServerResponse) => {
 	try {
@@ -847,7 +854,11 @@ const handleGetService = async (serviceId: string, res: ServerResponse) => {
 		if (!found) {
 			return sendJson(res, 404, {
 				success: false,
-				error: { tag: 'AcuityError', code: 'NOT_FOUND', message: `Service ${serviceId} not found` },
+				error: {
+					tag: 'AcuityError',
+					code: 'NOT_FOUND',
+					message: `Service ${serviceId} not found`,
+				},
 			});
 		}
 		sendSuccess(res, found);
@@ -887,30 +898,47 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 		serviceName: body.serviceName,
 		startDate: body.startDate,
 	});
-	const cacheKey = buildAvailabilityDatesCacheKey(
-		ACUITY_BASE_URL,
-		body.serviceId,
-		targetMonth ?? 'current',
-	);
-	const result = await runCachedBridgeRead(context, 'availability_dates', cacheKey, () =>
-		isAcuityAppointmentTypeId(body.serviceId)
-			? runEffect(acuitySteps.readDatesViaUrl(body.serviceId, targetMonth))
-			: (async () => {
-				const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
-				logRequestEvent('INFO', 'Availability dates resolved service name', context, {
-					event: 'availability_dates_resolved_service',
-					serviceId: body.serviceId,
-					serviceName,
-					startDate: body.startDate,
-				});
-				return runEffect(
-					acuitySteps.readAvailableDates({
+	const cacheKey = buildAvailabilityDatesCacheKey(ACUITY_BASE_URL, body.serviceId, targetMonth ?? 'current');
+	let observedFreshAvailability = false;
+	let cacheReadResult = true;
+	const result = await runCachedBridgeRead(
+		context,
+		'availability_dates',
+		cacheKey,
+		async () => {
+			const snapshot = await readUsableAvailabilitySnapshot<readonly AvailableDate[]>(context, {
+				kind: 'dates',
+				serviceId: body.serviceId,
+				serviceName: body.serviceName,
+				scope: targetMonth ?? 'current',
+			});
+			if (snapshot) {
+				cacheReadResult = false;
+				return snapshot;
+			}
+
+			observedFreshAvailability = true;
+			cacheReadResult = true;
+			return isAcuityAppointmentTypeId(body.serviceId)
+				? runEffect(acuitySteps.readDatesViaUrl(body.serviceId, targetMonth))
+				: (async () => {
+					const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
+					logRequestEvent('INFO', 'Availability dates resolved service name', context, {
+						event: 'availability_dates_resolved_service',
+						serviceId: body.serviceId,
 						serviceName,
-						targetMonth,
-						monthsToScan: 2,
-					}),
-				);
-			})(),
+						startDate: body.startDate,
+					});
+					return runEffect(
+						acuitySteps.readAvailableDates({
+							serviceName,
+							targetMonth,
+							monthsToScan: 2,
+						}),
+					);
+				})();
+		},
+		() => cacheReadResult,
 	);
 
 	if (!result.ok) {
@@ -925,16 +953,22 @@ const handleAvailableDates = async (req: IncomingMessage, res: ServerResponse, c
 		});
 		return sendJson(res, 500, {
 			success: false,
-			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Availability lookup failed' },
+			error: {
+				tag: err._tag ?? 'InfrastructureError',
+				code: 'code' in err ? (err as { code: string }).code : 'UNKNOWN',
+				message: 'message' in err ? (err as { message: string }).message : 'Availability lookup failed',
+			},
 		});
 	}
-	await recordAvailabilitySnapshot(
-		'dates',
-		body.serviceId,
-		targetMonth ?? 'current',
-		Array.isArray(result.value) ? result.value : [],
-		context,
-	);
+	if (observedFreshAvailability) {
+		await recordAvailabilitySnapshot(
+			'dates',
+			body.serviceId,
+			targetMonth ?? 'current',
+			Array.isArray(result.value) ? result.value : [],
+			context,
+		);
+	}
 	scheduleDatePrewarm(context, body.serviceId, body.serviceName, targetMonth);
 	scheduleSlotPrewarm(context, body.serviceId, body.serviceName, result.value);
 	sendSuccess(res, result.value);
@@ -952,7 +986,11 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 	if (serviceName === null) {
 		return sendValidationError(res, 'serviceName', 'serviceName must be a string');
 	}
-	const body = { serviceId: rawBody.serviceId, serviceName, date: rawBody.date };
+	const body = {
+		serviceId: rawBody.serviceId,
+		serviceName,
+		date: rawBody.date,
+	};
 	logRequestEvent('INFO', 'Availability slots requested', context, {
 		event: 'availability_slots_requested',
 		serviceId: body.serviceId,
@@ -960,30 +998,51 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 		date: body.date,
 	});
 	const cacheKey = buildAvailabilitySlotsCacheKey(ACUITY_BASE_URL, body.serviceId, body.date);
-	const result = await runCachedBridgeRead(context, 'availability_slots', cacheKey, () =>
-		isAcuityAppointmentTypeId(body.serviceId)
-			? runEffect(
-				acuitySteps.readSlotsViaUrl(
-					body.serviceId,
-					body.date,
-					createSlotReadTelemetryContext(context, 'availability_slots'),
-				),
-			)
+	let observedFreshAvailability = false;
+	let cacheReadResult = true;
+	const result = await runCachedBridgeRead(
+		context,
+		'availability_slots',
+		cacheKey,
+		async () => {
+			const snapshot = await readUsableAvailabilitySnapshot<readonly TimeSlot[]>(context, {
+				kind: 'slots',
+				serviceId: body.serviceId,
+				serviceName: body.serviceName,
+				scope: body.date,
+			});
+			if (snapshot) {
+				cacheReadResult = false;
+				return snapshot;
+			}
+
+			observedFreshAvailability = true;
+			cacheReadResult = true;
+			return isAcuityAppointmentTypeId(body.serviceId)
+				? runEffect(
+					acuitySteps.readSlotsViaUrl(
+						body.serviceId,
+						body.date,
+						createSlotReadTelemetryContext(context, 'availability_slots'),
+					),
+				)
 			: (async () => {
-				const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
-				logRequestEvent('INFO', 'Availability slots resolved service name', context, {
-					event: 'availability_slots_resolved_service',
-					serviceId: body.serviceId,
-					serviceName,
-					date: body.date,
-				});
-				return runEffect(
-					acuitySteps.readTimeSlots({
+					const serviceName = await resolveServiceName(body.serviceId, body.serviceName);
+					logRequestEvent('INFO', 'Availability slots resolved service name', context, {
+						event: 'availability_slots_resolved_service',
+						serviceId: body.serviceId,
 						serviceName,
 						date: body.date,
-					}),
-				);
-			})(),
+					});
+					return runEffect(
+						acuitySteps.readTimeSlots({
+							serviceName,
+							date: body.date,
+						}),
+					);
+				})();
+		},
+		() => cacheReadResult,
 	);
 
 	if (!result.ok) {
@@ -998,21 +1057,31 @@ const handleAvailableSlots = async (req: IncomingMessage, res: ServerResponse, c
 		});
 		return sendJson(res, 500, {
 			success: false,
-			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Slot lookup failed' },
+			error: {
+				tag: err._tag ?? 'InfrastructureError',
+				code: 'code' in err ? (err as { code: string }).code : 'UNKNOWN',
+				message: 'message' in err ? (err as { message: string }).message : 'Slot lookup failed',
+			},
 		});
 	}
-	await recordAvailabilitySnapshot(
-		'slots',
-		body.serviceId,
-		body.date,
-		Array.isArray(result.value) ? result.value : [],
-		context,
-	);
+	if (observedFreshAvailability) {
+		await recordAvailabilitySnapshot(
+			'slots',
+			body.serviceId,
+			body.date,
+			Array.isArray(result.value) ? result.value : [],
+			context,
+		);
+	}
 	sendSuccess(res, result.value);
 };
 
 const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse, context: RequestContext) => {
-	const body = (await parseBody(req)) as { serviceId: string; serviceName?: string; datetime: string };
+	const body = (await parseBody(req)) as {
+		serviceId: string;
+		serviceName?: string;
+		datetime: string;
+	};
 	const date = body.datetime.split('T')[0];
 	logRequestEvent('INFO', 'Availability check requested', context, {
 		event: 'availability_check_requested',
@@ -1050,17 +1119,24 @@ const handleCheckSlot = async (req: IncomingMessage, res: ServerResponse, contex
 		});
 		return sendJson(res, 500, {
 			success: false,
-			error: { tag: err._tag ?? 'InfrastructureError', code: 'code' in err ? (err as {code:string}).code : 'UNKNOWN', message: 'message' in err ? (err as {message:string}).message : 'Slot check failed' },
+			error: {
+				tag: err._tag ?? 'InfrastructureError',
+				code: 'code' in err ? (err as { code: string }).code : 'UNKNOWN',
+				message: 'message' in err ? (err as { message: string }).message : 'Slot check failed',
+			},
 		});
 	}
-	const available = result.value.some((s: { datetime: string; available: boolean }) =>
-		s.datetime === body.datetime && s.available
+	const available = result.value.some(
+		(s: { datetime: string; available: boolean }) => s.datetime === body.datetime && s.available,
 	);
 	sendSuccess(res, available);
 };
 
 const handleCreateBooking = async (req: IncomingMessage, res: ServerResponse, context: RequestContext) => {
-	const body = (await parseBody(req)) as { request: BookingRequest; couponCode?: string };
+	const body = (await parseBody(req)) as {
+		request: BookingRequest;
+		couponCode?: string;
+	};
 	const { request } = body;
 
 	const serviceName = await resolveServiceName(request.serviceId);
@@ -1078,7 +1154,10 @@ const handleCreateBooking = async (req: IncomingMessage, res: ServerResponse, co
 				client: request.client,
 				appointmentTypeId: request.serviceId,
 			});
-			yield* acuitySteps.fillFormFields({ client: request.client, customFields: request.client.customFields });
+			yield* acuitySteps.fillFormFields({
+				client: request.client,
+				customFields: request.client.customFields,
+			});
 			yield* acuitySteps.submitBooking();
 			const confirmation = yield* acuitySteps.extractConfirmation();
 			return acuitySteps.toBooking(confirmation, request, '', 'acuity');
@@ -1109,11 +1188,7 @@ const handleDeprecatedSyncPaymentBooking = (res: ServerResponse) =>
 		},
 	});
 
-const handleEnqueueBookingJob = async (
-	req: IncomingMessage,
-	res: ServerResponse,
-	context: RequestContext,
-) => {
+const handleEnqueueBookingJob = async (req: IncomingMessage, res: ServerResponse, context: RequestContext) => {
 	const rawBody = await parseBody(req);
 	if (!isRecord(rawBody)) {
 		return sendValidationError(res, 'body', 'Request body must be an object');
@@ -1133,7 +1208,11 @@ const handleEnqueueBookingJob = async (
 	if (couponBypassRequired && !coupon) {
 		return sendJson(res, 400, {
 			success: false,
-			error: { tag: 'ValidationError', code: 'couponCode', message: 'Coupon code is required for payment bypass' },
+			error: {
+				tag: 'ValidationError',
+				code: 'couponCode',
+				message: 'Coupon code is required for payment bypass',
+			},
 		});
 	}
 	const idempotencyKey = optionalString(rawBody.idempotencyKey) ?? undefined;
@@ -1166,11 +1245,7 @@ const handleEnqueueBookingJob = async (
 	return sendAccepted(res, toEnqueueResponse(record));
 };
 
-const handleEnqueueAvailabilityRefresh = async (
-	req: IncomingMessage,
-	res: ServerResponse,
-	context: RequestContext,
-) => {
+const handleEnqueueAvailabilityRefresh = async (req: IncomingMessage, res: ServerResponse, context: RequestContext) => {
 	const rawBody = await parseBody(req);
 	if (!isRecord(rawBody)) {
 		return sendValidationError(res, 'body', 'Request body must be an object');
@@ -1201,33 +1276,30 @@ const handleEnqueueAvailabilityRefresh = async (
 		return sendValidationError(res, 'date', 'date is required for slot refresh jobs');
 	}
 
-	const idempotencyKey = idempotencyKeyOverride ?? [
-		'availability-refresh',
-		ACUITY_BASE_URL,
-		kind,
-		rawBody.serviceId,
-		kind === 'dates' ? month : date,
-	].join(':');
+	const idempotencyKey =
+		idempotencyKeyOverride ??
+		['availability-refresh', ACUITY_BASE_URL, kind, rawBody.serviceId, kind === 'dates' ? month : date].join(':');
 
-	const job: BridgeJobCommand = kind === 'dates'
-		? {
-				kind: 'availability_dates_refresh',
-				command: {
-					serviceId: rawBody.serviceId,
-					serviceName,
-					month: month as string,
-					adapterProfile: adapterProfile(),
-				},
-			}
-		: {
-				kind: 'availability_slots_refresh',
-				command: {
-					serviceId: rawBody.serviceId,
-					serviceName,
-					date: date as string,
-					adapterProfile: adapterProfile(),
-				},
-			};
+	const job: BridgeJobCommand =
+		kind === 'dates'
+			? {
+					kind: 'availability_dates_refresh',
+					command: {
+						serviceId: rawBody.serviceId,
+						serviceName,
+						month: month as string,
+						adapterProfile: adapterProfile(),
+					},
+				}
+			: {
+					kind: 'availability_slots_refresh',
+					command: {
+						serviceId: rawBody.serviceId,
+						serviceName,
+						date: date as string,
+						adapterProfile: adapterProfile(),
+					},
+				};
 
 	const record = await bridgeAsyncStore.enqueueJob(job, { idempotencyKey });
 
@@ -1247,16 +1319,17 @@ const handleGetAsyncJob = async (operationId: string, res: ServerResponse) => {
 	if (!record) {
 		return sendJson(res, 404, {
 			success: false,
-			error: { tag: 'InfrastructureError', code: 'NOT_FOUND', message: `Job ${operationId} not found` },
+			error: {
+				tag: 'InfrastructureError',
+				code: 'NOT_FOUND',
+				message: `Job ${operationId} not found`,
+			},
 		});
 	}
 	return sendSuccess(res, record);
 };
 
-const handleGetAvailabilitySnapshot = async (
-	url: URL,
-	res: ServerResponse,
-) => {
+const handleGetAvailabilitySnapshot = async (url: URL, res: ServerResponse) => {
 	const kind = url.searchParams.get('kind');
 	const serviceId = url.searchParams.get('serviceId');
 	const scope = url.searchParams.get('scope');
@@ -1329,7 +1402,11 @@ const server = createServer(async (req, res) => {
 			});
 			return sendJson(res, 401, {
 				success: false,
-				error: { tag: 'InfrastructureError', code: 'UNAUTHORIZED', message: 'Invalid auth token' },
+				error: {
+					tag: 'InfrastructureError',
+					code: 'UNAUTHORIZED',
+					message: 'Invalid auth token',
+				},
 			});
 		}
 	}
@@ -1398,7 +1475,11 @@ const server = createServer(async (req, res) => {
 		});
 		sendJson(res, 404, {
 			success: false,
-			error: { tag: 'InfrastructureError', code: 'NOT_FOUND', message: `Unknown route: ${method} ${path}` },
+			error: {
+				tag: 'InfrastructureError',
+				code: 'NOT_FOUND',
+				message: `Unknown route: ${method} ${path}`,
+			},
 		});
 	} catch (e) {
 		logRequestEvent('ERROR', 'Unhandled request error', context, {

--- a/src/shared/bridge-read-cache.test.ts
+++ b/src/shared/bridge-read-cache.test.ts
@@ -120,6 +120,33 @@ describe("runBridgeReadCached", () => {
     expect(await mock.get("lock:failed-slot-key")).toBeNull();
   });
 
+  it("can skip caching successful values", async () => {
+    const read = vi.fn(async () => ({
+      ok: true as const,
+      value: [{ datetime: "stale-snapshot" }],
+    }));
+
+    const result = await runBridgeReadCached({
+      redisClient: mock as unknown as BridgeReadCacheClient,
+      cacheKind: "availability_slots",
+      cacheKey: "uncached-slot-key",
+      ttlSeconds: 60,
+      emptyTtlSeconds: 10,
+      read,
+      shouldCache: () => false,
+      log: (event) => events.push(event),
+      waitTimeoutMs: 1000,
+      pollIntervalMs: 10,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: [{ datetime: "stale-snapshot" }],
+    });
+    expect(await mock.get("uncached-slot-key")).toBeNull();
+    expect(await mock.get("lock:uncached-slot-key")).toBeNull();
+  });
+
   it("falls through when the single-flight winner does not publish before the wait budget", async () => {
     await mock.set("lock:slow-slot-key", "winner-token", "PX", 30_000, "NX");
     const read = vi.fn(async () => ({

--- a/src/shared/bridge-read-cache.ts
+++ b/src/shared/bridge-read-cache.ts
@@ -36,6 +36,7 @@ export interface RunBridgeReadCachedOptions<A, E> {
   readonly ttlSeconds: number;
   readonly emptyTtlSeconds: number;
   readonly read: () => Promise<BridgeReadResult<A, E>>;
+  readonly shouldCache?: (value: A) => boolean;
   readonly log?: (event: BridgeReadCacheEvent) => void;
   readonly lockTtlMs?: number;
   readonly waitTimeoutMs?: number;
@@ -92,6 +93,7 @@ export const runBridgeReadCached = async <A, E>({
   ttlSeconds,
   emptyTtlSeconds,
   read,
+  shouldCache,
   log,
   lockTtlMs = BRIDGE_READ_CACHE_DEFAULTS.lockTtlMs,
   waitTimeoutMs = BRIDGE_READ_CACHE_DEFAULTS.waitTimeoutMs,
@@ -140,6 +142,7 @@ export const runBridgeReadCached = async <A, E>({
       record("lock_winner");
       const result = await observeRead();
       if (!result.ok) return result;
+      if (shouldCache && !shouldCache(result.value)) return result;
 
       try {
         await writeCached(

--- a/src/shared/metrics.test.ts
+++ b/src/shared/metrics.test.ts
@@ -7,6 +7,7 @@ import {
 	observePageOpEffect,
 	recordCacheHit,
 	recordCacheMiss,
+	recordAvailabilitySnapshotServed,
 	renderMetrics,
 	trackBrowserSession,
 } from './metrics.js';
@@ -26,6 +27,7 @@ describe('metrics', () => {
 		expect(names).toContain('acuity_bridge_read_cache_events_total');
 		expect(names).toContain('acuity_bridge_read_cache_wait_duration_seconds');
 		expect(names).toContain('acuity_bridge_read_duration_seconds');
+		expect(names).toContain('acuity_availability_snapshot_served_total');
 	});
 
 	it('renders Prometheus text format', async () => {
@@ -47,44 +49,30 @@ describe('metrics', () => {
 		// Delta assertion — registry is a module-level singleton so absolute
 		// values accumulate across tests. Pin the +1 rather than trust state.
 		const before =
-			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
-				(v) => v.labels.source === 'lock_winner',
-			)?.value ?? 0;
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find((v) => v.labels.source === 'lock_winner')?.value ?? 0;
 		metrics.serviceCatalogScrapeTotal.inc({ source: 'lock_winner' });
 		const after =
-			(await metrics.serviceCatalogScrapeTotal.get()).values.find(
-				(v) => v.labels.source === 'lock_winner',
-			)?.value ?? 0;
+			(await metrics.serviceCatalogScrapeTotal.get()).values.find((v) => v.labels.source === 'lock_winner')?.value ?? 0;
 		expect(after).toBe(before + 1);
 	});
 });
 
 describe('bridge read cache metrics wiring', () => {
-	const counterValue = async (
-		cacheKind: string,
-		event: string,
-	): Promise<number> => {
+	const counterValue = async (cacheKind: string, event: string): Promise<number> => {
 		const snap = await metrics.bridgeReadCacheEventsTotal.get();
-		return snap.values.find(
-			(v) =>
-				v.labels.cache_kind === cacheKind &&
-				v.labels.event === event,
-		)?.value ?? 0;
+		return snap.values.find((v) => v.labels.cache_kind === cacheKind && v.labels.event === event)?.value ?? 0;
 	};
 
-	const histogramCount = async (
-		metricName: string,
-		labels: Record<string, string>,
-	): Promise<number> => {
+	const histogramCount = async (metricName: string, labels: Record<string, string>): Promise<number> => {
 		const metric = metrics.registry.getSingleMetric(metricName);
 		const snap = await metric?.get();
 		const countName = `${metricName}_count`;
-		return snap?.values.find((v) => {
-			if (v.metricName !== countName) return false;
-			return Object.entries(labels).every(
-				([key, value]) => v.labels[key] === value,
-			);
-		})?.value ?? 0;
+		return (
+			snap?.values.find((v) => {
+				if (v.metricName !== countName) return false;
+				return Object.entries(labels).every(([key, value]) => v.labels[key] === value);
+			})?.value ?? 0
+		);
 	};
 
 	it('increments fixed-label cache event counters', async () => {
@@ -95,28 +83,38 @@ describe('bridge read cache metrics wiring', () => {
 	});
 
 	it('records wait duration samples by outcome', async () => {
-		const before = await histogramCount(
-			'acuity_bridge_read_cache_wait_duration_seconds',
-			{ cache_kind: 'availability_slots', outcome: 'hit' },
-		);
+		const before = await histogramCount('acuity_bridge_read_cache_wait_duration_seconds', {
+			cache_kind: 'availability_slots',
+			outcome: 'hit',
+		});
 		metrics.recordBridgeReadCacheWait('availability_slots', 'hit', 250);
-		const after = await histogramCount(
-			'acuity_bridge_read_cache_wait_duration_seconds',
-			{ cache_kind: 'availability_slots', outcome: 'hit' },
-		);
+		const after = await histogramCount('acuity_bridge_read_cache_wait_duration_seconds', {
+			cache_kind: 'availability_slots',
+			outcome: 'hit',
+		});
 		expect(after).toBe(before + 1);
 	});
 
 	it('records uncached bridge read duration samples', async () => {
-		const before = await histogramCount(
-			'acuity_bridge_read_duration_seconds',
-			{ cache_kind: 'availability_dates' },
-		);
+		const before = await histogramCount('acuity_bridge_read_duration_seconds', {
+			cache_kind: 'availability_dates',
+		});
 		await metrics.observeBridgeRead('availability_dates', async () => 42);
-		const after = await histogramCount(
-			'acuity_bridge_read_duration_seconds',
-			{ cache_kind: 'availability_dates' },
-		);
+		const after = await histogramCount('acuity_bridge_read_duration_seconds', {
+			cache_kind: 'availability_dates',
+		});
+		expect(after).toBe(before + 1);
+	});
+
+	it('increments snapshot-served counters by kind and freshness', async () => {
+		const snapshotCounter = async (kind: string, freshness: string): Promise<number> => {
+			const snap = await metrics.availabilitySnapshotServedTotal.get();
+			return snap.values.find((v) => v.labels.kind === kind && v.labels.freshness === freshness)?.value ?? 0;
+		};
+
+		const before = await snapshotCounter('slots', 'stale');
+		recordAvailabilitySnapshotServed('slots', 'stale');
+		const after = await snapshotCounter('slots', 'stale');
 		expect(after).toBe(before + 1);
 	});
 });
@@ -132,10 +130,7 @@ describe('browser page limiter metrics wiring', () => {
 		const snap = await metrics.browserPageAcquireDuration.get();
 		return (
 			snap.values.find(
-				(v) =>
-					v.metricName ===
-						'acuity_browser_page_acquire_duration_seconds_count' &&
-					v.labels.outcome === outcome,
+				(v) => v.metricName === 'acuity_browser_page_acquire_duration_seconds_count' && v.labels.outcome === outcome,
 			)?.value ?? 0
 		);
 	};
@@ -206,8 +201,7 @@ describe('pageOperationsDuration wiring', () => {
 			const snap = await metrics.pageOperationsDuration.get();
 			// `_count` lines have `metricName: <name>_count` and the matching operation label.
 			const row = snap.values.find(
-				(v) => v.metricName === 'acuity_page_operations_duration_seconds_count' &&
-					v.labels.operation === op,
+				(v) => v.metricName === 'acuity_page_operations_duration_seconds_count' && v.labels.operation === op,
 			);
 			return (row?.value as number | undefined) ?? 0;
 		};
@@ -222,8 +216,7 @@ describe('pageOperationsDuration wiring', () => {
 		const bucketCountFor = async (op: string): Promise<number> => {
 			const snap = await metrics.pageOperationsDuration.get();
 			const row = snap.values.find(
-				(v) => v.metricName === 'acuity_page_operations_duration_seconds_count' &&
-					v.labels.operation === op,
+				(v) => v.metricName === 'acuity_page_operations_duration_seconds_count' && v.labels.operation === op,
 			);
 			return (row?.value as number | undefined) ?? 0;
 		};
@@ -242,8 +235,7 @@ describe('pageOperationsDuration wiring', () => {
 		const bucketCountFor = async (op: string): Promise<number> => {
 			const snap = await metrics.pageOperationsDuration.get();
 			const row = snap.values.find(
-				(v) => v.metricName === 'acuity_page_operations_duration_seconds_count' &&
-					v.labels.operation === op,
+				(v) => v.metricName === 'acuity_page_operations_duration_seconds_count' && v.labels.operation === op,
 			);
 			return (row?.value as number | undefined) ?? 0;
 		};
@@ -271,9 +263,11 @@ describe('browserActiveSessions wiring', () => {
 			trackBrowserSession(
 				Effect.sync(() => {
 					// Synchronous peek while the session is "held".
-					const row = (metrics.browserActiveSessions as unknown as {
-						hashMap: Map<string, { value: number }>;
-					}).hashMap;
+					const row = (
+						metrics.browserActiveSessions as unknown as {
+							hashMap: Map<string, { value: number }>;
+						}
+					).hashMap;
 					// Fallback to prom-client async snapshot if the internal
 					// structure changes in future versions.
 					void row;
@@ -289,9 +283,7 @@ describe('browserActiveSessions wiring', () => {
 
 	it('decrements even when the wrapped Effect fails', async () => {
 		const baseline = await gaugeValue();
-		await expect(
-			Effect.runPromise(trackBrowserSession(Effect.fail('nope' as never))),
-		).rejects.toBeDefined();
+		await expect(Effect.runPromise(trackBrowserSession(Effect.fail('nope' as never)))).rejects.toBeDefined();
 		expect(await gaugeValue()).toBe(baseline);
 	});
 

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -1,11 +1,5 @@
 import { Effect } from 'effect';
-import {
-	Counter,
-	Gauge,
-	Histogram,
-	Registry,
-	collectDefaultMetrics,
-} from 'prom-client';
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
 
 /**
  * Prometheus metrics registry for the acuity-middleware bridge.
@@ -105,6 +99,13 @@ const bridgeReadDuration = new Histogram({
 	registers: [registry],
 });
 
+const availabilitySnapshotServedTotal = new Counter({
+	name: 'acuity_availability_snapshot_served_total',
+	help: 'Availability snapshots served on the request path by kind and freshness',
+	labelNames: ['kind', 'freshness'],
+	registers: [registry],
+});
+
 // ─── Derived cache hit-ratio ─────────────────────────────────────────────────
 //
 // `cacheHitRatio` is a derived gauge — prom-client cannot compute it for us,
@@ -156,52 +157,37 @@ export const _resetCacheHitRatioForTests = (): void => {
 	cacheHitRatio.set(1);
 };
 
-export const recordBridgeReadCacheEvent = (
-	cacheKind: string,
-	event: string,
-): void => {
+export const recordBridgeReadCacheEvent = (cacheKind: string, event: string): void => {
 	bridgeReadCacheEventsTotal.inc({ cache_kind: cacheKind, event });
 };
 
-export const setBrowserPageLimiterState = (
-	active: number,
-	queued: number,
-): void => {
+export const setBrowserPageLimiterState = (active: number, queued: number): void => {
 	browserPageLimiterActive.set(Math.max(0, active));
 	browserPageLimiterQueued.set(Math.max(0, queued));
 };
 
-export const recordBrowserPageAcquire = (
-	outcome: 'success' | 'timeout',
-	waitMs: number,
-): void => {
+export const recordBrowserPageAcquire = (outcome: 'success' | 'timeout', waitMs: number): void => {
 	browserPageAcquireDuration.observe({ outcome }, Math.max(0, waitMs) / 1000);
 	if (outcome === 'timeout') {
 		browserPageAcquireTimeoutsTotal.inc();
 	}
 };
 
-export const recordBridgeReadCacheWait = (
-	cacheKind: string,
-	outcome: 'hit' | 'timeout',
-	waitMs: number,
-): void => {
-	bridgeReadCacheWaitDuration.observe(
-		{ cache_kind: cacheKind, outcome },
-		Math.max(0, waitMs) / 1000,
-	);
+export const recordBridgeReadCacheWait = (cacheKind: string, outcome: 'hit' | 'timeout', waitMs: number): void => {
+	bridgeReadCacheWaitDuration.observe({ cache_kind: cacheKind, outcome }, Math.max(0, waitMs) / 1000);
 };
 
-export const observeBridgeRead = async <A>(
-	cacheKind: string,
-	fn: () => Promise<A>,
-): Promise<A> => {
+export const observeBridgeRead = async <A>(cacheKind: string, fn: () => Promise<A>): Promise<A> => {
 	const end = bridgeReadDuration.startTimer({ cache_kind: cacheKind });
 	try {
 		return await fn();
 	} finally {
 		end();
 	}
+};
+
+export const recordAvailabilitySnapshotServed = (kind: string, freshness: 'fresh' | 'stale'): void => {
+	availabilitySnapshotServedTotal.inc({ kind, freshness });
 };
 
 // ─── Page-operation timer helper ─────────────────────────────────────────────
@@ -211,10 +197,7 @@ export const observeBridgeRead = async <A>(
 // `scrape_catalog`, `wizard_navigate`). Never label per-service_id or per-url.
 
 /** Observe a Playwright/page operation's wall time. Handles Promise success + failure. */
-export const observePageOp = async <A>(
-	operation: string,
-	fn: () => Promise<A>,
-): Promise<A> => {
+export const observePageOp = async <A>(operation: string, fn: () => Promise<A>): Promise<A> => {
 	const end = pageOperationsDuration.startTimer({ operation });
 	try {
 		return await fn();
@@ -245,9 +228,7 @@ export const observePageOpEffect = <A, E, R>(
 // combinator instead of calling `.inc()` / `.dec()` directly so the
 // release path runs even on interrupt.
 
-export const trackBrowserSession = <A, E, R>(
-	effect: Effect.Effect<A, E, R>,
-): Effect.Effect<A, E, R> =>
+export const trackBrowserSession = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
 	Effect.acquireUseRelease(
 		Effect.sync(() => browserActiveSessions.inc()),
 		() => effect,
@@ -268,6 +249,7 @@ export const metrics = {
 	bridgeReadCacheEventsTotal,
 	bridgeReadCacheWaitDuration,
 	bridgeReadDuration,
+	availabilitySnapshotServedTotal,
 	recordCacheHit,
 	recordCacheMiss,
 	setBrowserPageLimiterState,
@@ -275,6 +257,7 @@ export const metrics = {
 	recordBridgeReadCacheEvent,
 	recordBridgeReadCacheWait,
 	observeBridgeRead,
+	recordAvailabilitySnapshotServed,
 	observePageOp,
 	observePageOpEffect,
 	trackBrowserSession,


### PR DESCRIPTION
## Summary

- serve fresh durable availability snapshots on `/availability/dates` and `/availability/slots` after Redis read-cache misses
- serve stale-but-not-expired snapshots immediately while enqueueing async refresh jobs
- avoid re-stamping stale snapshots as fresh observations, and avoid writing snapshot-served values back into the Redis read cache
- add request-path snapshot metrics and document stale/expiry behavior

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm check:package`
- `git diff --check`