### PR TITLE
Release scheduling bridge 0.5.9

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.8",
+    version = "0.5.9",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.8",
+    version = "0.5.9",
     compatibility_level = 1,
 )
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.8`
-- Bazel module version: `0.5.8`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.8`
+- package version: `0.5.9`
+- Bazel module version: `0.5.9`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.9`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary\n- bump @tummycrypt/scheduling-bridge to 0.5.9\n- align MODULE.bazel, BUILD.bazel, and generated repo facts\n\n## Includes\n- bounded async worker concurrency from #127\n\n## Verification\n- pnpm docs:generate\n- pnpm docs:check\n- pnpm check:release-metadata\n- pnpm check:artifact-authority\n- pnpm check:package