### PR TITLE
Fairly weight heartbeat demand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ That makes this repo central to the migration paper and to the operational beta-
 
 ## Current Tracking
 
-As of `2026-05-08`, the active structural work here is:
+As of `2026-05-10`, the active structural work here is:
 
 - `TIN-89` package, Bazel, CI, publish, and dependency truth across shared
   scheduling packages
@@ -52,8 +52,8 @@ As of `2026-05-08`, the active structural work here is:
 
 Operationally relevant truth:
 
-- current package metadata is `@tummycrypt/scheduling-bridge` `0.5.7`
-- `0.5.7` depends on `@tummycrypt/scheduling-kit ^0.8.0`
+- current package metadata is `@tummycrypt/scheduling-bridge` `0.5.10`
+- `0.5.10` depends on `@tummycrypt/scheduling-kit ^0.8.0`
 - the `0.5.x` line is the async bridge redesign lane: async booking jobs,
   availability snapshots, Redis/Postgres async stores, and request-path
   availability prewarm enqueueing

--- a/README.md
+++ b/README.md
@@ -89,21 +89,22 @@ weighted demand:
 }
 ```
 
-The heartbeat evaluates higher-weight demand first. Equal-weight demand is
-interleaved by service/request group before `maxJobs` is applied, so one service
-cannot consume the whole enqueue budget while same-priority services remain
-cold. The handler skips fresh durable snapshots, enqueues stale/expired/missing
-date and slot refresh jobs up to `maxJobs`, and uses a time-windowed idempotency
-key so frequent cron runs do not create duplicate job storms. It does not run
-browser automation on the HTTP request path; the async worker owns the Acuity
-read. If an idempotency key resolves to a retryable failed job, heartbeat
-requeues that existing operation before reporting it as work; non-retryable
-terminal jobs are reported under `skipped` instead of masquerading as newly
-enqueued refreshes.
+The heartbeat uses weighted fairness across service/request groups before
+`maxJobs` is applied. A higher `weight` biases additional work toward that
+demand, but every active demand group receives early representation before one
+high-weight service can consume the whole enqueue budget. Equal-weight demand is
+round-robin interleaved by request order. The handler skips fresh durable
+snapshots, enqueues stale/expired/missing date and slot refresh jobs up to
+`maxJobs`, and uses a time-windowed idempotency key so frequent cron runs do not
+create duplicate job storms. It does not run browser automation on the HTTP
+request path; the async worker owns the Acuity read. If an idempotency key
+resolves to a retryable failed job, heartbeat requeues that existing operation
+before reporting it as work; non-retryable terminal jobs are reported under
+`skipped` instead of masquerading as newly enqueued refreshes.
 
 ### Queue Hygiene
 
-Bridge `0.5.9` supports bounded worker drain concurrency through
+Bridge `0.5.10` supports bounded worker drain concurrency through
 `BRIDGE_WORKER_CONCURRENCY`. The package default remains `1`; the MassageIthaca
 K8s deployment currently opts into `2` through Blahaj/OpenTofu after proving the
 datepicker readiness gate remains green.

--- a/src/server/__tests__/async-endpoints.test.ts
+++ b/src/server/__tests__/async-endpoints.test.ts
@@ -903,15 +903,15 @@ describe('bridge async protocol endpoints', () => {
 					{
 						kind: 'dates',
 						serviceId: service.id,
-						scope: '2026-07',
+						scope: '2026-08',
 						freshness: 'missing',
-						weight: 10,
+						weight: 1,
 					},
 					{
-						kind: 'slots',
+						kind: 'dates',
 						serviceId: service.id,
-						scope: '2026-06-15',
-						freshness: 'expired',
+						scope: '2026-07',
+						freshness: 'missing',
 						weight: 10,
 					},
 				],
@@ -924,10 +924,11 @@ describe('bridge async protocol endpoints', () => {
 						freshness: 'fresh',
 					}),
 					expect.objectContaining({
-						kind: 'dates',
+						kind: 'slots',
 						serviceId: service.id,
-						scope: '2026-08',
+						scope: '2026-06-15',
 						reason: 'limit',
+						weight: 10,
 					}),
 				]),
 			},
@@ -940,13 +941,13 @@ describe('bridge async protocol endpoints', () => {
 				expect.objectContaining({
 					kind: 'availability_dates_refresh',
 					idempotencyKey: expect.stringContaining(
-						'test-heartbeat:https://example.as.me:dates:53178494:2026-07:',
+						'test-heartbeat:https://example.as.me:dates:53178494:2026-08:',
 					),
 				}),
 				expect.objectContaining({
-					kind: 'availability_slots_refresh',
+					kind: 'availability_dates_refresh',
 					idempotencyKey: expect.stringContaining(
-						'test-heartbeat:https://example.as.me:slots:53178494:2026-06-15:',
+						'test-heartbeat:https://example.as.me:dates:53178494:2026-07:',
 					),
 				}),
 			]),
@@ -969,18 +970,18 @@ describe('bridge async protocol endpoints', () => {
 					operationId: first.data.enqueued[0].operationId,
 					action: 'deduped',
 					kind: 'dates',
-					scope: '2026-07',
+					scope: '2026-08',
 				}),
 				expect.objectContaining({
 					operationId: first.data.enqueued[1].operationId,
 					action: 'deduped',
-					kind: 'slots',
-					scope: '2026-06-15',
+					kind: 'dates',
+					scope: '2026-07',
 				}),
 				expect.objectContaining({
 					action: 'queued',
-					kind: 'dates',
-					scope: '2026-08',
+					kind: 'slots',
+					scope: '2026-06-15',
 				}),
 			]),
 		);
@@ -1228,6 +1229,83 @@ describe('bridge async protocol endpoints', () => {
 					kind: 'availability_dates_refresh',
 					idempotencyKey: expect.stringContaining(
 						'test-heartbeat-fairness:https://example.as.me:dates:svc-c:2026-06:',
+					),
+				}),
+			]),
+		);
+	});
+
+	it('prevents high-weight heartbeat demand from monopolizing the enqueue budget', async () => {
+		process.env.AUTH_TOKEN = 'heartbeat-token';
+		const store = createInMemoryBridgeAsyncStore();
+		const running = await listen(store);
+		activeServer = running.server;
+		const url = `${running.baseUrl}/internal/availability/heartbeat`;
+
+		const response = await fetch(url, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer heartbeat-token',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				maxJobs: 4,
+				idempotencyWindowMs: 60_000,
+				idempotencyKeyPrefix: 'test-heartbeat-weighted-fairness',
+				demands: [
+					{
+						serviceId: 'svc-high',
+						weight: 10,
+						months: ['2026-06', '2026-07', '2026-08', '2026-09'],
+					},
+					{
+						serviceId: 'svc-low-a',
+						weight: 1,
+						months: ['2026-06', '2026-07'],
+					},
+					{
+						serviceId: 'svc-low-b',
+						weight: 1,
+						months: ['2026-06'],
+					},
+				],
+			}),
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(202);
+		expect(body.data.enqueued).toMatchObject([
+			{ kind: 'dates', serviceId: 'svc-high', scope: '2026-06', weight: 10 },
+			{ kind: 'dates', serviceId: 'svc-low-a', scope: '2026-06', weight: 1 },
+			{ kind: 'dates', serviceId: 'svc-low-b', scope: '2026-06', weight: 1 },
+			{ kind: 'dates', serviceId: 'svc-high', scope: '2026-07', weight: 10 },
+		]);
+		expect(body.data.skipped).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					serviceId: 'svc-high',
+					scope: '2026-08',
+					reason: 'limit',
+				}),
+				expect.objectContaining({
+					serviceId: 'svc-low-a',
+					scope: '2026-07',
+					reason: 'limit',
+				}),
+			]),
+		);
+		await expect(store.listReadyJobs(10)).resolves.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: 'availability_dates_refresh',
+					idempotencyKey: expect.stringContaining(
+						'test-heartbeat-weighted-fairness:https://example.as.me:dates:svc-low-a:2026-06:',
+					),
+				}),
+				expect.objectContaining({
+					kind: 'availability_dates_refresh',
+					idempotencyKey: expect.stringContaining(
+						'test-heartbeat-weighted-fairness:https://example.as.me:dates:svc-low-b:2026-06:',
 					),
 				}),
 			]),

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -677,50 +677,50 @@ interface AvailabilityHeartbeatDemandGroup {
 	readonly candidates: readonly AvailabilityHeartbeatCandidate[];
 }
 
-const interleaveEqualWeightHeartbeatGroups = (
-	groups: readonly AvailabilityHeartbeatDemandGroup[],
-): readonly AvailabilityHeartbeatCandidate[] => {
-	const interleaved: AvailabilityHeartbeatCandidate[] = [];
-	const orderedGroups = [...groups].sort((a, b) => a.order - b.order);
-	const maxLength = Math.max(
-		0,
-		...orderedGroups.map((group) => group.candidates.length),
-	);
-	for (
-		let candidateIndex = 0;
-		candidateIndex < maxLength;
-		candidateIndex += 1
-	) {
-		for (const group of orderedGroups) {
-			const candidate = group.candidates[candidateIndex];
-			if (candidate) {
-				interleaved.push(candidate);
-			}
-		}
-	}
-	return interleaved;
+interface AvailabilityHeartbeatDemandGroupCursor {
+	readonly group: AvailabilityHeartbeatDemandGroup;
+	readonly schedulingWeight: number;
+	candidateIndex: number;
+	served: number;
+}
+
+const heartbeatSchedulingWeight = (weight: number): number => {
+	if (!Number.isFinite(weight)) return 1;
+	return Math.max(1, Math.min(100, Math.floor(weight)));
 };
 
 const orderHeartbeatCandidateGroups = (
 	groups: readonly AvailabilityHeartbeatDemandGroup[],
 ): readonly AvailabilityHeartbeatCandidate[] => {
-	const orderedGroups = [...groups].sort(
-		(a, b) => b.weight - a.weight || a.order - b.order,
-	);
 	const orderedCandidates: AvailabilityHeartbeatCandidate[] = [];
-	for (let index = 0; index < orderedGroups.length; ) {
-		const weight = orderedGroups[index]?.weight ?? 0;
-		const sameWeightGroups: AvailabilityHeartbeatDemandGroup[] = [];
-		while (
-			index < orderedGroups.length &&
-			orderedGroups[index].weight === weight
-		) {
-			sameWeightGroups.push(orderedGroups[index]);
-			index += 1;
-		}
-		orderedCandidates.push(
-			...interleaveEqualWeightHeartbeatGroups(sameWeightGroups),
-		);
+	const cursors: AvailabilityHeartbeatDemandGroupCursor[] = groups
+		.filter((group) => group.candidates.length > 0)
+		.map((group) => ({
+			group,
+			schedulingWeight: heartbeatSchedulingWeight(group.weight),
+			candidateIndex: 0,
+			served: 0,
+		}));
+
+	while (cursors.some((cursor) => cursor.candidateIndex < cursor.group.candidates.length)) {
+		const next = cursors
+			.filter(
+				(cursor) => cursor.candidateIndex < cursor.group.candidates.length,
+			)
+			.sort((a, b) => {
+				const aShare = a.served / a.schedulingWeight;
+				const bShare = b.served / b.schedulingWeight;
+				return (
+					aShare - bShare ||
+					b.group.weight - a.group.weight ||
+					a.group.order - b.group.order
+				);
+			})[0];
+		const candidate = next?.group.candidates[next.candidateIndex];
+		if (!next || !candidate) break;
+		orderedCandidates.push(candidate);
+		next.candidateIndex += 1;
+		next.served += 1;
 	}
 	return orderedCandidates;
 };


### PR DESCRIPTION
## Summary

- replace strict weight-sorted heartbeat ordering with weighted fair demand scheduling
- preserve equal-weight round-robin behavior while preventing one high-weight service from monopolizing small maxJobs budgets
- update async endpoint coverage and package docs for the new scheduler semantics
- refresh local agent package truth from 0.5.7 to 0.5.10

## Validation

- pnpm test
- pnpm typecheck
- pnpm docs:check
- pnpm build
- pnpm test:host
- pnpm check:artifact-authority

Closes #133