### PR TITLE
Use readiness floor for availability heartbeat freshness

### DIFF
--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -55,7 +55,7 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 ## Protocol Surface
 
-- protocol version: `1.1.0`
+- protocol version: `1.2.0`
 - flow owner: `scheduling-bridge`
 - transport: `http-json`
 - backend: `acuity`
@@ -73,6 +73,8 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 | `availabilityRefresh` | `/availability/refresh` |
 | `availabilitySnapshot` | `/availability/snapshot` |
 | `availabilityHeartbeat` | `/internal/availability/heartbeat` |
+| `availabilityReadiness` | `/internal/availability/readiness` |
+| `availabilityWaitReady` | `/internal/availability/wait-ready` |
 | `bookingCreate` | `/booking/create` |
 | `bookingCreateWithPayment` | `/booking/create-with-payment` |
 | `bookingJobs` | `/booking/jobs` |
@@ -88,6 +90,8 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 - `availability:refresh-async`
 - `availability:snapshot`
 - `availability:heartbeat-internal`
+- `availability:readiness-internal`
+- `availability:wait-ready-internal`
 - `booking:create`
 - `booking:create-with-payment:deprecated`
 - `booking:create-with-payment-async`

--- a/llms.txt
+++ b/llms.txt
@@ -27,7 +27,7 @@ Toolchains:
 - CI publish node: `24`
 
 Protocol:
-- version: `1.1.0`
+- version: `1.2.0`
 - flow owner: `scheduling-bridge`
 - backend: `acuity`
 - transport: `http-json`
@@ -42,6 +42,8 @@ Endpoints:
 - `availabilityRefresh` -> `/availability/refresh`
 - `availabilitySnapshot` -> `/availability/snapshot`
 - `availabilityHeartbeat` -> `/internal/availability/heartbeat`
+- `availabilityReadiness` -> `/internal/availability/readiness`
+- `availabilityWaitReady` -> `/internal/availability/wait-ready`
 - `bookingCreate` -> `/booking/create`
 - `bookingCreateWithPayment` -> `/booking/create-with-payment`
 - `bookingJobs` -> `/booking/jobs`
@@ -56,6 +58,8 @@ Capabilities:
 - `availability:refresh-async`
 - `availability:snapshot`
 - `availability:heartbeat-internal`
+- `availability:readiness-internal`
+- `availability:wait-ready-internal`
 - `booking:create`
 - `booking:create-with-payment:deprecated`
 - `booking:create-with-payment-async`

--- a/src/async/types.ts
+++ b/src/async/types.ts
@@ -170,6 +170,7 @@ export interface AvailabilityHeartbeatRequest {
 	readonly maxJobs?: number;
 	readonly idempotencyWindowMs?: number;
 	readonly idempotencyKeyPrefix?: string;
+	readonly snapshotFreshnessFloorMs?: number;
 }
 
 export interface EnqueueBridgeJobResponse {

--- a/src/server/__tests__/async-endpoints.test.ts
+++ b/src/server/__tests__/async-endpoints.test.ts
@@ -987,6 +987,59 @@ describe('bridge async protocol endpoints', () => {
 		await expect(store.listReadyJobs(10)).resolves.toHaveLength(3);
 	});
 
+	it('uses the readiness freshness floor for normal heartbeat scheduling', async () => {
+		process.env.AUTH_TOKEN = 'heartbeat-token';
+		const store = createInMemoryBridgeAsyncStore();
+		await store.upsertAvailabilitySnapshot({
+			kind: 'dates',
+			serviceId: service.id,
+			scope: '2026-06',
+			adapterProfile: {
+				backend: 'acuity',
+				baseUrl: 'https://example.as.me',
+			},
+			value: [{ date: '2026-06-15' }],
+			observedAt: '2000-01-01T00:00:00.000Z',
+			staleAt: '2999-01-01T00:05:00.000Z',
+			expiresAt: '2999-01-01T00:30:00.000Z',
+		});
+		const running = await listen(store);
+		activeServer = running.server;
+
+		const response = await fetch(
+			`${running.baseUrl}/internal/availability/heartbeat`,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer heartbeat-token',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					maxJobs: 1,
+					idempotencyKeyPrefix: 'test-heartbeat-readiness-floor',
+					demands: [{ serviceId: service.id, months: ['2026-06'] }],
+				}),
+			},
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(202);
+		expect(body.data.enqueued).toMatchObject([
+			{
+				kind: 'dates',
+				serviceId: service.id,
+				scope: '2026-06',
+				freshness: 'stale',
+			},
+		]);
+		await expect(store.listReadyJobs(10)).resolves.toMatchObject([
+			{
+				kind: 'availability_dates_refresh',
+				status: 'queued',
+			},
+		]);
+	});
+
 	it('requeues retryable heartbeat idempotency hits instead of reporting failed records as enqueued', async () => {
 		process.env.AUTH_TOKEN = 'heartbeat-token';
 		const store = createInMemoryBridgeAsyncStore();

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -2261,11 +2261,16 @@ const handleAvailabilityHeartbeat = async (
 		rawBody.idempotencyWindowMs,
 		HEARTBEAT_DEFAULT_IDEMPOTENCY_WINDOW_MS,
 	);
+	const snapshotFreshnessFloorMs = parsePositiveMs(
+		rawBody.snapshotFreshnessFloorMs,
+		READINESS_DEFAULT_FRESHNESS_FLOOR_MS,
+	);
 
 	const response = await runAvailabilityHeartbeat(candidates.value, {
 		maxJobs,
 		idempotencyWindowMs,
 		idempotencyKeyPrefix,
+		snapshotFreshnessFloorMs,
 		context,
 	});
 	return sendAccepted(res, response);


### PR DESCRIPTION
## Summary
- apply the readiness snapshot freshness floor to normal availability heartbeat calls
- expose optional snapshotFreshnessFloorMs on the heartbeat request type
- add route coverage for snapshots that are before the readiness floor but still before staleAt
- refresh generated protocol docs

## Validation
- pnpm exec vitest run src/server/__tests__/async-endpoints.test.ts --reporter=dot
- pnpm exec tsc --noEmit
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm docs:generate