### PR TITLE
Handle direct Acuity time-list availability reads

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-bridge",
     tags = ["manual"],
-    version = "0.5.12",
+    version = "0.5.13",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ Adapter targets:
 
 module(
     name = "tummycrypt_scheduling_bridge",
-    version = "0.5.12",
+    version = "0.5.13",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ before reporting it as work; non-retryable terminal jobs are reported under
 
 ### Queue Hygiene
 
-Bridge `0.5.12` supports bounded worker drain concurrency through
+Bridge `0.5.13` supports bounded worker drain concurrency through
 `BRIDGE_WORKER_CONCURRENCY`. The package default remains `1`; the MassageIthaca
 K8s deployment currently opts into `2` through Blahaj/OpenTofu after proving the
 datepicker readiness gate remains green.

--- a/docs/generated/repo-facts.md
+++ b/docs/generated/repo-facts.md
@@ -10,9 +10,9 @@ This page is generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 ## Package Identity
 
 - package: `@tummycrypt/scheduling-bridge`
-- package version: `0.5.12`
-- Bazel module version: `0.5.12`
-- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.12`
+- package version: `0.5.13`
+- Bazel module version: `0.5.13`
+- Bazel package stanza: `@tummycrypt/scheduling-bridge@0.5.13`
 - repository: `git+https://github.com/Jesssullivan/scheduling-bridge.git`
 
 ## Toolchains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-bridge",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "Backend-agnostic scheduling adapter hub with Playwright automation",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/adapters/acuity/steps/read-via-url.test.ts
+++ b/src/adapters/acuity/steps/read-via-url.test.ts
@@ -11,6 +11,7 @@ import {
 	parseTimeSelectionDates,
 	parseTimeSelectionSlots,
 	readDatesViaUrl,
+	readSlotsViaUrl,
 	type TimeSelectionEntry,
 	urlReadNetworkIdleTimeoutMs,
 } from './read-via-url.js';
@@ -122,6 +123,12 @@ const makeUrlDateReadPage = (
 			if (selector.includes('next-button')) return navHandle('next');
 			return {};
 		}),
+		$: vi.fn(async (selector: string) => (
+			selector.includes('monthly-calendar') ||
+			selector.includes('react-calendar')
+				? {}
+				: null
+		)),
 		waitForTimeout: vi.fn(async () => undefined),
 		waitForFunction: vi.fn(async () => {
 			onWaitForFunction?.();
@@ -143,10 +150,60 @@ const makeUrlDateReadPage = (
 	};
 };
 
+const makeDirectTimeListPage = (entries: TimeSelectionEntry[]) => {
+	const gotoUrls: string[] = [];
+
+	const page = {
+		goto: vi.fn(async (url: string) => {
+			gotoUrls.push(url);
+		}),
+		waitForLoadState: vi.fn(async () => undefined),
+		waitForSelector: vi.fn(async () => ({})),
+		$: vi.fn(async (selector: string) => (
+			selector.includes('time-selection') || selector.includes('time-slot')
+				? {}
+				: null
+		)),
+		$$: vi.fn(async () => []),
+		waitForTimeout: vi.fn(async () => undefined),
+		waitForFunction: vi.fn(async () => undefined),
+		$eval: vi.fn(async () => null),
+		evaluate: vi.fn(async (_fn: unknown, selector?: string) => {
+			if (typeof selector === 'string' && selector.includes('time-selection')) {
+				return entries;
+			}
+			if (typeof selector === 'string') return [];
+			return false;
+		}),
+	} as unknown as Page;
+
+	return {
+		page,
+		gotoUrls,
+	};
+};
+
 const runDateRead = (page: Page, targetMonth?: string) =>
 	Effect.runPromise(
 		Effect.scoped(
 			readDatesViaUrl('53178494', targetMonth).pipe(
+				Effect.provideService(BrowserService, {
+					acquirePage: Effect.succeed(page),
+					screenshot: () => Effect.succeed(Buffer.from('')),
+					config: {
+						...defaultBrowserConfig,
+						baseUrl: 'https://MassageIthaca.as.me',
+						timeout: 1_000,
+					},
+				}),
+			),
+		),
+	);
+
+const runSlotRead = (page: Page, date: string) =>
+	Effect.runPromise(
+		Effect.scoped(
+			readSlotsViaUrl('53178494', date).pipe(
 				Effect.provideService(BrowserService, {
 					acquirePage: Effect.succeed(page),
 					screenshot: () => Effect.succeed(Buffer.from('')),
@@ -240,5 +297,43 @@ describe('readDatesViaUrl DOM behavior', () => {
 		expect(fake.gotoUrls[0]).toBe(
 			'https://massageithaca.as.me/?appointmentType=53178494',
 		);
+	});
+
+	it('does not require a calendar before reading the direct Acuity time list', async () => {
+		const fake = makeDirectTimeListPage([
+			{
+				text: '10:00 AM1 spot left',
+				ariaLabel: '10:00 AM, 1 spot left, Sunday Jun 7',
+				disabled: false,
+			},
+		]);
+
+		const dates = await runDateRead(fake.page, '2026-06');
+
+		expect(dates).toEqual([{ date: '2026-06-07', slots: 1 }]);
+		expect(fake.gotoUrls[0]).toBe(
+			'https://massageithaca.as.me/?appointmentType=53178494',
+		);
+		expect(fake.page.$eval).not.toHaveBeenCalled();
+	});
+
+	it('reads slots from the direct Acuity time list without a calendar', async () => {
+		const fake = makeDirectTimeListPage([
+			{
+				text: '10:00 AM1 spot left',
+				ariaLabel: '10:00 AM, 1 spot left, Sunday Jun 7',
+				disabled: false,
+			},
+		]);
+
+		const slots = await runSlotRead(fake.page, '2026-06-07');
+
+		expect(slots).toEqual([
+			{ datetime: '2026-06-07T10:00:00', available: true },
+		]);
+		expect(fake.gotoUrls[0]).toBe(
+			'https://massageithaca.as.me/?appointmentType=53178494&date=2026-06-07',
+		);
+		expect(fake.page.$$).not.toHaveBeenCalled();
 	});
 });

--- a/src/adapters/acuity/steps/read-via-url.ts
+++ b/src/adapters/acuity/steps/read-via-url.ts
@@ -46,6 +46,8 @@ export interface TimeSelectionEntry {
 	readonly disabled: boolean;
 }
 
+type AvailabilitySurface = 'calendar' | 'time-list';
+
 const DEFAULT_URL_READ_NETWORK_IDLE_MS = 1500;
 const DEFAULT_EMPTY_DATE_SETTLE_MS = 2500;
 const DEFAULT_MORE_TIMES_CLICKS = 8;
@@ -305,6 +307,34 @@ const navigateToServiceCalendar = (
 		catch: (e) => new WizardStepError({ step, message: `Navigation failed: ${e}` }),
 	});
 
+const waitForAvailabilitySurface = (
+	page: Page,
+	timeout: number,
+	step: 'read-availability' | 'read-slots',
+): Effect.Effect<AvailabilitySurface, WizardStepError> =>
+	Effect.tryPromise({
+		try: async () => {
+			const waitMs = Math.min(timeout, 10_000);
+			const calendarSelector = Selectors.calendar.join(', ');
+			const timeListSelector = Selectors.timeSlot.join(', ');
+			const surfaceSelector = `${calendarSelector}, ${timeListSelector}`;
+
+			await page.waitForSelector(surfaceSelector, { timeout: waitMs });
+
+			const calendar = await page.$(calendarSelector).catch(() => null);
+			if (calendar) return 'calendar' as const;
+
+			const timeList = await page.$(timeListSelector).catch(() => null);
+			if (timeList) return 'time-list' as const;
+
+			throw new Error('No known Acuity availability surface matched');
+		},
+		catch: () => new WizardStepError({
+			step,
+			message: 'Availability surface did not load within timeout',
+		}),
+	});
+
 const navigateToTargetMonth = (
 	page: Page,
 	targetMonth: string | undefined,
@@ -406,17 +436,24 @@ export const readDatesViaUrl = (
 		url.searchParams.set('appointmentType', serviceId);
 
 		yield* navigateToServiceCalendar(page, url, config.timeout, 'read-availability');
-		yield* navigateToTargetMonth(page, targetMonth, 'read-availability');
+		const surface = yield* waitForAvailabilitySurface(
+			page,
+			config.timeout,
+			'read-availability',
+		);
+		if (surface === 'calendar') {
+			yield* navigateToTargetMonth(page, targetMonth, 'read-availability');
+		} else if (targetMonth && !parseYearMonthKey(targetMonth)) {
+			return yield* Effect.fail(new WizardStepError({
+				step: 'read-availability',
+				message: `Invalid target month: ${targetMonth}`,
+			}));
+		}
 
 		// Wait for either the legacy react-calendar grid or the current direct
 		// time-list view. Acuity may skip the grid when the service URL resolves
 		// directly to upcoming times.
 		const directTimeSelector = Selectors.timeSlot[0];
-		const availabilitySelector = `${Selectors.calendarDay.join(', ')}, ${Selectors.timeSlot.join(', ')}`;
-		yield* Effect.tryPromise({
-			try: () => page.waitForSelector(availabilitySelector, { timeout: 10000 }),
-			catch: () => null,
-		}).pipe(Effect.ignore);
 
 		const tileSelector = Selectors.calendarDay[0]; // .react-calendar__tile
 		let dates = yield* readEnabledCalendarDates(page, tileSelector);
@@ -491,40 +528,54 @@ export const readSlotsViaUrl = (
 
 		const navigationStartedAt = Date.now();
 		yield* navigateToServiceCalendar(page, url, config.timeout, 'read-slots');
-		yield* navigateToTargetMonth(page, targetMonth, 'read-slots');
+		const surface = yield* waitForAvailabilitySurface(
+			page,
+			config.timeout,
+			'read-slots',
+		);
+		if (surface === 'calendar') {
+			yield* navigateToTargetMonth(page, targetMonth, 'read-slots');
+		} else if (!parseYearMonthKey(targetMonth)) {
+			return yield* Effect.fail(new WizardStepError({
+				step: 'read-slots',
+				message: `Invalid target month: ${targetMonth}`,
+			}));
+		}
 		navigationMs = Date.now() - navigationStartedAt;
 
 		// Click the target date on the calendar. Disabled dates are a valid
 		// "no availability" result, not a scrape failure.
 		const tileSelector = Selectors.calendarDay[0];
-		const clickedTargetDate = yield* Effect.tryPromise({
-			try: async () => {
-				const calendarReadyStartedAt = Date.now();
-				await page.waitForSelector(tileSelector, { timeout: 10000 }).catch(() => {});
-				calendarReadyMs = Date.now() - calendarReadyStartedAt;
+		let clickedTargetDate = false;
+		if (surface === 'calendar') {
+			clickedTargetDate = yield* Effect.tryPromise({
+				try: async () => {
+					const calendarReadyStartedAt = Date.now();
+					await page.waitForSelector(tileSelector, { timeout: 10000 }).catch(() => {});
+					calendarReadyMs = Date.now() - calendarReadyStartedAt;
 
-				const dateSelectStartedAt = Date.now();
-				const tiles = await page.$$(tileSelector);
-				calendarTileCount = tiles.length;
-				for (const tile of tiles) {
-					const abbr = await tile.$('abbr');
-					const label = await abbr?.getAttribute('aria-label');
-					if (label) {
-						const d = new Date(label);
-						if (d.toISOString().slice(0, 10) === date) {
-							matchedDateFound = true;
-							const disabled = await tile.evaluate((el) => {
-								const button = el as HTMLButtonElement;
-								return (
-									button.disabled ||
-									button.getAttribute('aria-disabled') === 'true' ||
-									button.classList.contains('react-calendar__tile--disabled')
-								);
-							});
-							if (disabled) {
-								dateSelectMs = Date.now() - dateSelectStartedAt;
-								return false;
-							}
+					const dateSelectStartedAt = Date.now();
+					const tiles = await page.$$(tileSelector);
+					calendarTileCount = tiles.length;
+					for (const tile of tiles) {
+						const abbr = await tile.$('abbr');
+						const label = await abbr?.getAttribute('aria-label');
+						if (label) {
+							const d = new Date(label);
+							if (d.toISOString().slice(0, 10) === date) {
+								matchedDateFound = true;
+								const disabled = await tile.evaluate((el) => {
+									const button = el as HTMLButtonElement;
+									return (
+										button.disabled ||
+										button.getAttribute('aria-disabled') === 'true' ||
+										button.classList.contains('react-calendar__tile--disabled')
+									);
+								});
+								if (disabled) {
+									dateSelectMs = Date.now() - dateSelectStartedAt;
+									return false;
+								}
 								await tile.click({ timeout: Math.min(config.timeout, 5000) });
 								dateSelectMs = Date.now() - dateSelectStartedAt;
 
@@ -533,13 +584,14 @@ export const readSlotsViaUrl = (
 								postClickSettleMs = Date.now() - settleStartedAt;
 								return true;
 							}
+						}
 					}
-				}
-				dateSelectMs = Date.now() - dateSelectStartedAt;
-				return false;
-			},
-			catch: (e) => new WizardStepError({ step: 'read-slots', message: `Date click failed: ${e}` }),
-		});
+					dateSelectMs = Date.now() - dateSelectStartedAt;
+					return false;
+				},
+				catch: (e) => new WizardStepError({ step: 'read-slots', message: `Date click failed: ${e}` }),
+			});
+		}
 
 		if (!clickedTargetDate) {
 			const directSlotReadStartedAt = Date.now();


### PR DESCRIPTION
## Summary
- detect whether Acuity served the legacy calendar or the current direct time-list surface before month navigation
- skip calendar month navigation when direct time buttons are present so date/slot reads can parse the current DOM
- bump @tummycrypt/scheduling-bridge release metadata to 0.5.13

## Validation
- pnpm exec vitest run src/adapters/acuity/steps/read-via-url.test.ts
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm check:release-metadata
- pnpm docs:check
- pnpm check:artifact-authority
- pnpm check:package
- git diff --check