### PR TITLE
[codex] Make heartbeat idempotency retry-aware

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.6",
+    version = "0.5.7",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.6",
+    version = "0.5.7",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ cold. The handler skips fresh durable snapshots, enqueues stale/expired/missing
 date and slot refresh jobs up to `maxJobs`, and uses a time-windowed idempotency
 key so frequent cron runs do not create duplicate job storms. It does not run
 browser automation on the HTTP request path; the async worker owns the Acuity
-read.
+read. If an idempotency key resolves to a retryable failed job, heartbeat
+requeues that existing operation before reporting it as work; non-retryable
+terminal jobs are reported under `skipped` instead of masquerading as newly
+enqueued refreshes.
 
 ### Health Contract
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.6`
-- Bazel module version: `0.5.6`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.6`
+- package version: `0.5.7`
+- Bazel module version: `0.5.7`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.7`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/async/types.ts
+++ b/src/async/types.ts
@@ -182,6 +182,7 @@ export interface AvailabilityHeartbeatJob {
 	readonly operationId: string;
 	readonly status: BridgeJobStatus;
 	readonly statusUrl: string;
+	readonly action: 'queued' | 'deduped' | 'requeued';
 	readonly kind: AvailabilitySnapshotKind;
 	readonly serviceId: string;
 	readonly scope: string;
@@ -193,9 +194,12 @@ export interface AvailabilityHeartbeatSkipped {
 	readonly kind: AvailabilitySnapshotKind;
 	readonly serviceId: string;
 	readonly scope: string;
-	readonly reason: 'fresh' | 'limit';
+	readonly reason: 'fresh' | 'limit' | 'terminal' | 'requeue_failed';
 	readonly freshness?: 'fresh';
 	readonly weight: number;
+	readonly status?: BridgeJobStatus;
+	readonly operationId?: string;
+	readonly statusUrl?: string;
 }
 
 export interface AvailabilityHeartbeatResponse {

--- a/src/server/__tests__/async-endpoints.test.ts
+++ b/src/server/__tests__/async-endpoints.test.ts
@@ -567,6 +567,118 @@ describe('bridge async protocol endpoints', () => {
 		await expect(store.listReadyJobs(10)).resolves.toHaveLength(2);
 	});
 
+	it('requeues retryable heartbeat idempotency hits instead of reporting failed records as enqueued', async () => {
+		process.env.AUTH_TOKEN = 'heartbeat-token';
+		const store = createInMemoryBridgeAsyncStore();
+		const running = await listen(store);
+		activeServer = running.server;
+		const url = `${running.baseUrl}/internal/availability/heartbeat`;
+		const payload = {
+			maxJobs: 1,
+			idempotencyWindowMs: 60_000,
+			idempotencyKeyPrefix: 'test-heartbeat-retry',
+			demands: [
+				{
+					serviceId: 'svc-retry',
+					serviceName: 'Retryable service',
+					weight: 10,
+					months: ['2026-06'],
+				},
+			],
+		};
+
+		const firstResponse = await fetch(url, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer heartbeat-token',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(payload),
+		});
+		const first = await firstResponse.json();
+		const operationId = first.data.enqueued[0].operationId as string;
+
+		expect(firstResponse.status).toBe(202);
+		expect(first.data.enqueued).toMatchObject([
+			{
+				operationId,
+				status: 'queued',
+				action: 'queued',
+				kind: 'dates',
+				serviceId: 'svc-retry',
+				scope: '2026-06',
+			},
+		]);
+
+		await store.failJob(operationId, {
+			status: 'failed_pre_submit',
+			code: 'NETWORK',
+			message: 'Browser error: PAGE_FAILED',
+			step: 'refresh-availability-dates',
+			retryable: true,
+		});
+
+		const retryResponse = await fetch(url, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer heartbeat-token',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(payload),
+		});
+		const retry = await retryResponse.json();
+
+		expect(retryResponse.status).toBe(202);
+		expect(retry.data.enqueued).toMatchObject([
+			{
+				operationId,
+				status: 'queued',
+				action: 'requeued',
+				kind: 'dates',
+				serviceId: 'svc-retry',
+				scope: '2026-06',
+			},
+		]);
+		await expect(store.listReadyJobs(10)).resolves.toMatchObject([
+			{
+				operationId,
+				status: 'queued',
+			},
+		]);
+
+		await store.failJob(operationId, {
+			status: 'failed_pre_submit',
+			code: 'PAYMENT_BYPASS_NOT_PROVEN',
+			message: 'Non-retryable failure',
+			step: 'bypass-payment',
+			retryable: false,
+		});
+
+		const terminalResponse = await fetch(url, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer heartbeat-token',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(payload),
+		});
+		const terminal = await terminalResponse.json();
+
+		expect(terminalResponse.status).toBe(202);
+		expect(terminal.data.enqueued).toEqual([]);
+		expect(terminal.data.skipped).toEqual([
+			expect.objectContaining({
+				operationId,
+				reason: 'terminal',
+				status: 'failed_pre_submit',
+				kind: 'dates',
+				serviceId: 'svc-retry',
+				scope: '2026-06',
+			}),
+		]);
+		await expect(store.listReadyJobs(10)).resolves.toHaveLength(0);
+	});
+
 	it('fairly interleaves equal-priority heartbeat demand across services', async () => {
 		process.env.AUTH_TOKEN = 'heartbeat-token';
 		const store = createInMemoryBridgeAsyncStore();

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -93,6 +93,7 @@ import type {
 	BridgeAdapterProfile,
 	BridgeJobCommand,
 	BridgeJobRecord,
+	BridgeJobStatus,
 	EnqueueBridgeJobResponse,
 } from '../async/types.js';
 import { createAcuityBridgeJobExecutor, runBridgeWorkerLoop } from './worker.js';
@@ -771,6 +772,16 @@ const toEnqueueResponse = (job: BridgeJobRecord): EnqueueBridgeJobResponse => ({
 	status: job.status,
 	statusUrl: jobStatusUrl(job.operationId),
 });
+
+const heartbeatRunnableStatuses = new Set<BridgeJobStatus>([
+	'queued',
+	'leased',
+	'running',
+]);
+
+const isRetryableHeartbeatFailure = (record: BridgeJobRecord): boolean =>
+	(record.status === 'failed_pre_submit' || record.status === 'reconcile_required') &&
+	record.failure?.retryable === true;
 
 const sendAccepted = <T>(res: ServerResponse, data: T) => sendJson(res, 202, { success: true, data });
 
@@ -1664,12 +1675,47 @@ const handleAvailabilityHeartbeat = async (req: IncomingMessage, res: ServerResp
 			candidate.scope,
 			idempotencyBucket,
 		].join(':');
-		const record = await bridgeAsyncStore.enqueueJob(job, { idempotencyKey });
-		recordAvailabilityHeartbeatJob(candidate.kind, 'enqueued');
+		let record = await bridgeAsyncStore.enqueueJob(job, { idempotencyKey });
+		let action: AvailabilityHeartbeatJob['action'] = 'queued';
+		if (isRetryableHeartbeatFailure(record)) {
+			const requeued = await bridgeAsyncStore.requeueJob(record.operationId);
+			if (!requeued) {
+				recordAvailabilityHeartbeatJob(candidate.kind, 'requeue_failed');
+				skipped.push({
+					kind: candidate.kind,
+					serviceId: candidate.serviceId,
+					scope: candidate.scope,
+					reason: 'requeue_failed',
+					weight: candidate.weight,
+					status: record.status,
+					operationId: record.operationId,
+					statusUrl: jobStatusUrl(record.operationId),
+				});
+				continue;
+			}
+			record = requeued;
+			action = 'requeued';
+		}
+		if (!heartbeatRunnableStatuses.has(record.status)) {
+			recordAvailabilityHeartbeatJob(candidate.kind, 'skipped_terminal');
+			skipped.push({
+				kind: candidate.kind,
+				serviceId: candidate.serviceId,
+				scope: candidate.scope,
+				reason: 'terminal',
+				weight: candidate.weight,
+				status: record.status,
+				operationId: record.operationId,
+				statusUrl: jobStatusUrl(record.operationId),
+			});
+			continue;
+		}
+		recordAvailabilityHeartbeatJob(candidate.kind, action);
 		enqueued.push({
 			operationId: record.operationId,
 			status: record.status,
 			statusUrl: jobStatusUrl(record.operationId),
+			action,
 			kind: candidate.kind,
 			serviceId: candidate.serviceId,
 			scope: candidate.scope,

--- a/src/shared/metrics.test.ts
+++ b/src/shared/metrics.test.ts
@@ -143,9 +143,9 @@ describe('bridge read cache metrics wiring', () => {
 			return snap.values.find((v) => v.labels.kind === kind && v.labels.action === action)?.value ?? 0;
 		};
 
-		const before = await heartbeatCounter('dates', 'enqueued');
-		recordAvailabilityHeartbeatJob('dates', 'enqueued');
-		const after = await heartbeatCounter('dates', 'enqueued');
+		const before = await heartbeatCounter('dates', 'queued');
+		recordAvailabilityHeartbeatJob('dates', 'queued');
+		const after = await heartbeatCounter('dates', 'queued');
 		expect(after).toBe(before + 1);
 	});
 });

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -219,7 +219,14 @@ export const recordAvailabilitySnapshotRead = (
 
 export const recordAvailabilityHeartbeatJob = (
 	kind: string,
-	action: 'enqueued' | 'skipped_fresh' | 'skipped_limit',
+	action:
+		| 'queued'
+		| 'deduped'
+		| 'requeued'
+		| 'skipped_fresh'
+		| 'skipped_limit'
+		| 'skipped_terminal'
+		| 'requeue_failed',
 ): void => {
 	availabilityHeartbeatJobsTotal.inc({ kind, action });
 };


### PR DESCRIPTION
## Summary
- bump scheduling-bridge to 0.5.7
- requeue retryable failed heartbeat idempotency hits before reporting them as heartbeat work
- report non-retryable terminal idempotency hits under skipped with operation/status metadata
- add endpoint regression coverage and update generated repo facts

## Validation
- pnpm docs:generate
- git diff --check
- pnpm typecheck
- pnpm test:host -- src/server/__tests__/async-endpoints.test.ts src/shared/metrics.test.ts
- pnpm docs:check
- pnpm prepublishOnly
- pnpm test

Root cause: heartbeat treated any idempotent enqueue return as newly enqueued work, even if the existing record was a retryable failed operation from an interrupted worker/rollout.