### PR TITLE
Fix Acuity direct time-list availability reads

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.11",
+    version = "0.5.12",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.11",
+    version = "0.5.12",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ before reporting it as work; non-retryable terminal jobs are reported under
 
 ### Queue Hygiene
 
-Bridge `0.5.11` supports bounded worker drain concurrency through
+Bridge `0.5.12` supports bounded worker drain concurrency through
 `BRIDGE_WORKER_CONCURRENCY`. The package default remains `1`; the MassageIthaca
 K8s deployment currently opts into `2` through Blahaj/OpenTofu after proving the
 datepicker readiness gate remains green.

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.11`
-- Bazel module version: `0.5.11`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.11`
+- package version: `0.5.12`
+- Bazel module version: `0.5.12`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.12`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/adapters/acuity/steps/read-via-url.test.ts
+++ b/src/adapters/acuity/steps/read-via-url.test.ts
@@ -8,7 +8,10 @@ import {
 } from '../../../shared/browser-service.js';
 import {
 	dateEmptySettleTimeoutMs,
+	parseTimeSelectionDates,
+	parseTimeSelectionSlots,
 	readDatesViaUrl,
+	type TimeSelectionEntry,
 	urlReadNetworkIdleTimeoutMs,
 } from './read-via-url.js';
 
@@ -158,6 +161,58 @@ const runDateRead = (page: Page, targetMonth?: string) =>
 	);
 
 describe('readDatesViaUrl DOM behavior', () => {
+	it('derives available dates from the current Acuity time-selection list', () => {
+		const entries: TimeSelectionEntry[] = [
+			{
+				text: '10:00 AM1 spot left',
+				ariaLabel: '10:00 AM, 1 spot left, Sunday May 31',
+				disabled: false,
+			},
+			{
+				text: '10:30 AM1 spot left',
+				ariaLabel: '10:30 AM, 1 spot left, Sunday May 31',
+				disabled: false,
+			},
+			{
+				text: '10:00 AM1 spot left',
+				ariaLabel: '10:00 AM, 1 spot left, Sunday Jun 7',
+				disabled: false,
+			},
+		];
+
+		expect(parseTimeSelectionDates(entries, '2026-05')).toEqual([
+			{ date: '2026-05-31', slots: 1 },
+		]);
+		expect(parseTimeSelectionDates(entries, '2026-06')).toEqual([
+			{ date: '2026-06-07', slots: 1 },
+		]);
+	});
+
+	it('filters direct time-selection slots to the requested date', () => {
+		const entries: TimeSelectionEntry[] = [
+			{
+				text: '10:00 AM1 spot left',
+				ariaLabel: '10:00 AM, 1 spot left, Sunday May 31',
+				disabled: false,
+			},
+			{
+				text: '10:00 AM1 spot left',
+				ariaLabel: '10:00 AM, 1 spot left, Sunday Jun 7',
+				disabled: false,
+			},
+			{
+				text: '10:30 AM1 spot left',
+				ariaLabel: '10:30 AM, 1 spot left, Sunday Jun 7',
+				disabled: true,
+			},
+		];
+
+		expect(parseTimeSelectionSlots(entries, '2026-06-07')).toEqual([
+			{ datetime: '10:00 AM1 spot left', available: true },
+			{ datetime: '10:30 AM1 spot left', available: false },
+		]);
+	});
+
 	it('waits for enabled dates before returning an empty month', async () => {
 		const datesByMonth = new Map<string, string[]>([['2026-07', []]]);
 		const fake = makeUrlDateReadPage('2026-07', datesByMonth, () => {
@@ -167,7 +222,7 @@ describe('readDatesViaUrl DOM behavior', () => {
 		const dates = await runDateRead(fake.page);
 
 		expect(dates).toEqual([{ date: '2026-07-15', slots: 1 }]);
-		expect(fake.page.evaluate).toHaveBeenCalledTimes(2);
+		expect(fake.page.evaluate).toHaveBeenCalledTimes(3);
 		expect(fake.page.waitForFunction).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -40,8 +40,44 @@ export interface UrlSlotResult {
 	readonly available: boolean;
 }
 
+export interface TimeSelectionEntry {
+	readonly text: string;
+	readonly ariaLabel: string;
+	readonly disabled: boolean;
+}
+
 const DEFAULT_URL_READ_NETWORK_IDLE_MS = 1500;
 const DEFAULT_EMPTY_DATE_SETTLE_MS = 2500;
+const DEFAULT_MORE_TIMES_CLICKS = 8;
+
+const MONTH_INDEX_BY_NAME = new Map<string, number>(
+	[
+		['jan', 0],
+		['january', 0],
+		['feb', 1],
+		['february', 1],
+		['mar', 2],
+		['march', 2],
+		['apr', 3],
+		['april', 3],
+		['may', 4],
+		['jun', 5],
+		['june', 5],
+		['jul', 6],
+		['july', 6],
+		['aug', 7],
+		['august', 7],
+		['sep', 8],
+		['sept', 8],
+		['september', 8],
+		['oct', 9],
+		['october', 9],
+		['nov', 10],
+		['november', 10],
+		['dec', 11],
+		['december', 11],
+	] as const,
+);
 
 export const urlReadNetworkIdleTimeoutMs = (
 	timeout: number,
@@ -95,6 +131,167 @@ const waitForSlotUiAfterDateClick = async (
 		page.waitForLoadState('networkidle', { timeout: waitMs }).then(() => undefined).catch(() => undefined),
 		page.waitForTimeout(waitMs).then(() => undefined),
 	]).catch(() => undefined);
+};
+
+const moreTimesClickLimit = (
+	env: Record<string, string | undefined> = process.env,
+): number => {
+	const parsed = Number(env.ACUITY_MORE_TIMES_CLICK_LIMIT);
+	if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_MORE_TIMES_CLICKS;
+	return Math.floor(parsed);
+};
+
+const waitForMoreTimesSettle = async (page: Page, timeout: number): Promise<void> => {
+	const waitMs = Math.min(timeout, postClickSlotSettleMs());
+	if (waitMs <= 0) return;
+	await page.waitForTimeout(waitMs).catch(() => undefined);
+};
+
+const inferYearForMonth = (
+	monthIndex: number,
+	targetMonth?: string,
+	now = new Date(),
+): number => {
+	const parsedTarget = targetMonth?.match(/^(\d{4})-(\d{2})$/);
+	if (parsedTarget) {
+		const targetYear = Number(parsedTarget[1]);
+		const targetMonthIndex = Number(parsedTarget[2]) - 1;
+		const delta = monthIndex - targetMonthIndex;
+		if (delta > 6) return targetYear - 1;
+		if (delta < -6) return targetYear + 1;
+		return targetYear;
+	}
+
+	const currentMonth = now.getMonth();
+	const currentYear = now.getFullYear();
+	return currentMonth - monthIndex > 6 ? currentYear + 1 : currentYear;
+};
+
+const parseTimeSelectionDate = (
+	label: string,
+	targetMonth?: string,
+): string | null => {
+	const match = label.match(
+		/\b(?:Sun(?:day)?|Mon(?:day)?|Tue(?:sday)?|Wed(?:nesday)?|Thu(?:rsday)?|Fri(?:day)?|Sat(?:urday)?)?\s*(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t|tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+([0-3]?\d)(?:,?\s+(\d{4}))?\b/i,
+	);
+	if (!match) return null;
+
+	const monthIndex = MONTH_INDEX_BY_NAME.get(match[1].toLowerCase());
+	if (monthIndex === undefined) return null;
+
+	const day = Number(match[2]);
+	if (!Number.isInteger(day) || day < 1 || day > 31) return null;
+
+	const year = match[3] ? Number(match[3]) : inferYearForMonth(monthIndex, targetMonth);
+	if (!Number.isInteger(year) || year < 2000) return null;
+
+	return `${year}-${String(monthIndex + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+};
+
+export const parseTimeSelectionDates = (
+	entries: readonly TimeSelectionEntry[],
+	targetMonth?: string,
+): UrlDateResult[] => {
+	const seen = new Set<string>();
+	const results: UrlDateResult[] = [];
+
+	for (const entry of entries) {
+		if (entry.disabled) continue;
+		const date = parseTimeSelectionDate(entry.ariaLabel || entry.text, targetMonth);
+		if (!date) continue;
+		if (targetMonth && !date.startsWith(`${targetMonth}-`)) continue;
+		if (seen.has(date)) continue;
+		seen.add(date);
+		results.push({ date, slots: 1 });
+	}
+
+	return results.sort((a, b) => a.date.localeCompare(b.date));
+};
+
+export const parseTimeSelectionSlots = (
+	entries: readonly TimeSelectionEntry[],
+	date: string,
+): UrlSlotResult[] =>
+	entries
+		.filter((entry) => parseTimeSelectionDate(entry.ariaLabel || entry.text, date.slice(0, 7)) === date)
+		.map((entry) => ({
+			datetime: entry.text || entry.ariaLabel,
+			available: !entry.disabled,
+		}));
+
+const collectTimeSelectionEntries = async (
+	page: Page,
+	selector: string,
+): Promise<TimeSelectionEntry[]> =>
+	page.evaluate((sel) => {
+		return Array.from(document.querySelectorAll(sel)).map((node) => {
+			const element = node as HTMLButtonElement;
+			return {
+				text: element.textContent?.trim() ?? '',
+				ariaLabel: element.getAttribute('aria-label') ?? '',
+				disabled:
+					element.disabled ||
+					element.hasAttribute('disabled') ||
+					element.getAttribute('aria-disabled') === 'true',
+			};
+		});
+	}, selector);
+
+const clickMoreTimes = async (page: Page): Promise<boolean> =>
+	page.evaluate(() => {
+		const buttons = Array.from(document.querySelectorAll('button'));
+		const button = buttons.find((candidate) => {
+			const label = candidate.getAttribute('aria-label')?.trim().toLowerCase() ?? '';
+			const text = candidate.textContent?.trim().toLowerCase() ?? '';
+			return label === 'more times' || text === 'more times';
+		}) as HTMLButtonElement | undefined;
+		if (!button || button.disabled || button.getAttribute('aria-disabled') === 'true') {
+			return false;
+		}
+		button.click();
+		return true;
+	});
+
+const readDirectTimeSelectionDates = async (
+	page: Page,
+	selector: string,
+	targetMonth: string | undefined,
+	timeout: number,
+): Promise<UrlDateResult[]> => {
+	let entries = await collectTimeSelectionEntries(page, selector);
+	let dates = parseTimeSelectionDates(entries, targetMonth);
+	const clickLimit = targetMonth ? moreTimesClickLimit() : 0;
+
+	for (let i = 0; dates.length === 0 && i < clickLimit; i += 1) {
+		const clicked = await clickMoreTimes(page);
+		if (!clicked) break;
+		await waitForMoreTimesSettle(page, timeout);
+		entries = await collectTimeSelectionEntries(page, selector);
+		dates = parseTimeSelectionDates(entries, targetMonth);
+	}
+
+	return dates;
+};
+
+const readDirectTimeSelectionSlots = async (
+	page: Page,
+	selector: string,
+	date: string,
+	timeout: number,
+): Promise<UrlSlotResult[]> => {
+	let entries = await collectTimeSelectionEntries(page, selector);
+	let slots = parseTimeSelectionSlots(entries, date);
+	const clickLimit = moreTimesClickLimit();
+
+	for (let i = 0; slots.length === 0 && i < clickLimit; i += 1) {
+		const clicked = await clickMoreTimes(page);
+		if (!clicked) break;
+		await waitForMoreTimesSettle(page, timeout);
+		entries = await collectTimeSelectionEntries(page, selector);
+		slots = parseTimeSelectionSlots(entries, date);
+	}
+
+	return slots;
 };
 
 const navigateToServiceCalendar = (
@@ -211,10 +408,13 @@ export const readDatesViaUrl = (
 		yield* navigateToServiceCalendar(page, url, config.timeout, 'read-availability');
 		yield* navigateToTargetMonth(page, targetMonth, 'read-availability');
 
-		// Wait for calendar tiles using the Selectors registry
-		const calendarSelector = Selectors.calendarDay.join(', ');
+		// Wait for either the legacy react-calendar grid or the current direct
+		// time-list view. Acuity may skip the grid when the service URL resolves
+		// directly to upcoming times.
+		const directTimeSelector = Selectors.timeSlot[0];
+		const availabilitySelector = `${Selectors.calendarDay.join(', ')}, ${Selectors.timeSlot.join(', ')}`;
 		yield* Effect.tryPromise({
-			try: () => page.waitForSelector(calendarSelector, { timeout: 10000 }),
+			try: () => page.waitForSelector(availabilitySelector, { timeout: 10000 }),
 			catch: () => null,
 		}).pipe(Effect.ignore);
 
@@ -224,12 +424,28 @@ export const readDatesViaUrl = (
 			return dates;
 		}
 
+		dates = yield* Effect.tryPromise({
+			try: () => readDirectTimeSelectionDates(page, directTimeSelector, targetMonth, config.timeout),
+			catch: (e) => new WizardStepError({ step: 'read-availability', message: `Direct time-list date read failed: ${e}` }),
+		});
+		if (dates.length > 0) {
+			return dates;
+		}
+
 		// Acuity occasionally paints the calendar shell before enabled dates are attached.
 		// Wait briefly for enabled tiles on the same page, but do not re-run a full
 		// deep-month navigation when the target month is legitimately empty.
 		yield* waitForEnabledCalendarDate(page, tileSelector, config.timeout);
 
-		return yield* readEnabledCalendarDates(page, tileSelector);
+		dates = yield* readEnabledCalendarDates(page, tileSelector);
+		if (dates.length > 0) {
+			return dates;
+		}
+
+		return yield* Effect.tryPromise({
+			try: () => readDirectTimeSelectionDates(page, directTimeSelector, targetMonth, config.timeout),
+			catch: (e) => new WizardStepError({ step: 'read-availability', message: `Direct time-list date read failed: ${e}` }),
+		});
 	}));
 
 // =============================================================================
@@ -326,6 +542,51 @@ export const readSlotsViaUrl = (
 		});
 
 		if (!clickedTargetDate) {
+			const directSlotReadStartedAt = Date.now();
+			const directSlots = yield* Effect.tryPromise({
+				try: () => readDirectTimeSelectionSlots(page, fallbackSelector, date, config.timeout),
+				catch: (e) => new WizardStepError({ step: 'read-slots', message: `Direct time-list slots read failed: ${e}` }),
+			});
+			slotDomReadMs = Date.now() - directSlotReadStartedAt;
+			if (directSlots.length > 0) {
+				const parseStartedAt = Date.now();
+				let parsedSlotCount = 0;
+				const parsedSlots = directSlots.map(s => {
+					const parsed = parseSlotText(s.datetime);
+					if (parsed) parsedSlotCount += 1;
+					return {
+						datetime: parsed ? buildIsoDatetime(date, parsed.time) : s.datetime,
+						available: s.available,
+					};
+				});
+				parseMs = Date.now() - parseStartedAt;
+				const profile = createSlotReadProfile({
+					serviceId,
+					date,
+					thresholdMs: profileConfig.thresholdMs,
+					calendarTileCount,
+					matchedDateFound: true,
+					slotCount: directSlots.length,
+					parsedSlotCount,
+					phases: {
+						navigationMs,
+						calendarReadyMs,
+						dateSelectMs,
+						postClickSettleMs,
+						slotWaitMs,
+						slotDomReadMs,
+						parseMs,
+					},
+					context,
+				});
+
+				if (shouldLogSlotReadProfile(profile, profileConfig)) {
+					ndjsonLog('INFO', 'Slot read profile', { ...buildSlotReadProfileEvent(profile) });
+				}
+
+				return parsedSlots;
+			}
+
 			const profile = createSlotReadProfile({
 				serviceId,
 				date,


### PR DESCRIPTION
## Summary
- support Acuity's current direct time-list DOM for availability date reads
- parse date/slot evidence from time-selection button aria labels and page through More Times
- bump @tummycrypt/scheduling-bridge to 0.5.12 for the runtime tuple

## Validation
- pnpm exec vitest run src/adapters/acuity/steps/read-via-url.test.ts
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm check:release-metadata
- pnpm docs:check
- git diff --check