### PR TITLE
Fix availability wait-ready convergence

### DIFF
--- a/src/server/__tests__/async-endpoints.test.ts
+++ b/src/server/__tests__/async-endpoints.test.ts
@@ -563,6 +563,63 @@ describe('bridge async protocol endpoints', () => {
 		await expect(store.listReadyJobs(10)).resolves.toHaveLength(2);
 	});
 
+	it('uses the readiness freshness floor when wait-ready schedules heartbeat work', async () => {
+		process.env.AUTH_TOKEN = 'readiness-token';
+		const store = createInMemoryBridgeAsyncStore();
+		await store.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: service.id,
+			scope: '2026-06',
+			adapterProfile: {
+				backend: 'acuity',
+				baseUrl: 'https://example.as.me',
+			},
+			value: [{ date: '2026-06-15' }],
+			observedAt: '2000-01-01T00:00:00.000Z',
+			staleAt: '2999-01-01T00:05:00.000Z',
+			expiresAt: '2999-01-01T00:30:00.000Z',
+		});
+		const running = await listen(store);
+		activeServer = running.server;
+
+		const response = await fetch(
+			`${running.baseUrl}/internal/availability/wait-ready`,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer readiness-token',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					demands: [{ serviceId: service.id, months: ['2026-06'] }],
+					maxJobs: 1,
+					timeoutMs: 1,
+					pollMs: 1,
+					snapshotFreshnessFloorMs: 90_000,
+					idempotencyKeyPrefix: 'test-readiness-floor',
+				}),
+			},
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(409);
+		expect(body.data.heartbeat.enqueued).toMatchObject([
+			{
+				action: expect.stringMatching(/^(queued|deduped)$/),
+				kind: 'dates',
+				serviceId: service.id,
+				scope: '2026-06',
+				freshness: 'stale',
+			},
+		]);
+		await expect(store.listReadyJobs(10)).resolves.toMatchObject([
+			{
+				kind: 'availability_dates_refresh',
+				status: 'queued',
+			},
+		]);
+	});
+
 	it('auth-gates the internal snapshot canary and records durable snapshot layer metrics', async () => {
 		process.env.AUTH_TOKEN = 'canary-token';
 		const store = createInMemoryBridgeAsyncStore();
@@ -801,16 +858,28 @@ describe('bridge async protocol endpoints', () => {
 		const second = await secondResponse.json();
 
 		expect(secondResponse.status).toBe(202);
-		expect(
-			second.data.enqueued.map(
-				(job: { operationId: string }) => job.operationId,
-			),
-		).toEqual(
-			first.data.enqueued.map(
-				(job: { operationId: string }) => job.operationId,
-			),
+		expect(second.data.enqueued).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					operationId: first.data.enqueued[0].operationId,
+					action: 'deduped',
+					kind: 'dates',
+					scope: '2026-07',
+				}),
+				expect.objectContaining({
+					operationId: first.data.enqueued[1].operationId,
+					action: 'deduped',
+					kind: 'slots',
+					scope: '2026-06-15',
+				}),
+				expect.objectContaining({
+					action: 'queued',
+					kind: 'dates',
+					scope: '2026-08',
+				}),
+			]),
 		);
-		await expect(store.listReadyJobs(10)).resolves.toHaveLength(2);
+		await expect(store.listReadyJobs(10)).resolves.toHaveLength(3);
 	});
 
 	it('requeues retryable heartbeat idempotency hits instead of reporting failed records as enqueued', async () => {

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -2053,6 +2053,7 @@ const runAvailabilityHeartbeat = async (
 		readonly maxJobs: number;
 		readonly idempotencyWindowMs: number;
 		readonly idempotencyKeyPrefix?: string;
+		readonly snapshotFreshnessFloorMs?: number;
 		readonly context: RequestContext;
 	},
 ): Promise<AvailabilityHeartbeatResponse> => {
@@ -2063,6 +2064,7 @@ const runAvailabilityHeartbeat = async (
 		options.idempotencyKeyPrefix ?? 'availability-heartbeat';
 	const enqueued: AvailabilityHeartbeatJob[] = [];
 	const skipped: AvailabilityHeartbeatSkipped[] = [];
+	let submittedJobs = 0;
 
 	for (const candidate of candidates) {
 		const snapshot = await bridgeAsyncStore.getAvailabilitySnapshot({
@@ -2072,7 +2074,13 @@ const runAvailabilityHeartbeat = async (
 			baseUrl: ACUITY_BASE_URL,
 		});
 		const freshness = snapshot
-			? classifyAvailabilitySnapshotFreshness(snapshot)
+			? options.snapshotFreshnessFloorMs === undefined
+				? classifyAvailabilitySnapshotFreshness(snapshot)
+				: classifyAvailabilityReadinessFreshness(
+						snapshot,
+						new Date(),
+						options.snapshotFreshnessFloorMs,
+					)
 			: 'missing';
 
 		if (freshness === 'fresh') {
@@ -2088,7 +2096,7 @@ const runAvailabilityHeartbeat = async (
 			continue;
 		}
 
-		if (enqueued.length >= options.maxJobs) {
+		if (submittedJobs >= options.maxJobs) {
 			recordAvailabilityHeartbeatJob(candidate.kind, 'skipped_limit');
 			skipped.push({
 				kind: candidate.kind,
@@ -2128,8 +2136,10 @@ const runAvailabilityHeartbeat = async (
 			candidate.scope,
 			idempotencyBucket,
 		].join(':');
+		const enqueueStartedAt = Date.now();
 		let record = await bridgeAsyncStore.enqueueJob(job, { idempotencyKey });
-		let action: AvailabilityHeartbeatJob['action'] = 'queued';
+		let action: AvailabilityHeartbeatJob['action'] =
+			Date.parse(record.createdAt) < enqueueStartedAt ? 'deduped' : 'queued';
 		if (isRetryableHeartbeatFailure(record)) {
 			const requeued = await bridgeAsyncStore.requeueJob(record.operationId);
 			if (!requeued) {
@@ -2148,6 +2158,9 @@ const runAvailabilityHeartbeat = async (
 			}
 			record = requeued;
 			action = 'requeued';
+		}
+		if (action !== 'deduped') {
+			submittedJobs += 1;
 		}
 		if (!heartbeatRunnableStatuses.has(record.status)) {
 			recordAvailabilityHeartbeatJob(candidate.kind, 'skipped_terminal');
@@ -2332,10 +2345,11 @@ const handleAvailabilityWaitReady = async (
 	const startedAt = Date.now();
 	let attempts = 0;
 
-	const heartbeat = await runAvailabilityHeartbeat(parsed.candidates, {
+	let heartbeat = await runAvailabilityHeartbeat(parsed.candidates, {
 		maxJobs,
 		idempotencyWindowMs,
 		idempotencyKeyPrefix,
+		snapshotFreshnessFloorMs: policy.snapshotFreshnessFloorMs,
 		context,
 	});
 	let readiness = await evaluateAvailabilityReadiness(
@@ -2347,6 +2361,13 @@ const handleAvailabilityWaitReady = async (
 		await wait(
 			Math.min(pollMs, Math.max(0, timeoutMs - (Date.now() - startedAt))),
 		);
+		heartbeat = await runAvailabilityHeartbeat(parsed.candidates, {
+			maxJobs,
+			idempotencyWindowMs,
+			idempotencyKeyPrefix,
+			snapshotFreshnessFloorMs: policy.snapshotFreshnessFloorMs,
+			context,
+		});
 		readiness = await evaluateAvailabilityReadiness(parsed.candidates, policy);
 		attempts += 1;
 	}


### PR DESCRIPTION
## Summary
- make wait-ready run heartbeat waves during the wait window instead of only once
- treat idempotent in-flight heartbeat hits as deduped so they do not consume new-job capacity
- make wait-ready heartbeat scheduling use the same snapshot freshness floor as readiness evaluation

## Validation
- pnpm test:host src/server/__tests__/async-endpoints.test.ts src/async/store.test.ts
- pnpm typecheck
- pnpm build

## Runtime finding
The Blahaj readiness gate now reaches the K8s bridge correctly, but live sha-542d825 timed out because broad readiness demand could not converge under the old one-shot heartbeat semantics.