### PR TITLE
Release scheduling bridge 0.5.10

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.9",
+    version = "0.5.10",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.9",
+    version = "0.5.10",
     compatibility_level = 1,
 )
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.9`
-- Bazel module version: `0.5.9`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.9`
+- package version: `0.5.10`
+- Bazel module version: `0.5.10`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.10`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

Release `@tummycrypt/scheduling-bridge@0.5.10` after the queue hygiene implementation in #131.

- bumps package metadata to `0.5.10`
- bumps Bazel module/package metadata to `0.5.10`
- regenerates repo facts

## Validation

- `pnpm check:release-metadata`
- `pnpm check:artifact-authority`
- `pnpm docs:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `git diff --check`

## Next

After merge/tag/publish, promote the `sha-<release>` bridge image through Blahaj so honey receives both the 0.5.10 code and the already-merged `BRIDGE_REDIS_ASYNC_JOB_TTL_SECONDS` env wiring.