### PR TITLE
[codex] Release bridge 0.5.12 pylon availability

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.11",
+    version = "0.5.12",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.11",
+    version = "0.5.12",
     compatibility_level = 1,
 )
 

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.11`
-- Bazel module version: `0.5.11`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.11`
+- package version: `0.5.12`
+- Bazel module version: `0.5.12`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.12`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/adapters/acuity/steps/read-via-url.test.ts
+++ b/src/adapters/acuity/steps/read-via-url.test.ts
@@ -8,7 +8,12 @@ import {
 } from '../../../shared/browser-service.js';
 import {
 	dateEmptySettleTimeoutMs,
+	parsePylonCalendarIdentity,
 	readDatesViaUrl,
+	readSlotsViaUrl,
+	resolvePylonStartDate,
+	toPylonAvailabilityDates,
+	toPylonAvailabilitySlots,
 	urlReadNetworkIdleTimeoutMs,
 } from './read-via-url.js';
 
@@ -74,76 +79,43 @@ describe('date empty settle timing config', () => {
 	});
 });
 
-const monthNames = [
-	'January',
-	'February',
-	'March',
-	'April',
-	'May',
-	'June',
-	'July',
-	'August',
-	'September',
-	'October',
-	'November',
-	'December',
-] as const;
-
-const formatMonthKey = (date: Date): string =>
-	`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-
-const makeUrlDateReadPage = (
-	initialMonth: string,
-	datesByMonth: Map<string, string[]>,
-	onWaitForFunction?: () => void,
+const makePylonReadPage = (
+	payload: Record<string, Array<{ time?: string; slotsAvailable?: number }>>,
 ) => {
-	const [year, month] = initialMonth.split('-').map(Number);
-	const current = new Date(year, month - 1, 1);
-	const navClicks: string[] = [];
 	const gotoUrls: string[] = [];
-
-	const navHandle = (direction: 'prev' | 'next') => ({
-		click: vi.fn(async () => {
-			current.setMonth(current.getMonth() + (direction === 'next' ? 1 : -1));
-			navClicks.push(direction);
-		}),
-	});
+	const apiUrls: string[] = [];
+	let currentUrl =
+		'https://massageithaca.as.me/schedule/4671d709/category/X19hbGxfXw%3D%3D/appointment/53178494/calendar/8973181?appointmentTypeIds[]=53178494';
 
 	const page = {
 		goto: vi.fn(async (url: string) => {
 			gotoUrls.push(url);
 		}),
 		waitForLoadState: vi.fn(async () => undefined),
-		waitForSelector: vi.fn(async (selector: string) => {
-			if (selector.includes('prev-button')) return navHandle('prev');
-			if (selector.includes('next-button')) return navHandle('next');
-			return {};
+		url: vi.fn(() => currentUrl),
+		evaluate: vi.fn(async (_fn: unknown, url: string) => {
+			apiUrls.push(url);
+			return payload;
 		}),
-		waitForTimeout: vi.fn(async () => undefined),
-		waitForFunction: vi.fn(async () => {
-			onWaitForFunction?.();
-		}),
-		$eval: vi.fn(async () => {
-			const label = `${monthNames[current.getMonth()]} ${current.getFullYear()}`;
-			return label;
-		}),
-		evaluate: vi.fn(async () => {
-			const dates = datesByMonth.get(formatMonthKey(current)) ?? [];
-			return dates.map((date) => ({ date, slots: 1 }));
-		}),
-	} as unknown as Page;
+		__setUrl: (url: string) => {
+			currentUrl = url;
+		},
+	} as unknown as Page & { __setUrl: (url: string) => void };
 
 	return {
 		page,
 		gotoUrls,
-		navClicks,
+		apiUrls,
 	};
 };
 
-const runDateRead = (page: Page, targetMonth?: string) =>
+const provideBrowser = <A, E>(
+	page: Page,
+	effect: Effect.Effect<A, E, BrowserService>,
+) =>
 	Effect.runPromise(
 		Effect.scoped(
-			readDatesViaUrl('53178494', targetMonth).pipe(
+			effect.pipe(
 				Effect.provideService(BrowserService, {
 					acquirePage: Effect.succeed(page),
 					screenshot: () => Effect.succeed(Buffer.from('')),
@@ -157,33 +129,111 @@ const runDateRead = (page: Page, targetMonth?: string) =>
 		),
 	);
 
-describe('readDatesViaUrl DOM behavior', () => {
-	it('waits for enabled dates before returning an empty month', async () => {
-		const datesByMonth = new Map<string, string[]>([['2026-07', []]]);
-		const fake = makeUrlDateReadPage('2026-07', datesByMonth, () => {
-			datesByMonth.set('2026-07', ['2026-07-15']);
-		});
+const runDateRead = (page: Page, targetMonth?: string) =>
+	provideBrowser(page, readDatesViaUrl('53178494', targetMonth));
 
-		const dates = await runDateRead(fake.page);
+const runSlotRead = (page: Page, date: string) =>
+	provideBrowser(page, readSlotsViaUrl('53178494', date));
 
-		expect(dates).toEqual([{ date: '2026-07-15', slots: 1 }]);
-		expect(fake.page.evaluate).toHaveBeenCalledTimes(2);
-		expect(fake.page.waitForFunction).toHaveBeenCalledTimes(1);
+describe('Acuity pylon availability helpers', () => {
+	it('does not ask Acuity pylon availability for past current-month dates', () => {
+		expect(resolvePylonStartDate('2026-05', '2026-05-14')).toBe('2026-05-14');
+		expect(resolvePylonStartDate('2026-06', '2026-05-14')).toBe('2026-06-01');
+		expect(resolvePylonStartDate(undefined, '2026-05-14')).toBe('2026-05-14');
 	});
 
-	it('navigates to the requested target month before reading enabled dates', async () => {
-		const datesByMonth = new Map<string, string[]>([
-			['2026-07', ['2026-07-15']],
-			['2026-09', ['2026-09-12']],
+	it('parses calendar identity from category and non-category URLs', () => {
+		expect(
+			parsePylonCalendarIdentity(
+				'https://massageithaca.as.me/schedule/4671d709/category/X19hbGxfXw%3D%3D/appointment/53178494/calendar/8973181',
+			),
+		).toEqual({
+			origin: 'https://massageithaca.as.me',
+			owner: '4671d709',
+			appointmentTypeId: '53178494',
+			calendarId: '8973181',
+		});
+		expect(
+			parsePylonCalendarIdentity(
+				'https://massageithaca.as.me/schedule/4671d709/appointment/53178494/calendar/8973181',
+			),
+		).toMatchObject({
+			owner: '4671d709',
+			appointmentTypeId: '53178494',
+			calendarId: '8973181',
+		});
+	});
+
+	it('maps pylon times payloads to available dates and slot counts', () => {
+		expect(
+			toPylonAvailabilityDates({
+				'2026-05-17': [
+					{ time: '2026-05-17T09:00:00-0400', slotsAvailable: 1 },
+					{ time: '2026-05-17T09:30:00-0400', slotsAvailable: 2 },
+				],
+				'2026-05-18': [
+					{ time: '2026-05-18T09:00:00-0400', slotsAvailable: 0 },
+				],
+			}),
+		).toEqual([{ date: '2026-05-17', slots: 3 }]);
+	});
+
+	it('maps pylon times payloads to local slot datetimes', () => {
+		expect(
+			toPylonAvailabilitySlots(
+				{
+					'2026-05-17': [
+						{ time: '2026-05-17T09:00:00-0400', slotsAvailable: 1 },
+						{ time: '2026-05-17T09:30:00-0400', slotsAvailable: 0 },
+					],
+				},
+				'2026-05-17',
+			),
+		).toEqual([
+			{ datetime: '2026-05-17T09:00:00', available: true },
+			{ datetime: '2026-05-17T09:30:00', available: false },
 		]);
-		const fake = makeUrlDateReadPage('2026-07', datesByMonth);
+	});
+});
 
-		const dates = await runDateRead(fake.page, '2026-09');
+describe('readDatesViaUrl pylon API behavior', () => {
+	it('reads dates from Acuity pylon availability/times instead of react-calendar DOM', async () => {
+		const fake = makePylonReadPage({
+			'2026-05-17': [
+				{ time: '2026-05-17T09:00:00-0400', slotsAvailable: 1 },
+				{ time: '2026-05-17T09:30:00-0400', slotsAvailable: 1 },
+			],
+		});
 
-		expect(dates).toEqual([{ date: '2026-09-12', slots: 1 }]);
-		expect(fake.navClicks).toEqual(['next', 'next']);
+		const dates = await runDateRead(fake.page, '2026-05');
+
+		expect(dates).toEqual([{ date: '2026-05-17', slots: 2 }]);
 		expect(fake.gotoUrls[0]).toBe(
 			'https://massageithaca.as.me/?appointmentType=53178494',
 		);
+		const apiUrl = new URL(fake.apiUrls[0]);
+		expect(apiUrl.pathname).toBe('/api/scheduling/v1/availability/times');
+		expect(apiUrl.searchParams.get('owner')).toBe('4671d709');
+		expect(apiUrl.searchParams.get('appointmentTypeId')).toBe('53178494');
+		expect(apiUrl.searchParams.get('calendarId')).toBe('8973181');
+		expect(apiUrl.searchParams.get('startDate')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		expect(apiUrl.searchParams.get('maxDays')).toBe('45');
+	});
+
+	it('reads slots from the same Acuity pylon API', async () => {
+		const fake = makePylonReadPage({
+			'2026-05-17': [
+				{ time: '2026-05-17T09:00:00-0400', slotsAvailable: 1 },
+			],
+		});
+
+		const slots = await runSlotRead(fake.page, '2026-05-17');
+
+		expect(slots).toEqual([
+			{ datetime: '2026-05-17T09:00:00', available: true },
+		]);
+		const apiUrl = new URL(fake.apiUrls[0]);
+		expect(apiUrl.searchParams.get('startDate')).toBe('2026-05-17');
+		expect(apiUrl.searchParams.get('maxDays')).toBe('1');
 	});
 });

--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -15,9 +15,6 @@ import { BrowserService } from '../../../shared/browser-service.js';
 import { ndjsonLog } from '../../../shared/logger.js';
 import { observePageOpEffect } from '../../../shared/metrics.js';
 import { WizardStepError } from '../errors.js';
-import { Selectors } from '../selectors.js';
-import { parseSlotText, buildIsoDatetime } from '../slot-parser.js';
-import { navigateToMonth, parseYearMonthKey } from '../wizard-calendar.js';
 import {
 	buildSlotReadProfileEvent,
 	createSlotReadProfile,
@@ -32,13 +29,27 @@ import {
 
 export interface UrlDateResult {
 	readonly date: string;  // YYYY-MM-DD
-	readonly slots: number; // 1 = available (exact count unknown without clicking)
+	readonly slots: number;
 }
 
 export interface UrlSlotResult {
-	readonly datetime: string; // time string like "4:00 PM"
+	readonly datetime: string; // local ISO datetime without offset
 	readonly available: boolean;
 }
+
+interface PylonCalendarIdentity {
+	readonly origin: string;
+	readonly owner: string;
+	readonly appointmentTypeId: string;
+	readonly calendarId: string;
+}
+
+interface PylonAvailabilitySlot {
+	readonly time?: string;
+	readonly slotsAvailable?: number;
+}
+
+type PylonAvailabilityTimes = Record<string, readonly PylonAvailabilitySlot[]>;
 
 const DEFAULT_URL_READ_NETWORK_IDLE_MS = 1500;
 const DEFAULT_EMPTY_DATE_SETTLE_MS = 2500;
@@ -77,26 +88,6 @@ const navigateForUrlRead = async (page: Page, url: URL, timeout: number): Promis
 	}
 };
 
-const postClickSlotSettleMs = (): number => {
-	const raw = Number(process.env.ACUITY_POST_CLICK_SLOT_SETTLE_MS);
-	return Number.isFinite(raw) && raw >= 0 ? raw : 900;
-};
-
-const waitForSlotUiAfterDateClick = async (
-	page: Page,
-	slotSelector: string,
-	timeout: number,
-): Promise<void> => {
-	const waitMs = Math.min(timeout, postClickSlotSettleMs());
-	if (waitMs <= 0) return;
-
-	await Promise.race([
-		page.waitForSelector(slotSelector, { timeout: waitMs }).then(() => undefined),
-		page.waitForLoadState('networkidle', { timeout: waitMs }).then(() => undefined).catch(() => undefined),
-		page.waitForTimeout(waitMs).then(() => undefined),
-	]).catch(() => undefined);
-};
-
 const navigateToServiceCalendar = (
 	page: Page,
 	url: URL,
@@ -108,81 +99,118 @@ const navigateToServiceCalendar = (
 		catch: (e) => new WizardStepError({ step, message: `Navigation failed: ${e}` }),
 	});
 
-const navigateToTargetMonth = (
-	page: Page,
-	targetMonth: string | undefined,
-	step: 'read-availability' | 'read-slots',
-): Effect.Effect<void, WizardStepError> => {
-	if (!targetMonth) return Effect.void;
-
-	const parsed = parseYearMonthKey(targetMonth);
-	if (!parsed) {
-		return Effect.fail(new WizardStepError({
-			step,
-			message: `Invalid target month: ${targetMonth}`,
-		}));
+export const parsePylonCalendarIdentity = (
+	rawUrl: string,
+): PylonCalendarIdentity | null => {
+	try {
+		const url = new URL(rawUrl);
+		const match = url.pathname.match(
+			/\/schedule\/([^/]+)(?:\/category\/[^/]+)?\/appointment\/(\d+)\/calendar\/(\d+)/,
+		);
+		if (!match) return null;
+		return {
+			origin: url.origin,
+			owner: decodeURIComponent(match[1]),
+			appointmentTypeId: match[2],
+			calendarId: match[3],
+		};
+	} catch {
+		return null;
 	}
-
-	return navigateToMonth(page, parsed.month, parsed.year, step);
 };
 
-const readEnabledCalendarDates = (
-	page: Page,
-	tileSelector: string,
-): Effect.Effect<UrlDateResult[], WizardStepError> =>
-	Effect.tryPromise({
-		try: () => page.evaluate((sel) => {
-			const results: Array<{ date: string; slots: number }> = [];
-			const neighboringClass = 'react-calendar__tile--neighboringMonth';
-			document.querySelectorAll(sel).forEach(tile => {
-				if ((tile as HTMLButtonElement).disabled) return;
-				if (tile.classList.contains(neighboringClass)) return;
-				if (tile.classList.contains('neighboringMonth')) return;
+export const resolvePylonStartDate = (
+	targetMonth?: string,
+	today = new Intl.DateTimeFormat('en-CA', {
+		timeZone: 'America/New_York',
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	}).format(new Date()),
+): string => {
+	if (!targetMonth || !/^\d{4}-\d{2}$/.test(targetMonth)) {
+		return today;
+	}
+	const monthStart = `${targetMonth}-01`;
+	return monthStart < today ? today : monthStart;
+};
 
-				const abbr = tile.querySelector('abbr');
-				const label = abbr?.getAttribute('aria-label') || tile.getAttribute('data-date') || '';
-				if (label) {
-					const d = new Date(label);
-					if (!isNaN(d.getTime())) {
-						results.push({ date: d.toISOString().slice(0, 10), slots: 1 });
-					}
-				}
-			});
-			return results;
-		}, tileSelector),
-		catch: (e) => new WizardStepError({ step: 'read-availability', message: `Calendar read failed: ${e}` }),
-	});
+const normalizeAcuityDatetime = (value: string): string =>
+	value.replace(/([+-]\d{2}:?\d{2}|Z)$/u, '');
 
-const waitForEnabledCalendarDate = (
+export const toPylonAvailabilityDates = (
+	payload: PylonAvailabilityTimes,
+): UrlDateResult[] =>
+	Object.entries(payload)
+		.filter(([date, slots]) => (
+			/^\d{4}-\d{2}-\d{2}$/.test(date) &&
+			Array.isArray(slots) &&
+			slots.some((slot) => Number(slot.slotsAvailable ?? 1) > 0)
+		))
+		.map(([date, slots]) => ({
+			date,
+			slots: slots.reduce(
+				(total, slot) => total + Math.max(0, Number(slot.slotsAvailable ?? 1)),
+				0,
+			),
+		}))
+		.sort((a, b) => a.date.localeCompare(b.date));
+
+export const toPylonAvailabilitySlots = (
+	payload: PylonAvailabilityTimes,
+	date: string,
+): UrlSlotResult[] =>
+	(payload[date] ?? [])
+		.filter((slot) => typeof slot.time === 'string' && slot.time.length > 0)
+		.map((slot) => ({
+			datetime: normalizeAcuityDatetime(slot.time!),
+			available: Number(slot.slotsAvailable ?? 1) > 0,
+		}));
+
+const fetchPylonAvailabilityTimes = (
 	page: Page,
-	tileSelector: string,
-	timeout: number,
-): Effect.Effect<void, never> =>
+	serviceId: string,
+	startDate: string,
+	maxDays: number,
+	step: 'read-availability' | 'read-slots',
+): Effect.Effect<PylonAvailabilityTimes, WizardStepError> =>
 	Effect.tryPromise({
 		try: async () => {
-			const waitMs = dateEmptySettleTimeoutMs(timeout);
-			if (waitMs <= 0) return;
+			const identity = parsePylonCalendarIdentity(page.url());
+			if (!identity) {
+				throw new Error(`Could not parse Acuity calendar identity from ${page.url()}`);
+			}
+			if (identity.appointmentTypeId !== serviceId) {
+				throw new Error(
+					`Expected appointment type ${serviceId} but got ${identity.appointmentTypeId}`,
+				);
+			}
 
-			await page.waitForFunction((sel) => {
-				const neighboringClasses = [
-					'react-calendar__tile--neighboringMonth',
-					'neighboringMonth',
-				];
-				return Array.from(document.querySelectorAll(sel)).some(tile => {
-					const button = tile as HTMLButtonElement;
-					if (button.disabled || button.getAttribute('aria-disabled') === 'true') return false;
-					if (neighboringClasses.some(className => tile.classList.contains(className))) return false;
+			const apiUrl = new URL('/api/scheduling/v1/availability/times', identity.origin);
+			apiUrl.searchParams.set('owner', identity.owner);
+			apiUrl.searchParams.set('appointmentTypeId', serviceId);
+			apiUrl.searchParams.set('calendarId', identity.calendarId);
+			apiUrl.searchParams.set('startDate', startDate);
+			apiUrl.searchParams.set('maxDays', String(maxDays));
+			apiUrl.searchParams.set('timezone', 'America/New_York');
 
-					const abbr = tile.querySelector('abbr');
-					const label = abbr?.getAttribute('aria-label') || tile.getAttribute('data-date') || '';
-					if (!label) return false;
-
-					return !Number.isNaN(new Date(label).getTime());
+			return page.evaluate(async (url) => {
+				const response = await fetch(url, {
+					headers: { accept: 'application/json' },
 				});
-			}, tileSelector, { timeout: waitMs }).catch(() => {});
+				if (!response.ok) {
+					throw new Error(`Acuity availability API returned ${response.status}`);
+				}
+				return await response.json() as PylonAvailabilityTimes;
+			}, apiUrl.toString());
 		},
-		catch: () => undefined,
-	}).pipe(Effect.ignore);
+		catch: (e) =>
+			new WizardStepError({
+				step,
+				message: `Acuity availability API read failed: ${e instanceof Error ? e.message : String(e)}`,
+				cause: e,
+			}),
+	});
 
 // =============================================================================
 // READ DATES VIA URL PARAM
@@ -209,27 +237,19 @@ export const readDatesViaUrl = (
 		url.searchParams.set('appointmentType', serviceId);
 
 		yield* navigateToServiceCalendar(page, url, config.timeout, 'read-availability');
-		yield* navigateToTargetMonth(page, targetMonth, 'read-availability');
+		const startDate = resolvePylonStartDate(targetMonth);
+		const payload = yield* fetchPylonAvailabilityTimes(
+			page,
+			serviceId,
+			startDate,
+			45,
+			'read-availability',
+		);
 
-		// Wait for calendar tiles using the Selectors registry
-		const calendarSelector = Selectors.calendarDay.join(', ');
-		yield* Effect.tryPromise({
-			try: () => page.waitForSelector(calendarSelector, { timeout: 10000 }),
-			catch: () => null,
-		}).pipe(Effect.ignore);
-
-		const tileSelector = Selectors.calendarDay[0]; // .react-calendar__tile
-		let dates = yield* readEnabledCalendarDates(page, tileSelector);
-		if (dates.length > 0) {
-			return dates;
-		}
-
-		// Acuity occasionally paints the calendar shell before enabled dates are attached.
-		// Wait briefly for enabled tiles on the same page, but do not re-run a full
-		// deep-month navigation when the target month is legitimately empty.
-		yield* waitForEnabledCalendarDate(page, tileSelector, config.timeout);
-
-		return yield* readEnabledCalendarDates(page, tileSelector);
+		const dates = toPylonAvailabilityDates(payload);
+		return targetMonth
+			? dates.filter((date) => date.date.startsWith(`${targetMonth}-`))
+			: dates;
 	}));
 
 // =============================================================================
@@ -239,7 +259,7 @@ export const readDatesViaUrl = (
 /**
  * Read time slots by navigating directly to a service's calendar
  * via ?appointmentType={id}&date={YYYY-MM-DD} URL parameters,
- * then clicking the target date tile.
+ * then reading Acuity's pylon availability API from that browser session.
  *
  * @param serviceId - Acuity numeric appointment type ID
  * @param date - Target date in YYYY-MM-DD format
@@ -257,147 +277,44 @@ export const readSlotsViaUrl = (
 		);
 
 		let navigationMs = 0;
-		let calendarReadyMs = 0;
-		let dateSelectMs = 0;
-		let postClickSettleMs = 0;
-		let slotWaitMs = 0;
+		const calendarReadyMs = 0;
+		const dateSelectMs = 0;
+		const postClickSettleMs = 0;
+		const slotWaitMs = 0;
 		let slotDomReadMs = 0;
-		let parseMs = 0;
+		const parseMs = 0;
 		let calendarTileCount = 0;
 		let matchedDateFound = false;
 
 		const url = new URL(config.baseUrl);
 		url.searchParams.set('appointmentType', serviceId);
 		url.searchParams.set('date', date);
-		const targetMonth = date.slice(0, 7);
-		const slotSelector = Selectors.timeSlot[0]; // button.time-selection
-		const fallbackSelector = Selectors.timeSlot.join(', ');
 
 		const navigationStartedAt = Date.now();
 		yield* navigateToServiceCalendar(page, url, config.timeout, 'read-slots');
-		yield* navigateToTargetMonth(page, targetMonth, 'read-slots');
 		navigationMs = Date.now() - navigationStartedAt;
 
-		// Click the target date on the calendar. Disabled dates are a valid
-		// "no availability" result, not a scrape failure.
-		const tileSelector = Selectors.calendarDay[0];
-		const clickedTargetDate = yield* Effect.tryPromise({
-			try: async () => {
-				const calendarReadyStartedAt = Date.now();
-				await page.waitForSelector(tileSelector, { timeout: 10000 }).catch(() => {});
-				calendarReadyMs = Date.now() - calendarReadyStartedAt;
-
-				const dateSelectStartedAt = Date.now();
-				const tiles = await page.$$(tileSelector);
-				calendarTileCount = tiles.length;
-				for (const tile of tiles) {
-					const abbr = await tile.$('abbr');
-					const label = await abbr?.getAttribute('aria-label');
-					if (label) {
-						const d = new Date(label);
-						if (d.toISOString().slice(0, 10) === date) {
-							matchedDateFound = true;
-							const disabled = await tile.evaluate((el) => {
-								const button = el as HTMLButtonElement;
-								return (
-									button.disabled ||
-									button.getAttribute('aria-disabled') === 'true' ||
-									button.classList.contains('react-calendar__tile--disabled')
-								);
-							});
-							if (disabled) {
-								dateSelectMs = Date.now() - dateSelectStartedAt;
-								return false;
-							}
-								await tile.click({ timeout: Math.min(config.timeout, 5000) });
-								dateSelectMs = Date.now() - dateSelectStartedAt;
-
-								const settleStartedAt = Date.now();
-								await waitForSlotUiAfterDateClick(page, fallbackSelector, config.timeout);
-								postClickSettleMs = Date.now() - settleStartedAt;
-								return true;
-							}
-					}
-				}
-				dateSelectMs = Date.now() - dateSelectStartedAt;
-				return false;
-			},
-			catch: (e) => new WizardStepError({ step: 'read-slots', message: `Date click failed: ${e}` }),
-		});
-
-		if (!clickedTargetDate) {
-			const profile = createSlotReadProfile({
-				serviceId,
-				date,
-				thresholdMs: profileConfig.thresholdMs,
-				calendarTileCount,
-				matchedDateFound,
-				slotCount: 0,
-				parsedSlotCount: 0,
-				phases: {
-					navigationMs,
-					calendarReadyMs,
-					dateSelectMs,
-					postClickSettleMs,
-					slotWaitMs,
-					slotDomReadMs,
-					parseMs,
-				},
-				context,
-			});
-
-			if (shouldLogSlotReadProfile(profile, profileConfig)) {
-				ndjsonLog('INFO', 'Slot read profile', { ...buildSlotReadProfileEvent(profile) });
-			}
-
-			return [];
-		}
-
-			// Read time slots using the Selectors registry
-			const slotWaitStartedAt = Date.now();
-		yield* Effect.tryPromise({
-			try: () => page.waitForSelector(fallbackSelector, { timeout: 10000 }),
-			catch: () => null,
-		}).pipe(Effect.ignore);
-		slotWaitMs = Date.now() - slotWaitStartedAt;
-
 		const slotDomReadStartedAt = Date.now();
-		const slots = yield* Effect.tryPromise({
-			try: () => page.evaluate((sel) => {
-				const results: Array<{ datetime: string; available: boolean }> = [];
-				document.querySelectorAll(sel).forEach(btn => {
-					const raw = btn.textContent?.trim() || '';
-					const disabled = btn.hasAttribute('disabled');
-					if (raw) {
-						results.push({ datetime: raw, available: !disabled });
-					}
-				});
-				return results;
-			}, slotSelector),
-			catch: (e) => new WizardStepError({ step: 'read-slots', message: `Slots read failed: ${e}` }),
-		});
+		const payload = yield* fetchPylonAvailabilityTimes(
+			page,
+			serviceId,
+			date,
+			1,
+			'read-slots',
+		);
+		const parsedSlots = toPylonAvailabilitySlots(payload, date);
 		slotDomReadMs = Date.now() - slotDomReadStartedAt;
+		calendarTileCount = Object.keys(payload).length;
+		matchedDateFound = Object.prototype.hasOwnProperty.call(payload, date);
 
-		// Parse slot text and build full ISO datetime (e.g., "4:00 PM" → "2026-04-01T16:00:00")
-		const parseStartedAt = Date.now();
-		let parsedSlotCount = 0;
-		const parsedSlots = slots.map(s => {
-			const parsed = parseSlotText(s.datetime);
-			if (parsed) parsedSlotCount += 1;
-			return {
-				datetime: parsed ? buildIsoDatetime(date, parsed.time) : s.datetime,
-				available: s.available,
-			};
-		});
-		parseMs = Date.now() - parseStartedAt;
 		const profile = createSlotReadProfile({
 			serviceId,
 			date,
 			thresholdMs: profileConfig.thresholdMs,
 			calendarTileCount,
 			matchedDateFound,
-			slotCount: slots.length,
-			parsedSlotCount,
+			slotCount: parsedSlots.length,
+			parsedSlotCount: parsedSlots.length,
 			phases: {
 				navigationMs,
 				calendarReadyMs,


### PR DESCRIPTION
## Summary
- release `@tummycrypt/scheduling-bridge@0.5.12`
- switch Acuity URL availability reads from the retired `react-calendar` DOM path to the current pylon availability API
- preserve browser-session navigation so owner/calendar identity still comes from the live Acuity redirect
- add regression coverage for pylon identity parsing, start-date handling, date mapping, and slot mapping

## Root Cause
Acuity no longer renders the calendar surface used by the bridge reader. The service/category anchors still resolve, but the old calendar/date/slot selectors time out before availability can be read.

## Live Evidence
- live patched reader against `https://MassageIthaca.as.me` found URGENT Care Massage service dates for May 2026
- first live date `2026-05-17` returned three available slots: `09:00`, `09:30`, `10:00` local
- Acuity returns HTTP 422 for past `startDate`, so current-month reads now start at today in `America/New_York`

## Validation
- `pnpm test:host src/adapters/acuity/steps/read-via-url.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:release-metadata`
- `pnpm docs:check`
- `pnpm check:package`
- `git diff --check`
