### PR TITLE
Release scheduling bridge 0.5.8

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.7",
+    version = "0.5.8",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.7",
+    version = "0.5.8",
     compatibility_level = 1,
 )
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.7`
-- Bazel module version: `0.5.7`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.7`
+- package version: `0.5.8`
+- Bazel module version: `0.5.8`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.8`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary
- bump package, Bazel module, and Bazel package metadata to 0.5.8
- refresh generated repo facts for the release tuple

## Validation
- pnpm docs:generate
- pnpm check:release-metadata
- pnpm typecheck
- pnpm test
- pnpm build