### PR TITLE
[codex] Add snapshot cache canary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,8 @@ As of `2026-05-08`, the active structural work here is:
 
 Operationally relevant truth:
 
-- current package metadata is `@tummycrypt/scheduling-bridge` `0.5.2`
-- `0.5.2` depends on `@tummycrypt/scheduling-kit ^0.8.0`
+- current package metadata is `@tummycrypt/scheduling-bridge` `0.5.4`
+- `0.5.4` depends on `@tummycrypt/scheduling-kit ^0.8.0`
 - the `0.5.x` line is the async bridge redesign lane: async booking jobs,
   availability snapshots, Redis/Postgres async stores, and request-path
   availability prewarm enqueueing

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.3",
+    version = "0.5.4",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.3",
+    version = "0.5.4",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ HTTP Request
 | POST | `/availability/check` | Check if a slot is available |
 | POST | `/availability/refresh` | Enqueue async availability refresh |
 | GET | `/availability/snapshot` | Read latest durable availability snapshot |
+| GET | `/internal/availability/snapshot-canary` | Auth-gated durable snapshot layer proof |
 | POST | `/booking/create` | Create a booking (standard) |
 | POST | `/booking/create-with-payment` | Deprecated sync paid booking endpoint; returns `410 ASYNC_REQUIRED` |
 | POST | `/booking/jobs` | Enqueue async paid booking job |
@@ -54,6 +55,15 @@ snapshot returns immediately and queues an async refresh, and an expired/missing
 snapshot falls through to the Acuity read path. Serving a stale snapshot does
 not re-stamp it as freshly observed; only successful Acuity reads or worker
 refresh jobs advance snapshot freshness.
+
+`GET /internal/availability/snapshot-canary?kind=dates|slots&serviceId=...&scope=...`
+is an operator canary for K8s/runtime proof. It is hidden unless `AUTH_TOKEN`
+is configured, requires bearer auth when enabled, bypasses the Redis read cache,
+reads the durable snapshot store directly, and returns only metadata, count, and
+duration. Successful canary hits increment
+`acuity_availability_snapshot_served_total` and
+`acuity_availability_snapshot_read_duration_seconds`, so operators can prove the
+bridge snapshot layer separately from app Redis hits and bridge Redis hits.
 
 ### Health Contract
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.3`
-- Bazel module version: `0.5.3`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.3`
+- package version: `0.5.4`
+- Bazel module version: `0.5.4`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.4`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/server/__tests__/async-endpoints.test.ts
+++ b/src/server/__tests__/async-endpoints.test.ts
@@ -282,6 +282,126 @@ describe('bridge async protocol endpoints', () => {
 		);
 	});
 
+	it('hides the internal snapshot canary unless bridge auth is configured', async () => {
+		const store = createInMemoryBridgeAsyncStore();
+		await store.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: service.id,
+			scope: '2026-06',
+			adapterProfile: {
+				backend: 'acuity',
+				baseUrl: 'https://example.as.me',
+			},
+			value: [{ date: '2026-06-15' }],
+			observedAt: '2999-01-01T00:00:00.000Z',
+			staleAt: '2999-01-01T00:05:00.000Z',
+			expiresAt: '2999-01-01T00:30:00.000Z',
+		});
+		const running = await listen(store);
+		activeServer = running.server;
+
+		const response = await fetch(
+			`${running.baseUrl}/internal/availability/snapshot-canary?kind=dates&serviceId=${service.id}&scope=2026-06`,
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(404);
+		expect(body).toMatchObject({
+			success: false,
+			error: {
+				code: 'NOT_FOUND',
+			},
+		});
+	});
+
+	it('auth-gates the internal snapshot canary and records durable snapshot layer metrics', async () => {
+		process.env.AUTH_TOKEN = 'canary-token';
+		const store = createInMemoryBridgeAsyncStore();
+		await store.upsertAvailabilitySnapshot({
+			kind: 'slots',
+			serviceId: service.id,
+			scope: '2026-06-15',
+			adapterProfile: {
+				backend: 'acuity',
+				baseUrl: 'https://example.as.me',
+			},
+			value: [{ time: '4:00 PM', datetime: '2026-06-15T16:00:00-04:00' }],
+			observedAt: '2000-01-01T00:00:00.000Z',
+			staleAt: '2000-01-01T00:01:00.000Z',
+			expiresAt: '2999-01-01T00:30:00.000Z',
+		});
+		const running = await listen(store);
+		activeServer = running.server;
+		const { metrics } = await import('../../shared/metrics.js');
+		const metricCount = async (
+			metricName: string,
+			labels: Record<string, string>,
+		): Promise<number> => {
+			const metric = metrics.registry.getSingleMetric(metricName);
+			const snap = await metric?.get();
+			const countName = `${metricName}_count`;
+			return (
+				snap?.values.find((v) => {
+					if (v.metricName !== countName) return false;
+					return Object.entries(labels).every(([key, value]) => v.labels[key] === value);
+				})?.value ?? 0
+			);
+		};
+		const snapshotServedCount = async (): Promise<number> => {
+			const snap = await metrics.availabilitySnapshotServedTotal.get();
+			return snap.values.find((v) => v.labels.kind === 'slots' && v.labels.freshness === 'stale')?.value ?? 0;
+		};
+		const durationBefore = await metricCount('acuity_availability_snapshot_read_duration_seconds', {
+			kind: 'slots',
+			freshness: 'stale',
+			outcome: 'hit',
+		});
+		const servedBefore = await snapshotServedCount();
+		const url = `${running.baseUrl}/internal/availability/snapshot-canary?kind=slots&serviceId=${service.id}&scope=2026-06-15`;
+
+		const unauthorized = await fetch(url);
+		expect(unauthorized.status).toBe(401);
+
+		const response = await fetch(url, {
+			headers: {
+				Authorization: 'Bearer canary-token',
+			},
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({
+			success: true,
+			data: {
+				layer: 'bridge_durable_snapshot',
+				kind: 'slots',
+				serviceId: service.id,
+				scope: '2026-06-15',
+				freshness: 'stale',
+				valueCount: 1,
+				refreshQueued: false,
+				metrics: {
+					servedCounter: {
+						name: 'acuity_availability_snapshot_served_total',
+					},
+					durationHistogram: {
+						name: 'acuity_availability_snapshot_read_duration_seconds',
+					},
+				},
+			},
+		});
+		expect(typeof body.data.durationMs).toBe('number');
+		expect(await snapshotServedCount()).toBe(servedBefore + 1);
+		expect(
+			await metricCount('acuity_availability_snapshot_read_duration_seconds', {
+				kind: 'slots',
+				freshness: 'stale',
+				outcome: 'hit',
+			}),
+		).toBe(durationBefore + 1);
+		await expect(store.listReadyJobs(10)).resolves.toEqual([]);
+	});
+
 	it('ignores expired request-path snapshots and refreshes from Acuity', async () => {
 		const store = createInMemoryBridgeAsyncStore();
 		await store.upsertAvailabilitySnapshot({

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -14,6 +14,7 @@
  *   POST /availability/check        - Check if a slot is available
  *   POST /availability/refresh      - Enqueue async availability refresh
  *   GET  /availability/snapshot     - Read latest availability snapshot
+ *   GET  /internal/availability/snapshot-canary - Auth-gated durable snapshot proof
  *   POST /booking/create            - Create booking (standard)
  *   POST /booking/create-with-payment - Deprecated sync paid booking endpoint
  *   POST /booking/jobs              - Enqueue async paid booking job
@@ -54,7 +55,12 @@ import {
 } from '../shared/acuity-service-catalog.js';
 import { getCached as redisL2GetCached, RedisL2 } from '../shared/redis-l2.js';
 import { runBridgeReadCached, type BridgeReadCacheClient } from '../shared/bridge-read-cache.js';
-import { metrics, recordAvailabilitySnapshotServed, renderMetrics } from '../shared/metrics.js';
+import {
+	metrics,
+	recordAvailabilitySnapshotRead,
+	recordAvailabilitySnapshotServed,
+	renderMetrics,
+} from '../shared/metrics.js';
 import { toSchedulingError, type MiddlewareError } from '../adapters/acuity/errors.js';
 import {
 	navigateToBooking,
@@ -667,6 +673,23 @@ const enqueueAvailabilityPrewarmJob = (
 };
 
 type AvailabilitySnapshotFreshness = 'fresh' | 'stale' | 'expired';
+type AvailabilitySnapshotReadMiss = 'missing' | 'expired' | 'error';
+
+interface AvailabilitySnapshotLayerHit<A extends readonly unknown[]> {
+	readonly ok: true;
+	readonly freshness: Exclude<AvailabilitySnapshotFreshness, 'expired'>;
+	readonly snapshot: AvailabilitySnapshot;
+	readonly result: { readonly ok: true; readonly value: A };
+	readonly durationMs: number;
+}
+
+interface AvailabilitySnapshotLayerMiss {
+	readonly ok: false;
+	readonly reason: AvailabilitySnapshotReadMiss;
+	readonly snapshot?: AvailabilitySnapshot;
+	readonly durationMs: number;
+	readonly error?: unknown;
+}
 
 const classifyAvailabilitySnapshotFreshness = (
 	snapshot: AvailabilitySnapshot,
@@ -682,15 +705,17 @@ const classifyAvailabilitySnapshotFreshness = (
 	return Number.isFinite(staleAtMs) && staleAtMs > nowMs ? 'fresh' : 'stale';
 };
 
-const readUsableAvailabilitySnapshot = async <A extends readonly unknown[]>(
+const readAvailabilitySnapshotLayer = async <A extends readonly unknown[]>(
 	context: RequestContext,
 	options: {
 		readonly kind: AvailabilitySnapshotKind;
 		readonly serviceId: string;
 		readonly serviceName?: string;
 		readonly scope: string;
+		readonly enqueueRefreshOnStale?: boolean;
 	},
-): Promise<Result<A> | null> => {
+): Promise<AvailabilitySnapshotLayerHit<A> | AvailabilitySnapshotLayerMiss> => {
+	const startedAt = Date.now();
 	try {
 		const snapshot = await bridgeAsyncStore.getAvailabilitySnapshot({
 			kind: options.kind,
@@ -698,7 +723,11 @@ const readUsableAvailabilitySnapshot = async <A extends readonly unknown[]>(
 			scope: options.scope,
 			baseUrl: ACUITY_BASE_URL,
 		});
-		if (!snapshot) return null;
+		if (!snapshot) {
+			const durationMs = Date.now() - startedAt;
+			recordAvailabilitySnapshotRead(options.kind, 'missing', 'miss', durationMs);
+			return { ok: false, reason: 'missing', durationMs };
+		}
 
 		const freshness = classifyAvailabilitySnapshotFreshness(snapshot);
 		logRequestEvent('INFO', 'Availability snapshot considered', context, {
@@ -713,15 +742,28 @@ const readUsableAvailabilitySnapshot = async <A extends readonly unknown[]>(
 			expiresAt: snapshot.expiresAt,
 		});
 
-		if (freshness === 'expired') return null;
+		const durationMs = Date.now() - startedAt;
+		if (freshness === 'expired') {
+			recordAvailabilitySnapshotRead(options.kind, 'expired', 'miss', durationMs);
+			return { ok: false, reason: 'expired', snapshot, durationMs };
+		}
 
 		recordAvailabilitySnapshotServed(options.kind, freshness);
-		if (freshness === 'stale') {
+		recordAvailabilitySnapshotRead(options.kind, freshness, 'hit', durationMs);
+		if (freshness === 'stale' && options.enqueueRefreshOnStale !== false) {
 			enqueueAvailabilityPrewarmJob(context, options);
 		}
 
-		return { ok: true, value: snapshot.value as A };
+		return {
+			ok: true,
+			freshness,
+			snapshot,
+			result: { ok: true, value: snapshot.value as A },
+			durationMs,
+		};
 	} catch (error) {
+		const durationMs = Date.now() - startedAt;
+		recordAvailabilitySnapshotRead(options.kind, 'error', 'error', durationMs);
 		logRequestEvent('WARN', 'Availability snapshot read failed', context, {
 			event: 'availability_snapshot_read_failed',
 			kind: options.kind,
@@ -729,8 +771,21 @@ const readUsableAvailabilitySnapshot = async <A extends readonly unknown[]>(
 			scope: options.scope,
 			error: describeLogValue(error),
 		});
-		return null;
+		return { ok: false, reason: 'error', durationMs, error };
 	}
+};
+
+const readUsableAvailabilitySnapshot = async <A extends readonly unknown[]>(
+	context: RequestContext,
+	options: {
+		readonly kind: AvailabilitySnapshotKind;
+		readonly serviceId: string;
+		readonly serviceName?: string;
+		readonly scope: string;
+	},
+): Promise<Result<A> | null> => {
+	const snapshot = await readAvailabilitySnapshotLayer<A>(context, options);
+	return snapshot.ok ? snapshot.result : null;
 };
 
 const scheduleDatePrewarm = (
@@ -1361,6 +1416,95 @@ const handleGetAvailabilitySnapshot = async (url: URL, res: ServerResponse) => {
 	return sendSuccess(res, snapshot);
 };
 
+const handleAvailabilitySnapshotCanary = async (url: URL, res: ServerResponse, context: RequestContext) => {
+	if (!AUTH_TOKEN) {
+		return sendJson(res, 404, {
+			success: false,
+			error: {
+				tag: 'InfrastructureError',
+				code: 'NOT_FOUND',
+				message: 'Not found',
+			},
+		});
+	}
+
+	const kind = url.searchParams.get('kind');
+	const serviceId = url.searchParams.get('serviceId');
+	const scope = url.searchParams.get('scope');
+	const serviceName = url.searchParams.get('serviceName') ?? undefined;
+	if (kind !== 'dates' && kind !== 'slots') {
+		return sendValidationError(res, 'kind', 'kind must be "dates" or "slots"');
+	}
+	if (!serviceId) {
+		return sendValidationError(res, 'serviceId', 'serviceId is required');
+	}
+	if (!scope) {
+		return sendValidationError(res, 'scope', 'scope is required');
+	}
+
+	const snapshot = await readAvailabilitySnapshotLayer<readonly unknown[]>(context, {
+		kind,
+		serviceId,
+		serviceName,
+		scope,
+		enqueueRefreshOnStale: false,
+	});
+
+	if (!snapshot.ok) {
+		const status = snapshot.reason === 'expired' ? 409 : snapshot.reason === 'missing' ? 404 : 500;
+		const code =
+			snapshot.reason === 'expired'
+				? 'SNAPSHOT_EXPIRED'
+				: snapshot.reason === 'missing'
+					? 'SNAPSHOT_NOT_FOUND'
+					: 'SNAPSHOT_READ_FAILED';
+		return sendJson(res, status, {
+			success: false,
+			error: {
+				tag: 'InfrastructureError',
+				code,
+				message: `Durable ${kind} snapshot canary ${snapshot.reason} for ${serviceId}/${scope}`,
+			},
+		});
+	}
+
+	return sendSuccess(res, {
+		layer: 'bridge_durable_snapshot',
+		kind,
+		serviceId,
+		scope,
+		freshness: snapshot.freshness,
+		valueCount: snapshot.result.value.length,
+		durationMs: snapshot.durationMs,
+		refreshQueued: false,
+		snapshot: {
+			snapshotId: snapshot.snapshot.snapshotId,
+			version: snapshot.snapshot.version,
+			observedAt: snapshot.snapshot.observedAt,
+			staleAt: snapshot.snapshot.staleAt,
+			expiresAt: snapshot.snapshot.expiresAt,
+			sourceJobId: snapshot.snapshot.sourceJobId,
+		},
+		metrics: {
+			servedCounter: {
+				name: 'acuity_availability_snapshot_served_total',
+				labels: {
+					kind,
+					freshness: snapshot.freshness,
+				},
+			},
+			durationHistogram: {
+				name: 'acuity_availability_snapshot_read_duration_seconds',
+				labels: {
+					kind,
+					freshness: snapshot.freshness,
+					outcome: 'hit',
+				},
+			},
+		},
+	});
+};
+
 // =============================================================================
 // SERVER
 // =============================================================================
@@ -1451,6 +1595,9 @@ const server = createServer(async (req, res) => {
 		}
 		if (path === '/availability/snapshot' && method === 'GET') {
 			return await handleGetAvailabilitySnapshot(url, res);
+		}
+		if (path === '/internal/availability/snapshot-canary' && method === 'GET') {
+			return await handleAvailabilitySnapshotCanary(url, res, context);
 		}
 		if (path.startsWith('/jobs/') && method === 'GET') {
 			const operationId = decodeURIComponent(path.slice('/jobs/'.length));

--- a/src/shared/metrics.test.ts
+++ b/src/shared/metrics.test.ts
@@ -8,6 +8,7 @@ import {
 	recordCacheHit,
 	recordCacheMiss,
 	recordAvailabilitySnapshotServed,
+	recordAvailabilitySnapshotRead,
 	renderMetrics,
 	trackBrowserSession,
 } from './metrics.js';
@@ -28,6 +29,7 @@ describe('metrics', () => {
 		expect(names).toContain('acuity_bridge_read_cache_wait_duration_seconds');
 		expect(names).toContain('acuity_bridge_read_duration_seconds');
 		expect(names).toContain('acuity_availability_snapshot_served_total');
+		expect(names).toContain('acuity_availability_snapshot_read_duration_seconds');
 	});
 
 	it('renders Prometheus text format', async () => {
@@ -115,6 +117,21 @@ describe('bridge read cache metrics wiring', () => {
 		const before = await snapshotCounter('slots', 'stale');
 		recordAvailabilitySnapshotServed('slots', 'stale');
 		const after = await snapshotCounter('slots', 'stale');
+		expect(after).toBe(before + 1);
+	});
+
+	it('records durable snapshot read duration samples by layer outcome', async () => {
+		const before = await histogramCount('acuity_availability_snapshot_read_duration_seconds', {
+			kind: 'dates',
+			freshness: 'fresh',
+			outcome: 'hit',
+		});
+		recordAvailabilitySnapshotRead('dates', 'fresh', 'hit', 12);
+		const after = await histogramCount('acuity_availability_snapshot_read_duration_seconds', {
+			kind: 'dates',
+			freshness: 'fresh',
+			outcome: 'hit',
+		});
 		expect(after).toBe(before + 1);
 	});
 });

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -106,6 +106,14 @@ const availabilitySnapshotServedTotal = new Counter({
 	registers: [registry],
 });
 
+const availabilitySnapshotReadDuration = new Histogram({
+	name: 'acuity_availability_snapshot_read_duration_seconds',
+	help: 'Wall time for durable availability snapshot store reads by kind, freshness, and outcome',
+	labelNames: ['kind', 'freshness', 'outcome'],
+	buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+	registers: [registry],
+});
+
 // ─── Derived cache hit-ratio ─────────────────────────────────────────────────
 //
 // `cacheHitRatio` is a derived gauge — prom-client cannot compute it for us,
@@ -190,6 +198,18 @@ export const recordAvailabilitySnapshotServed = (kind: string, freshness: 'fresh
 	availabilitySnapshotServedTotal.inc({ kind, freshness });
 };
 
+export const recordAvailabilitySnapshotRead = (
+	kind: string,
+	freshness: 'fresh' | 'stale' | 'expired' | 'missing' | 'error',
+	outcome: 'hit' | 'miss' | 'error',
+	durationMs: number,
+): void => {
+	availabilitySnapshotReadDuration.observe(
+		{ kind, freshness, outcome },
+		Math.max(0, durationMs) / 1000,
+	);
+};
+
 // ─── Page-operation timer helper ─────────────────────────────────────────────
 //
 // Keep label cardinality low: `operation` should be a small enum of
@@ -250,6 +270,7 @@ export const metrics = {
 	bridgeReadCacheWaitDuration,
 	bridgeReadDuration,
 	availabilitySnapshotServedTotal,
+	availabilitySnapshotReadDuration,
 	recordCacheHit,
 	recordCacheMiss,
 	setBrowserPageLimiterState,
@@ -258,6 +279,7 @@ export const metrics = {
 	recordBridgeReadCacheWait,
 	observeBridgeRead,
 	recordAvailabilitySnapshotServed,
+	recordAvailabilitySnapshotRead,
 	observePageOp,
 	observePageOpEffect,
 	trackBrowserSession,


### PR DESCRIPTION
## Summary

- add an auth-gated internal durable snapshot canary at `/internal/availability/snapshot-canary`
- add `acuity_availability_snapshot_read_duration_seconds` for layer-specific snapshot timing
- bump package/Bazel metadata to `0.5.4` and refresh generated repo facts

## Why

TIN-1063 needs a way to prove the bridge durable snapshot layer independently from app Redis and bridge Redis hot paths. The canary bypasses the Redis read cache, reads the durable snapshot store directly, returns only metadata/count/timing, and requires `AUTH_TOKEN` to be configured.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm check:package`
- `pnpm check:artifact-authority`
- `pnpm check:release-metadata`
- `pnpm docs:generate`
- `pnpm docs:check`
- `git diff --check -- . ' :(exclude)dist' ' :(exclude)pkg'`
