### PR TITLE
Fairly interleave heartbeat demand

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.5",
+    version = "0.5.6",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.5",
+    version = "0.5.6",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,14 @@ weighted demand:
 }
 ```
 
-The heartbeat sorts demand by descending weight, skips fresh durable snapshots,
-enqueues stale/expired/missing date and slot refresh jobs up to `maxJobs`, and
-uses a time-windowed idempotency key so frequent cron runs do not create
-duplicate job storms. It does not run browser automation on the HTTP request
-path; the async worker owns the Acuity read.
+The heartbeat evaluates higher-weight demand first. Equal-weight demand is
+interleaved by service/request group before `maxJobs` is applied, so one service
+cannot consume the whole enqueue budget while same-priority services remain
+cold. The handler skips fresh durable snapshots, enqueues stale/expired/missing
+date and slot refresh jobs up to `maxJobs`, and uses a time-windowed idempotency
+key so frequent cron runs do not create duplicate job storms. It does not run
+browser automation on the HTTP request path; the async worker owns the Acuity
+read.
 
 ### Health Contract
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.5`
-- Bazel module version: `0.5.5`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.5`
+- package version: `0.5.6`
+- Bazel module version: `0.5.6`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.6`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/server/__tests__/async-endpoints.test.ts
+++ b/src/server/__tests__/async-endpoints.test.ts
@@ -567,6 +567,72 @@ describe('bridge async protocol endpoints', () => {
 		await expect(store.listReadyJobs(10)).resolves.toHaveLength(2);
 	});
 
+	it('fairly interleaves equal-priority heartbeat demand across services', async () => {
+		process.env.AUTH_TOKEN = 'heartbeat-token';
+		const store = createInMemoryBridgeAsyncStore();
+		const running = await listen(store);
+		activeServer = running.server;
+		const url = `${running.baseUrl}/internal/availability/heartbeat`;
+
+		const response = await fetch(url, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer heartbeat-token',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				maxJobs: 4,
+				idempotencyWindowMs: 60_000,
+				idempotencyKeyPrefix: 'test-heartbeat-fairness',
+				demands: [
+					{
+						serviceId: 'svc-a',
+						weight: 10,
+						months: ['2026-06', '2026-07', '2026-08'],
+					},
+					{
+						serviceId: 'svc-b',
+						weight: 10,
+						months: ['2026-06', '2026-07', '2026-08'],
+					},
+					{
+						serviceId: 'svc-c',
+						weight: 10,
+						months: ['2026-06', '2026-07', '2026-08'],
+					},
+				],
+			}),
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(202);
+		expect(body.data.enqueued).toMatchObject([
+			{ kind: 'dates', serviceId: 'svc-a', scope: '2026-06' },
+			{ kind: 'dates', serviceId: 'svc-b', scope: '2026-06' },
+			{ kind: 'dates', serviceId: 'svc-c', scope: '2026-06' },
+			{ kind: 'dates', serviceId: 'svc-a', scope: '2026-07' },
+		]);
+		expect(body.data.skipped).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ serviceId: 'svc-b', scope: '2026-07', reason: 'limit' }),
+				expect.objectContaining({ serviceId: 'svc-c', scope: '2026-07', reason: 'limit' }),
+				expect.objectContaining({ serviceId: 'svc-a', scope: '2026-08', reason: 'limit' }),
+			]),
+		);
+		await expect(store.listReadyJobs(10)).resolves.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: 'availability_dates_refresh',
+					idempotencyKey: expect.stringContaining('test-heartbeat-fairness:https://example.as.me:dates:svc-b:2026-06:'),
+				}),
+				expect.objectContaining({
+					kind: 'availability_dates_refresh',
+					idempotencyKey: expect.stringContaining('test-heartbeat-fairness:https://example.as.me:dates:svc-c:2026-06:'),
+				}),
+			]),
+		);
+	});
+
 	it('ignores expired request-path snapshots and refreshes from Acuity', async () => {
 		const store = createInMemoryBridgeAsyncStore();
 		await store.upsertAvailabilitySnapshot({

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -539,6 +539,46 @@ interface AvailabilityHeartbeatCandidate {
 	readonly order: number;
 }
 
+interface AvailabilityHeartbeatDemandGroup {
+	readonly weight: number;
+	readonly order: number;
+	readonly candidates: readonly AvailabilityHeartbeatCandidate[];
+}
+
+const interleaveEqualWeightHeartbeatGroups = (
+	groups: readonly AvailabilityHeartbeatDemandGroup[],
+): readonly AvailabilityHeartbeatCandidate[] => {
+	const interleaved: AvailabilityHeartbeatCandidate[] = [];
+	const orderedGroups = [...groups].sort((a, b) => a.order - b.order);
+	const maxLength = Math.max(0, ...orderedGroups.map((group) => group.candidates.length));
+	for (let candidateIndex = 0; candidateIndex < maxLength; candidateIndex += 1) {
+		for (const group of orderedGroups) {
+			const candidate = group.candidates[candidateIndex];
+			if (candidate) {
+				interleaved.push(candidate);
+			}
+		}
+	}
+	return interleaved;
+};
+
+const orderHeartbeatCandidateGroups = (
+	groups: readonly AvailabilityHeartbeatDemandGroup[],
+): readonly AvailabilityHeartbeatCandidate[] => {
+	const orderedGroups = [...groups].sort((a, b) => b.weight - a.weight || a.order - b.order);
+	const orderedCandidates: AvailabilityHeartbeatCandidate[] = [];
+	for (let index = 0; index < orderedGroups.length; ) {
+		const weight = orderedGroups[index]?.weight ?? 0;
+		const sameWeightGroups: AvailabilityHeartbeatDemandGroup[] = [];
+		while (index < orderedGroups.length && orderedGroups[index].weight === weight) {
+			sameWeightGroups.push(orderedGroups[index]);
+			index += 1;
+		}
+		orderedCandidates.push(...interleaveEqualWeightHeartbeatGroups(sameWeightGroups));
+	}
+	return orderedCandidates;
+};
+
 const parsePositiveInteger = (
 	value: unknown,
 	fallback: number,
@@ -595,7 +635,7 @@ const collectHeartbeatCandidates = (
 	const commonDates = collectStringList(rawBody.dates, ISO_DATE_RE, 'dates');
 	if (!commonDates.ok) return commonDates;
 
-	const candidates: AvailabilityHeartbeatCandidate[] = [];
+	const groups: AvailabilityHeartbeatDemandGroup[] = [];
 	for (const [demandIndex, demand] of rawBody.demands.entries()) {
 		if (!isRecord(demand)) {
 			return {
@@ -632,31 +672,37 @@ const collectHeartbeatCandidates = (
 		}
 		const parsedWeight = Number(demand.weight ?? 0);
 		const weight = Number.isFinite(parsedWeight) ? parsedWeight : 0;
+		const demandCandidates: AvailabilityHeartbeatCandidate[] = [];
 		for (const month of months.value) {
-			candidates.push({
+			demandCandidates.push({
 				kind: 'dates',
 				serviceId: demand.serviceId,
 				serviceName,
 				scope: month,
 				weight,
-				order: candidates.length,
+				order: demandCandidates.length,
 			});
 		}
 		for (const date of dates.value) {
-			candidates.push({
+			demandCandidates.push({
 				kind: 'slots',
 				serviceId: demand.serviceId,
 				serviceName,
 				scope: date,
 				weight,
-				order: candidates.length,
+				order: demandCandidates.length,
 			});
 		}
+		groups.push({
+			weight,
+			order: demandIndex,
+			candidates: demandCandidates,
+		});
 	}
 
 	return {
 		ok: true,
-		value: candidates.sort((a, b) => b.weight - a.weight || a.order - b.order),
+		value: orderHeartbeatCandidateGroups(groups),
 	};
 };
 


### PR DESCRIPTION
## Summary
- bump scheduling-bridge to 0.5.6
- interleave equal-priority availability heartbeat demand groups before applying maxJobs
- preserve strict higher-weight priority while removing same-priority request-order starvation
- add heartbeat fairness coverage and update README/generated repo facts

## Validation
- pnpm test:host -- src/server/__tests__/async-endpoints.test.ts
- pnpm typecheck
- pnpm docs:generate
- pnpm build
- pnpm test
- pnpm check:release-metadata
- pnpm check:package
- pnpm docs:check
- pnpm check:artifact-authority